### PR TITLE
fix: case-insensitive search for title/text/field queries

### DIFF
--- a/server/indexer/querybuilder/builder.go
+++ b/server/indexer/querybuilder/builder.go
@@ -66,12 +66,18 @@ func getTokenQuery(t Token) (query.Query, bool) {
 				v = v[1:]
 			}
 			if strings.Contains(v, "*") {
-				q := bleve.NewWildcardQuery(v)
+				q := bleve.NewWildcardQuery(strings.ToLower(v))
 				q.SetField(field)
 				q.SetBoost(weights[field])
 				return q, negated
 			}
-			q := bleve.NewTermQuery(v)
+			if field == "url" || field == "domain" {
+				q := bleve.NewTermQuery(strings.ToLower(v))
+				q.SetField(field)
+				q.SetBoost(weights[field])
+				return q, negated
+			}
+			q := bleve.NewMatchQuery(v)
 			q.SetField(field)
 			q.SetBoost(weights[field])
 			return q, negated
@@ -85,12 +91,12 @@ func getTokenQuery(t Token) (query.Query, bool) {
 		qs := []query.Query{}
 		for _, f := range []string{"title", "text"} {
 			if strings.Contains(t.Value, "*") {
-				q := bleve.NewWildcardQuery(t.Value)
+				q := bleve.NewWildcardQuery(strings.ToLower(t.Value))
 				q.SetField(f)
 				q.SetBoost(weights[f])
 				qs = append(qs, q)
 			} else {
-				q := bleve.NewTermQuery(t.Value)
+				q := bleve.NewMatchQuery(t.Value)
 				q.SetField(f)
 				q.SetBoost(weights[f])
 				qs = append(qs, q)


### PR DESCRIPTION
## Problem

Search was case-sensitive: searching for `GitHub` returned no results, while `github` worked fine.

**Root cause:** `bleve.NewTermQuery` matches byte-exact without running the term through any analyzer. The `title` and `text` fields are indexed using the standard Bleve analyzer (which lowercases tokens), but the search term was passed as-is.

## Fix

In `server/indexer/querybuilder/builder.go`:

- **title/text plain terms:** `NewTermQuery` → `NewMatchQuery` (runs the search term through the same analyzer used at index time)
- **title/text wildcards:** added `strings.ToLower()` on the search term
- **Field queries `title:`/`text:`:** `NewTermQuery` → `NewMatchQuery`
- **Field queries `url:`/`domain:`:** `strings.ToLower()` + `NewTermQuery` (the url analyzer is lowercase-only)

## Test plan

- [ ] Search lowercase: `github` → results ✓ (was already working)
- [ ] Search mixed-case: `GitHub` → results ✓ (was broken)
- [ ] Search uppercase: `GITHUB` → results ✓ (was broken)
- [ ] Verify `title:GitHub` field query works case-insensitively
- [ ] Verify negation `-GitHub` still works
- [ ] Run `go build ./...` — compiles without errors

Generated with [Claude Code](https://claude.com/claude-code)