### PR TITLE
[fix]: only run workflows in source repo

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,7 @@ permissions:
 
 jobs:
   build:
+    if: github.repository == 'asciimoo/hister'
     name: GoReleaser build
     runs-on: ubuntu-latest
     container:

--- a/.github/workflows/update-nix-vendor-hash.yml
+++ b/.github/workflows/update-nix-vendor-hash.yml
@@ -17,6 +17,7 @@ permissions:
 
 jobs:
   update-vendor-hash:
+    if: github.repository == 'asciimoo/hister'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
# Why
Only run workflows in source repo and not in every fork, which depending on the workflow creates multiple pull requests.

# How
Check current git repository.

#
Testing welcome.