### PR TITLE
Add MCP integration documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Hister is a web history management tool that provides blazing fast, content-base
 - **Advanced search capabilities**: Utilize a powerful [query language](https://blevesearch.com/docs/Query-String-Query/) for precise results
 - **Efficient retrieval**: Use keyword aliases to quickly find content
 - **Flexible content management**: Configure blacklist and priority rules for better control
+- **AI assistant integration**: Use Hister as an [MCP server](#mcp-model-context-protocol-integration) for Claude and other AI tools
 
 ## Setup & run
 
@@ -44,6 +45,47 @@ Settings can be configured in `~/.config/hister/config.yml` config file - don't 
 
 Execute `./hister create-config config.yml` to generate a configuration file with the default configuration values.
 
+
+## MCP (Model Context Protocol) Integration
+
+Hister can act as an MCP server, allowing AI assistants like [Claude](https://claude.ai) to search, index, and manage your browser history directly.
+
+```bash
+hister mcp
+```
+
+This starts a stdio MCP server exposing 5 tools:
+
+| Tool | Description |
+|------|-------------|
+| `search` | Full-text search through indexed history |
+| `index` | Download and index a URL |
+| `delete` | Remove a URL from the index |
+| `list_recent` | List recently visited pages |
+| `top_visited` | List most frequently visited pages |
+
+### Claude Code
+
+```bash
+claude mcp add hister /usr/local/bin/hister mcp
+```
+
+### Claude Desktop
+
+Add to `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) or `%APPDATA%\Claude\claude_desktop_config.json` (Windows):
+
+```json
+{
+  "mcpServers": {
+    "hister": {
+      "command": "/usr/local/bin/hister",
+      "args": ["mcp"]
+    }
+  }
+}
+```
+
+See the [MCP documentation](docs/content/documentation/mcp.md) for details.
 
 ## Check out our [Documentation](https://hister.org/documentation/) for more details
 

--- a/docs/content/documentation/mcp.md
+++ b/docs/content/documentation/mcp.md
@@ -1,0 +1,102 @@
++++
+date = '2026-02-22T00:00:00+01:00'
+draft = false
+title = 'MCP Integration'
+layout = 'documentation'
++++
+
+Hister supports the [Model Context Protocol (MCP)](https://modelcontextprotocol.io), allowing AI assistants like [Claude](https://claude.ai) to search your browser history, index URLs, and manage your search index — directly from a chat interface, without opening a browser.
+
+## How It Works
+
+Running `hister mcp` starts a stdio MCP server. MCP clients connect to it as a subprocess and communicate via JSON-RPC over stdin/stdout. No network port is opened.
+
+## Available Tools
+
+| Tool | Input | Description |
+|------|-------|-------------|
+| `search` | `query` (string), `limit` (int, default 10) | Full-text search through indexed history |
+| `index` | `url` (string) | Download and index a URL |
+| `delete` | `url` (string) | Remove a URL from the index |
+| `list_recent` | `limit` (int, default 10) | List most recently visited pages |
+| `top_visited` | `limit` (int, default 10) | List most frequently visited pages, ordered by visit count |
+
+## Setup
+
+### Claude Code
+
+Register Hister as a local MCP server using the Claude CLI:
+
+```bash
+claude mcp add hister /usr/local/bin/hister mcp
+```
+
+To verify it's working, restart Claude Code — the `hister` tools will appear in the MCP tools list.
+
+### Claude Desktop
+
+Add the following to your Claude Desktop configuration file:
+
+**macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
+**Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
+**Linux**: `~/.config/Claude/claude_desktop_config.json`
+
+```json
+{
+  "mcpServers": {
+    "hister": {
+      "command": "/usr/local/bin/hister",
+      "args": ["mcp"]
+    }
+  }
+}
+```
+
+Restart Claude Desktop after saving the file.
+
+### Other MCP Clients
+
+Any MCP-compatible client can use Hister. Configure it as a stdio server:
+
+- **Command**: `hister`
+- **Args**: `["mcp"]`
+
+## Requirements
+
+The Hister server (`hister listen`) does **not** need to be running for the MCP server to work. The MCP server accesses the search index and database directly.
+
+However, the `index` tool does make an HTTP request to download the target URL, so an internet connection is required for that tool.
+
+## Example Usage
+
+Once configured, you can ask Claude things like:
+
+- *"Search my browser history for articles about Rust error handling"*
+- *"What are the 10 most visited sites in my history?"*
+- *"Index this URL for me: https://example.com/article"*
+- *"Show me the pages I visited most recently"*
+- *"Delete https://example.com from my search index"*
+
+## Configuration
+
+The MCP server uses the same configuration file as the rest of Hister (`~/.config/hister/config.yml`). You can specify a custom config path with the `--config` flag:
+
+```bash
+hister --config /path/to/config.yml mcp
+```
+
+## Building from Source
+
+If you build Hister from source, install it to your PATH before configuring MCP clients:
+
+```bash
+go install github.com/asciimoo/hister@latest
+```
+
+Or from a local clone:
+
+```bash
+git clone https://github.com/asciimoo/hister.git
+cd hister
+go install .
+```


### PR DESCRIPTION
## Summary

- **README.md**: New MCP section with tool overview table and setup snippets for Claude Code and Claude Desktop
- **docs/content/documentation/mcp.md**: New documentation page (Hugo) covering all 5 MCP tools, setup instructions for Claude Code / Claude Desktop / other MCP clients, example prompts, config options, and build-from-source instructions

Companion documentation for PR #78 (feat/mcp-server).

## Test plan

- [ ] README renders correctly on GitHub with MCP section visible
- [ ] Hugo docs page builds without errors (`cd docs && hugo`)
- [ ] Setup instructions match actual `hister mcp` behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)