### PR TITLE
Allow !! Bang To Work at Start and End

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -264,8 +264,7 @@ func serveIndex(c *webContext) {
 		// Prefix takes precedence over suffix, so "!! query !!" will be treated as "query !!"
 		if strings.HasPrefix(query, "!!") {
 			query = query[2:]
-		}
-		else if strings.HasSuffix(query, "!!") {
+		} else if strings.HasSuffix(query, "!!") {
 			query = query[:len(query)-2]
 		}
 		c.Redirect(strings.Replace(c.Config.App.SearchURL, "{query}", strings.TrimSpace(query), 1))

--- a/server/static/js/search.js
+++ b/server/static/js/search.js
@@ -592,8 +592,12 @@ function viewResultPopup(e) {
 }
 
 function openSelectedResult(e, newWindow) {
-    if(input.value.startsWith("!!")) {
-        openUrl(getSearchUrl(input.value.substring(2)), newWindow);
+    const query = input.value.trim();
+    if(query.startsWith("!!")) {
+        openUrl(getSearchUrl(query.substring(2)), newWindow);
+        return;
+    } else if (query.endsWith("!!")) {
+        openUrl(getSearchUrl(query.substring(0, query.length - 2)), newWindow);
         return;
     }
     e.preventDefault();


### PR DESCRIPTION
## Description 
Currently the !! bang only works as a a prefix `!! hello world`.  This PR allows `hello world !!` to work as well. 

It would make searching with hister and then searching with your external search engine easier as you don't have to move to the start of the search box. 

## Changes
- Updated server.go to check for suffix as well as prefix
- Updated search.js to check fo suffix as well as prefix 

## Testing
- Built hister and tested on Firefox 

Let me know if there any changes you'd like me to make.

- Andrew Pearson