### PR TITLE
[fix] make it possible to use alt/option key for navigation on macOS

### DIFF
--- a/server/static/js/search.js
+++ b/server/static/js/search.js
@@ -490,9 +490,14 @@ window.addEventListener("keydown", function(e) {
     } else if(e.metaKey) {
         modifier = "meta";
     }
-    let key = e.key.toLowerCase();
-    if(modifier) {
-        key = modifier + "+" + key;
+    let key;
+    if(modifier && e.code?.startsWith("Key")) {
+        key = modifier + "+" + e.code.replace("Key", "").toLowerCase();
+    } else {
+        key = e.key.toLowerCase();
+        if(modifier) {
+            key = modifier + "+" + key;
+        }
     }
     if(hotkeys[key]) {
         hotkeyActions[hotkeys[key]](e);


### PR DESCRIPTION
on macOS pressing alt + j produces ∆ and alt + k produces ˚ and so on, so we need to instead use `e.code`

https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/code