### PR TITLE
[enh] add flake.nix and nixos, darwin & home module

### DIFF
--- a/.github/workflows/update-nix-vendor-hash.yml
+++ b/.github/workflows/update-nix-vendor-hash.yml
@@ -1,0 +1,49 @@
+name: Update Nix vendorHash
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - go.mod
+      - go.sum
+      - nix/package.nix
+      - .github/workflows/update-nix-vendor-hash.yml
+  workflow_dispatch:
+
+jobs:
+  update-vendor-hash:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v6.0.2
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31.9.0
+
+      - name: Update vendorHash
+        run: ./nix/update-nix-vendor-hash.sh
+
+      - name: Check for changes
+        id: git-check
+        run: |
+          if git diff --quiet nix/package.nix; then
+            echo "changed=false" >> $GITHUB_OUTPUT
+          else
+            echo "changed=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create Pull Request
+        if: steps.git-check.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@v8.1.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: update-nix-vendor-hash
+          commit-message: "chore: update vendorHash for Go module changes"
+          title: "Update Nix vendorHash"
+          body: |
+            [chore] update nix/package.nix vendorHash
+            
+            Triggered by: ${{ github.repository }}@${{ github.sha }}
+          delete-branch: true

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ ext/node_modules
 ext/hister_ext_src.zip
 ext/hister_ext_ff.zip
 ext/hister_ext_chrome.zip
+result
+result-*

--- a/README.md
+++ b/README.md
@@ -40,13 +40,177 @@ Execute `./hister` to see all available commands.
  - Run `./hister help` to list the available commands
  - Execute `./hister listen` to start the web application
 
-
 ## Configuration
 
 Settings can be configured in `~/.config/hister/config.yml` config file - don't forget to restart webapp after updating.
 
 Execute `./hister create-config config.yml` to generate a configuration file with the default configuration values.
 
+
+### Nix
+
+#### Quick usage
+
+Run directly from the repository:
+
+```bash
+nix run github:asciimoo/hister
+```
+
+Add to your current shell session:
+
+```bash
+nix shell github:asciimoo/hister
+```
+
+Install permanently to your user profile:
+
+```bash
+nix profile install github:asciimoo/hister
+```
+
+#### NixOS
+
+Add the following to your `flake.nix`:
+
+```nix
+{
+  inputs.hister.url = "github:asciimoo/hister";
+
+  outputs = { self, nixpkgs, hister, ... }: {
+    nixosConfigurations.yourHostname = nixpkgs.lib.nixosSystem {
+      modules = [
+        ./configuration.nix
+        hister.nixosModules.default
+      ];
+    };
+  };
+}
+```
+
+Then enable the service:
+
+```nix
+services.hister = {
+  enable = true;
+  port = 4433;
+  dataDir = "/var/lib/hister";
+  configPath = /path/to/config.yml; # optional, use existing YAML file
+  config = {  # optional, or use Nix attrset (automatically converted to YAML)
+    app = {
+      directory = "~/.config/hister/";
+      search_url = "https://google.com/search?q={query}";
+    };
+    server = {
+      address = "127.0.0.1:4433";
+    };
+  };
+};
+```
+
+**Note**: Only one of `configPath` or `config` can be set at a time.
+
+#### Add to system packages
+
+If you don't want to use the system module, you can add the package directly to `environment.systemPackages` in your `configuration.nix`:
+
+**NixOS & Darwin (macOS):**
+
+```nix
+{ inputs, ... }: {
+  environment.systemPackages = [ inputs.hister.packages.${pkgs.system}.default ];
+}
+```
+
+#### Add to user packages (Home-Manager)
+
+If you don't want to use the Home-Manager module, you can add the package directly to `home.packages` in your `home.nix`:
+
+```nix
+{ inputs, ... }: {
+  home.packages = [ inputs.hister.packages.${pkgs.system}.default ];
+}
+```
+
+#### Home-Manager
+
+Add the following to your `flake.nix`:
+
+```nix
+{
+  inputs.hister.url = "github:asciimoo/hister";
+
+  outputs = { self, nixpkgs, home-manager, hister, ... }: {
+    homeConfigurations."yourUsername" = home-manager.lib.homeManagerConfiguration {
+      modules = [
+        ./home.nix
+        hister.homeModules.default
+      ];
+    };
+  };
+}
+```
+
+Then enable the service:
+
+```nix
+services.hister = {
+  enable = true;
+  port = 4433;
+  dataDir = "/home/yourUsername/.local/share/hister";
+  configPath = /path/to/config.yml; # optional, use existing YAML file
+  config = {  # optional, or use Nix attrset (automatically converted to YAML)
+    app = {
+      directory = "~/.config/hister/";
+      search_url = "https://google.com/search?q={query}";
+    };
+    server = {
+      address = "127.0.0.1:4433";
+    };
+  };
+};
+```
+
+**Note**: Only one of `configPath` or `config` can be set at a time.
+
+#### Darwin (macOS)
+
+Add the following to your `flake.nix`:
+
+```nix
+{
+  inputs.hister.url = "github:asciimoo/hister";
+
+  outputs = { self, darwin, hister, ... }: {
+    darwinConfigurations."yourHostname" = darwin.lib.darwinSystem {
+      modules = [
+        ./configuration.nix
+        hister.darwinModules.default
+      ];
+    };
+  };
+}
+```
+
+Then enable the service:
+
+```nix
+services.hister = {
+  enable = true;
+  port = 4433;
+  dataDir = "/Users/yourUsername/Library/Application Support/hister";
+  configPath = /path/to/config.yml; # optional
+  config = {  # optional, or use Nix attrset (automatically converted to YAML)
+    app = {
+      directory = "~/.config/hister/";
+      search_url = "https://google.com/search?q={query}";
+    };
+    server = {
+      address = "127.0.0.1:4433";
+    };
+  };
+};
+```
 
 ## Bugs
 

--- a/config/config.go
+++ b/config/config.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"html/template"
+	"net"
 	"net/url"
 	"os"
 	"os/user"
@@ -153,6 +154,18 @@ func parseConfig(rawConfig []byte) (*Config, error) {
 }
 
 func (c *Config) init() error {
+	if dataDir := os.Getenv("HISTER_DATA_DIR"); dataDir != "" {
+		c.App.Directory = dataDir
+	}
+
+	if envPort := os.Getenv("HISTER_PORT"); envPort != "" {
+		host, _, err := net.SplitHostPort(c.Server.Address)
+		if err != nil || host == "" {
+			host = c.Server.Address
+		}
+		c.Server.Address = net.JoinHostPort(host, envPort)
+	}
+
 	if c.Server.BaseURL == "" {
 		c.Server.BaseURL = fmt.Sprintf("http://%s", c.Server.Address)
 	}

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,48 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1769996383,
+        "narHash": "sha256-AnYjnFWgS49RlqX7LrC4uA+sCCDBj0Ry/WOJ5XWAsa0=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "57928607ea566b5db3ad13af0e57e921e6b12381",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1770781623,
+        "narHash": "sha256-RYEMTlGCVc67pxVxjOlGd8w6fpF7Bur7gKL88FB0WTs=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "c05d2232d2feaa4c7a07f1168606917402868195",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,51 @@
+{
+  description = "Hister - Web history on steroids";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-parts.url = "github:hercules-ci/flake-parts";
+    flake-parts.inputs.nixpkgs-lib.follows = "nixpkgs";
+  };
+
+  outputs =
+    inputs:
+    inputs.flake-parts.lib.mkFlake { inherit inputs; } {
+      systems = [
+        "x86_64-linux"
+        "x86_64-darwin"
+        "aarch64-linux"
+        "aarch64-darwin"
+      ];
+
+      perSystem =
+        {
+          config,
+          self',
+          inputs',
+          pkgs,
+          system,
+          ...
+        }:
+        {
+          packages.default = pkgs.callPackage ./nix/package.nix { histerRev = inputs.self.rev or "unknown"; };
+          packages.hister = pkgs.callPackage ./nix/package.nix { histerRev = inputs.self.rev or "unknown"; };
+
+          devShells.default = pkgs.mkShell {
+            packages = builtins.attrValues {
+              inherit (pkgs) go gopls gotools;
+            };
+          };
+        };
+
+      flake = {
+        nixosModules.default = inputs.self.nixosModules.hister;
+        nixosModules.hister = import ./nix/nixos.nix;
+
+        homeModules.default = inputs.self.homeModules.hister;
+        homeModules.hister = import ./nix/home.nix;
+
+        darwinModules.default = inputs.self.darwinModules.hister;
+        darwinModules.hister = import ./nix/darwin.nix;
+      };
+    };
+}

--- a/hister.go
+++ b/hister.go
@@ -221,6 +221,13 @@ func initialize() {
 
 func initConfig() {
 	var err error
+
+	if !rootCmd.PersistentFlags().Changed("config") {
+		if envConfig := os.Getenv("HISTER_CONFIG"); envConfig != "" {
+			cfgFile = envConfig
+		}
+	}
+
 	cfg, err = config.Load(cfgFile)
 	if err != nil {
 		exit(1, "Failed to initialize config: "+err.Error())

--- a/nix/darwin.nix
+++ b/nix/darwin.nix
@@ -1,0 +1,55 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+{
+  imports = [
+    ./options.nix
+  ];
+
+  config = lib.mkIf config.services.hister.enable {
+    environment.systemPackages = [ config.services.hister.package ];
+
+    services.hister.package = lib.mkDefault (pkgs.callPackage ./package.nix { });
+
+    assertions = [
+      {
+        assertion = !(config.services.hister.configPath != null && config.services.hister.config != null);
+        message = "Only one of services.hister.configPath and services.hister.config can be set";
+      }
+    ];
+
+    services.hister.user = lib.mkDefault config.system.primaryUser;
+    services.hister.dataDir = lib.mkDefault "${config.system.primaryUserHome}/Library/Application Support/hister";
+
+    system.activationScripts.extraActivation.text = ''
+      ${lib.getExe' pkgs.coreutils "install"} -d -o ${lib.escapeShellArg config.services.hister.user} -g staff ${lib.escapeShellArg config.services.hister.dataDir}
+    '';
+
+    launchd.user.agents.hister = {
+      serviceConfig = {
+        ProgramArguments = [
+          (lib.getExe config.services.hister.package)
+          "listen"
+        ];
+        KeepAlive = true;
+        WorkingDirectory = config.services.hister.dataDir;
+        EnvironmentVariables = {
+          HISTER_DATA_DIR = config.services.hister.dataDir;
+          HISTER_PORT = builtins.toString config.services.hister.port;
+        }
+        // lib.optionalAttrs (config.services.hister.configPath != null) {
+          HISTER_CONFIG = builtins.toString config.services.hister.configPath;
+        }
+        // lib.optionalAttrs (config.services.hister.config != null) {
+          HISTER_CONFIG = "${(pkgs.formats.yaml { }).generate "hister-config.yml"
+            config.services.hister.config
+          }";
+        };
+      };
+      managedBy = "services.hister.enable";
+    };
+  };
+}

--- a/nix/home.nix
+++ b/nix/home.nix
@@ -1,0 +1,84 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+{
+  imports = [
+    ./options.nix
+  ];
+
+  config = lib.mkIf config.services.hister.enable {
+    home.packages = [ config.services.hister.package ];
+
+    services.hister.package = lib.mkDefault (pkgs.callPackage ./package.nix { });
+    services.hister.dataDir = lib.mkDefault "${config.home.homeDirectory}/.local/share/hister";
+
+    assertions = [
+      {
+        assertion = !(config.services.hister.configPath != null && config.services.hister.config != null);
+        message = "Only one of services.hister.configPath and services.hister.config can be set";
+      }
+    ];
+
+    home.file.".local/share/hister/.keep".text = "";
+
+    systemd.user.services.hister = {
+      Unit = {
+        Description = "Hister web history service";
+        After = [ "network.target" ];
+      };
+
+      Service = {
+        ExecStart = "${lib.getExe config.services.hister.package} listen";
+        Restart = "on-failure";
+        WorkingDirectory = config.services.hister.dataDir;
+
+        Environment = lib.mapAttrsToList (name: value: "${name}=${value}") (
+          {
+            HISTER_DATA_DIR = config.services.hister.dataDir;
+            HISTER_PORT = builtins.toString config.services.hister.port;
+          }
+          // lib.optionalAttrs (config.services.hister.configPath != null) {
+            HISTER_CONFIG = builtins.toString config.services.hister.configPath;
+          }
+          // lib.optionalAttrs (config.services.hister.config != null) {
+            HISTER_CONFIG = "${(pkgs.formats.yaml { }).generate "hister-config.yml"
+              config.services.hister.config
+            }";
+          }
+        );
+      };
+
+      Install = {
+        WantedBy = [ "default.target" ];
+      };
+    };
+
+    launchd.agents.hister = {
+      enable = true;
+      config = {
+        ProgramArguments = [
+          (lib.getExe config.services.hister.package)
+          "listen"
+        ];
+        KeepAlive = true;
+        WorkingDirectory = config.services.hister.dataDir;
+
+        EnvironmentVariables = {
+          HISTER_DATA_DIR = config.services.hister.dataDir;
+          HISTER_PORT = builtins.toString config.services.hister.port;
+        }
+        // lib.optionalAttrs (config.services.hister.configPath != null) {
+          HISTER_CONFIG = builtins.toString config.services.hister.configPath;
+        }
+        // lib.optionalAttrs (config.services.hister.config != null) {
+          HISTER_CONFIG = "${(pkgs.formats.yaml { }).generate "hister-config.yml"
+            config.services.hister.config
+          }";
+        };
+      };
+    };
+  };
+}

--- a/nix/nixos.nix
+++ b/nix/nixos.nix
@@ -1,0 +1,77 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+{
+  imports = [
+    ./options.nix
+  ];
+
+  config = lib.mkIf config.services.hister.enable {
+    environment.systemPackages = [ config.services.hister.package ];
+
+    services.hister.package = lib.mkDefault (pkgs.callPackage ./package.nix { });
+
+    assertions = [
+      {
+        assertion = !(config.services.hister.configPath != null && config.services.hister.config != null);
+        message = "Only one of services.hister.configPath and services.hister.config can be set";
+      }
+    ];
+
+    users.users = lib.mkIf (config.services.hister.user == "hister") {
+      hister = {
+        description = "Hister web history service";
+        group = config.services.hister.group;
+        isSystemUser = true;
+        home = config.services.hister.dataDir;
+      };
+    };
+
+    users.groups = lib.mkIf (config.services.hister.group == "hister") {
+      hister = { };
+    };
+
+    systemd.tmpfiles.rules = [
+      "d '${config.services.hister.dataDir}' ${config.services.hister.dataDirMode} ${config.services.hister.user} ${config.services.hister.group} - -"
+      "z '${config.services.hister.dataDir}' ${config.services.hister.dataDirMode} ${config.services.hister.user} ${config.services.hister.group} - -"
+    ];
+
+    systemd.services.hister = {
+      description = "Hister web history service";
+      after = [
+        "network.target"
+        "systemd-tmpfiles-setup.service"
+      ];
+      requires = [ "systemd-tmpfiles-setup.service" ];
+      wantedBy = [ "multi-user.target" ];
+
+      environment = {
+        HISTER_DATA_DIR = config.services.hister.dataDir;
+        HISTER_PORT = builtins.toString config.services.hister.port;
+      }
+      // lib.optionalAttrs (config.services.hister.configPath != null) {
+        HISTER_CONFIG = builtins.toString config.services.hister.configPath;
+      }
+      // lib.optionalAttrs (config.services.hister.config != null) {
+        HISTER_CONFIG = "${(pkgs.formats.yaml { }).generate "hister-config.yml"
+          config.services.hister.config
+        }";
+      };
+
+      serviceConfig = {
+        ExecStart = "${lib.getExe config.services.hister.package} listen";
+        Restart = "on-failure";
+        User = config.services.hister.user;
+        Group = config.services.hister.group;
+        WorkingDirectory = config.services.hister.dataDir;
+      };
+    };
+
+    networking.firewall.allowedTCPPorts = lib.mkIf config.services.hister.enable [
+      config.services.hister.port
+    ];
+  };
+}

--- a/nix/options.nix
+++ b/nix/options.nix
@@ -1,0 +1,59 @@
+{ lib, pkgs, ... }:
+{
+  options.services.hister = {
+    enable = lib.mkEnableOption "Hister web history service";
+
+    package = lib.mkPackageOption pkgs "hister" { };
+
+    dataDir = lib.mkOption {
+      type = lib.types.path;
+      default = "/var/lib/hister";
+      description = "Directory where Hister stores its data.";
+    };
+
+    dataDirMode = lib.mkOption {
+      type = lib.types.str;
+      default = "0755";
+      description = "Permissions mode for the data directory.";
+    };
+
+    port = lib.mkOption {
+      type = lib.types.port;
+      default = 4433;
+      description = "Port on which Hister listens.";
+    };
+
+    configPath = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
+      default = null;
+      description = "Path to an existing configuration file.";
+    };
+
+    config = lib.mkOption {
+      type = with lib.types; nullOr attrs;
+      default = null;
+      description = "Configuration as a Nix attribute set. This will be converted to a YAML file.";
+      example = {
+        app = {
+          directory = "~/.config/hister/";
+          search_url = "https://google.com/search?q={query}";
+        };
+        server = {
+          address = "127.0.0.1:4433";
+        };
+      };
+    };
+
+    user = lib.mkOption {
+      type = lib.types.str;
+      default = "hister";
+      description = "User account under which Hister runs.";
+    };
+
+    group = lib.mkOption {
+      type = lib.types.str;
+      default = "hister";
+      description = "Group under which Hister runs.";
+    };
+  };
+}

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  buildGoModule,
+  histerRev ? "unknown",
+}:
+let
+  packageJson = builtins.fromJSON (builtins.readFile ../ext/package.json);
+in
+buildGoModule (finalAttrs: {
+  pname = "hister";
+  version = packageJson.version;
+
+  src = ../.;
+
+  vendorHash = "sha256-3rAw9YMvDqh7aA1cft2NghfQ8jEiZdwykajJUwu7Zus=";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.version=${finalAttrs.version}"
+    "-X main.commit=${histerRev}"
+  ];
+
+  subPackages = [ "." ];
+
+  doCheck = false;
+
+  meta = {
+    description = "Web history on steroids - blazing fast, content-based search for visited websites";
+    homepage = "https://github.com/asciimoo/hister";
+    license = lib.licenses.agpl3Only;
+    maintainers = [ lib.maintainers.FlameFlag ];
+    mainProgram = "hister";
+    platforms = lib.platforms.unix;
+  };
+})

--- a/nix/update-nix-vendor-hash.sh
+++ b/nix/update-nix-vendor-hash.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+echo "::notice::Running nix build to get vendorHash..."
+echo "::group::Build output"
+OUTPUT=$(nix build .#hister 2>&1 || true)
+echo "::endgroup::"
+
+if echo "$OUTPUT" | grep -q "hash mismatch in fixed-output derivation"; then
+  NEW_HASH=$(echo "$OUTPUT" | grep "got:" | sed 's/.*got: *//')
+  echo "::notice::Found new hash: $NEW_HASH"
+  
+  sed -i.bak "s|vendorHash = \".*\";|vendorHash = \"$NEW_HASH\";|" nix/package.nix
+  rm -f nix/package.nix.bak
+  
+  echo "::notice file=nix/package.nix::Updated vendorHash"
+  
+  echo "::group::Verifying build with new hash"
+  nix build .#hister 2>&1 | tail -5
+  echo "::endgroup::"
+  echo "::notice::Build successful!"
+else
+  echo "::notice::No hash mismatch found or build succeeded already"
+  if echo "$OUTPUT" | grep -q "these 2 derivations will be built"; then
+    echo "::notice::Build already passes, no update needed"
+  fi
+  exit 0
+fi


### PR DESCRIPTION
Add Nix Package, NixOS Module, Darwin Module and Home-Manager Module support

I added a GHA Action that's needed for the vendorHash. Anytime deps change a PR will be made with the new hash that just needs to be merged.

Also added `HISTER_DATA_DIR` env var so the modules can set the data dir path depending on the platform (NixOS uses `/var/lib/hister`, Home-Manager uses `~/.local/share/hister`, Darwin uses `~/Library/Application Support/hister`)

I don't know much Go, so sorry if the Go code isn't the optimal way to do it!

P.S: Awesome project, I've been messing around with it since yesterday