### PR TITLE
[mod] refactor nix modules

### DIFF
--- a/nix/darwin.nix
+++ b/nix/darwin.nix
@@ -1,7 +1,7 @@
 {
   config,
   lib,
-  pkgs,
+  histerEnv,
   ...
 }:
 {
@@ -12,22 +12,6 @@
   config = lib.mkIf config.services.hister.enable {
     environment.systemPackages = [ config.services.hister.package ];
 
-    services.hister.package = lib.mkDefault (pkgs.callPackage ./package.nix { });
-
-    assertions = [
-      {
-        assertion = !(config.services.hister.configPath != null && config.services.hister.config != null);
-        message = "Only one of services.hister.configPath and services.hister.config can be set";
-      }
-    ];
-
-    services.hister.user = lib.mkDefault config.system.primaryUser;
-    services.hister.dataDir = lib.mkDefault "${config.system.primaryUserHome}/Library/Application Support/hister";
-
-    system.activationScripts.extraActivation.text = ''
-      ${lib.getExe' pkgs.coreutils "install"} -d -o ${lib.escapeShellArg config.services.hister.user} -g staff ${lib.escapeShellArg config.services.hister.dataDir}
-    '';
-
     launchd.user.agents.hister = {
       serviceConfig = {
         ProgramArguments = [
@@ -35,19 +19,8 @@
           "listen"
         ];
         KeepAlive = true;
-        WorkingDirectory = config.services.hister.dataDir;
-        EnvironmentVariables = {
-          HISTER_DATA_DIR = config.services.hister.dataDir;
-          HISTER_PORT = builtins.toString config.services.hister.port;
-        }
-        // lib.optionalAttrs (config.services.hister.configPath != null) {
-          HISTER_CONFIG = builtins.toString config.services.hister.configPath;
-        }
-        // lib.optionalAttrs (config.services.hister.config != null) {
-          HISTER_CONFIG = "${(pkgs.formats.yaml { }).generate "hister-config.yml"
-            config.services.hister.config
-          }";
-        };
+        WorkingDirectory = lib.mkIf (config.services.hister.dataDir != null) config.services.hister.dataDir;
+        EnvironmentVariables = histerEnv config.services.hister;
       };
       managedBy = "services.hister.enable";
     };


### PR DESCRIPTION
Follow up of https://github.com/asciimoo/hister/pull/18

Addresses: https://github.com/asciimoo/hister/pull/18#issuecomment-3894120666

As well improved the docs (about nix setup) to be more clear, and less verbose

I added `getDefaultDataDir()` to handle platform-specific data directories instead of hardcoding `~/.config/hister` - Also following XDG spec (https://specifications.freedesktop.org/basedir/latest/)

This way it follows `~/Library/Application Support/` on Darwin/MacOS, `XDG_STATE_HOME` on Linux, `LOCALAPPDATA` on Windows, or `UserConfigDir` elsewhere

`StateDirectory` tells `systemd` to create `/var/lib/hister` directory automatically when the unit starts

---

- make `datadir` and `port` optional (default null) to allow config-only
setup
- remove `dataDirMode` option and directory creation logic (it should be
sole responsibility of go)
- move `user`/`group` options to nixos module only
- add shared `histerEnv` helper for environment variables
- update package definition to use flake self reference (so rev is
preserved)