### PR TITLE
[enh]: support ctrl clicking results

### DIFF
--- a/server/static/js/search.js
+++ b/server/static/js/search.js
@@ -306,7 +306,11 @@ function createResult(r) {
 }
 
 function clickHandler(e, leftClickCallback, middleClickCallback) {
-    e.addEventListener("click", leftClickCallback);
+    e.addEventListener("click", ev => {
+        if (ev.ctrlKey) {
+            leftClickCallback(true);
+        }
+    });
 	e.addEventListener("auxclick", ev => {
 		if (ev.button == 1) {
 			middleClickCallback(ev);


### PR DESCRIPTION
I noticed that ctrl + clicking a result would not open it in a new tab, which was behaviour I did not expect (most links support this), so I've implemented a workaround for that in this commit. Seems to work on Firefox 147.0.3 at least.