### PR TITLE
[enh] Safari support - initial proof of concept

### DIFF
--- a/manage.sh
+++ b/manage.sh
@@ -56,6 +56,7 @@ build_addon() {
     echo "[!] Warning: The default manifest.json is for chrome browsers, overwrite it with manifest_ff.json for firefox"
     cd ext
     npm run build
+    xcrun safari-web-extension-packager ./dist --project-location ./xc-project --app-name Hister
     cd ..
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -70,6 +70,8 @@ func (lrw *loggingResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) 
 func (c *csrfExceptionHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if r.URL.Path == "/add" && strings.HasPrefix(r.Header.Get("Origin"), "moz-extension://") {
 		c.origHandler.ServeHTTP(w, r)
+	} else if r.URL.Path == "/add" && strings.HasPrefix(r.Header.Get("Origin"), "safari-web-extension://") {
+		c.origHandler.ServeHTTP(w, r)
 	} else {
 		c.csrfHandler.ServeHTTP(w, r)
 	}
@@ -337,6 +339,21 @@ func serveAdd(c *webContext) {
 		c.Render("add", nil)
 		return
 	}
+	if m == http.MethodOptions {
+		if c.Request.Header.Get("Access-Control-Request-Method") != http.MethodPost {
+			c.Response.WriteHeader(http.StatusForbidden)
+			return
+		}
+		origin := c.Request.Header.Get("Origin")
+		if strings.HasPrefix(origin, "safari-web-extension://") {
+			c.Response.Header().Add("Access-Control-Allow-Origin", origin)
+		}
+		c.Response.Header().Add("Access-Control-Allow-Methods", http.MethodPost)
+		c.Response.Header().Add("Access-Control-Allow-Headers", "Content-Type")
+		c.Response.Header().Add("Access-Control-Max-Age", "86400")
+		c.Response.WriteHeader(http.StatusNoContent)
+		return
+	}
 	if m != http.MethodPost {
 		serve500(c)
 		return
@@ -361,6 +378,7 @@ func serveAdd(c *webContext) {
 		d.Title = f.Get("title")
 		d.Text = f.Get("text")
 	}
+
 	if !c.Config.Rules.IsSkip(d.URL) && !strings.HasPrefix(d.URL, c.Config.BaseURL("/")) {
 		if err := d.Process(); err != nil {
 			log.Error().Err(err).Str("URL", d.URL).Msg("failed to process document")
@@ -372,6 +390,10 @@ func serveAdd(c *webContext) {
 			log.Error().Err(err).Str("URL", d.URL).Msg("failed to create index")
 			serve500(c)
 			return
+		}
+		origin := c.Request.Header.Get("Origin")
+		if strings.HasPrefix(origin, "safari-web-extension://") {
+			c.Response.Header().Add("Access-Control-Allow-Origin", origin)
 		}
 		c.Response.WriteHeader(http.StatusCreated)
 	} else {


### PR DESCRIPTION
The chrome manifest v3 can be converted automatically to a Safari Web Extention with `safari-web-extension-packager`, though it uses default icons and description. Effort is needed to package it up pretty. Safari doing `fetch()` demands CORS headers on the `POST /add`, and a pre-flight `OPTIONS /add` request. Safari web extensions appear to have a similar behaviour to Firefox, with the `Origin` header url containing a UUID unique to the installation.

Commit a44a471 is a minimal change to implement support, hopefully to serve as the basis for a proper implementation.

Draft: this is likely not the best way to add CORS headers, this PR is just a POC to demonstrate the possibility.