### PR TITLE
Import UX: set --min-visit default to 5, show index stats in footer

### DIFF
--- a/hister.go
+++ b/hister.go
@@ -251,7 +251,7 @@ func init() {
 	listenCmd.Flags().StringP("address", "a", dcfg.Server.Address, "Listen address")
 	indexCmd.Flags().StringP("server-url", "u", dcfg.Server.BaseURL, "hister server URL")
 
-	importCmd.Flags().IntP("min-visit", "m", 1, "only import URLs that were opened at least 'min-visit' times")
+	importCmd.Flags().IntP("min-visit", "m", 5, "only import URLs that were opened at least 'min-visit' times")
 
 	reindexCmd.Flags().BoolP("exclude-sensitive", "x", false, "don't add documents that contain sensitive content matched by config.SensitiveContentPatterns")
 

--- a/server/indexer/indexer.go
+++ b/server/indexer/indexer.go
@@ -290,6 +290,17 @@ func (d *Document) Process() error {
 	return nil
 }
 
+func Count() (uint64, error) {
+	q := query.NewMatchAllQuery()
+	req := bleve.NewSearchRequest(q)
+	req.Size = 0
+	res, err := i.idx.Search(req)
+	if err != nil {
+		return 0, err
+	}
+	return res.Total, nil
+}
+
 func Iterate(fn func(*Document)) {
 	q := query.NewMatchAllQuery()
 	resultNum := 20

--- a/server/server.go
+++ b/server/server.go
@@ -32,6 +32,7 @@ var (
 	errCSRFMismatch = errors.New("CSRF token mismatch")
 	storeName       = "hister"
 	tokName         = "csrf_token"
+	AppVersion      = "v0.1.0"
 )
 
 type tArgs map[string]any
@@ -586,6 +587,10 @@ func (c *webContext) Render(tpl string, args tArgs) {
 	args["Config"] = c.Config
 	args["Nonce"] = c.nonce
 	args["CSRF"] = c.csrf
+	args["AppVersion"] = AppVersion
+	if count, err := indexer.Count(); err == nil {
+		args["IndexCount"] = count
+	}
 	t, ok := tpls[tpl]
 	if !ok {
 		log.Error().Str("template", tpl).Msg("template not found")

--- a/server/templates/layout/base.tpl
+++ b/server/templates/layout/base.tpl
@@ -43,6 +43,9 @@
             <a href="/about">About</a> |
             <a href="/api">API</a> |
             <a href="https://github.com/asciimoo/hister/">GitHub</a>
+            <span class="footer-meta">
+                {{ if .IndexCount }}{{ .IndexCount }} pages indexed | {{ end }}{{ .AppVersion }}
+            </span>
         </footer>
         <script src="/static/js/site.js" nonce="{{ .Nonce }}"></script>
     </body>


### PR DESCRIPTION
## Summary

- **`--min-visit` default changed from 1 to 5**: Importing with the default of 1 visit results in a large number of low-quality URLs (redirects, one-off visits, error pages) that add noise to the index without providing value. A default of 5 visits better reflects pages the user actually uses.
- **Indexed page count in footer**: The footer now shows the total number of indexed documents (e.g. `1688 pages indexed`), giving users a quick sense of their index size without needing a separate CLI command.
- **App version in footer**: The footer now shows the running version (e.g. `v0.1.0`), useful for support and debugging.

## Changes

- `hister.go`: `--min-visit` flag default `1` → `5`
- `server/indexer/indexer.go`: new `Count() (uint64, error)` function using a size-0 Bleve query
- `server/server.go`: inject `IndexCount` and `AppVersion` into every template render; add `AppVersion` package variable
- `server/templates/layout/base.tpl`: footer extended with `<span class="footer-meta">N pages indexed | vX.Y.Z</span>`

## Test plan

- [ ] Run `hister import chrome <db>` without `--min-visit` flag — should now use threshold of 5
- [ ] Open the web UI — footer should show page count and version
- [ ] Verify `hister import chrome <db> --min-visit 1` still works (explicit override)

🤖 Generated with [Claude Code](https://claude.com/claude-code)