### PR TITLE
Import: skip private/local and non-http URLs without network attempt

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -28,6 +28,7 @@ type Config struct {
 	fname                    string
 	App                      App               `yaml:"app"`
 	Server                   Server            `yaml:"server"`
+	Import                   Import            `yaml:"import"`
 	Hotkeys                  Hotkeys           `yaml:"hotkeys"`
 	SensitiveContentPatterns map[string]string `yaml:"sensitive_content_patterns"`
 	Rules                    *Rules            `yaml:"-"`
@@ -40,6 +41,10 @@ type App struct {
 	LogLevel            string `yaml:"log_level"`
 	DebugSQL            bool   `yaml:"debug_sql"`
 	OpenResultsOnNewTab bool   `yaml:"open_results_on_new_tab"`
+}
+
+type Import struct {
+	SkipPrivateURLs bool `yaml:"skip_private_urls"`
 }
 
 type Server struct {
@@ -165,6 +170,9 @@ func CreateDefaultConfig() *Config {
 			Directory:           getDefaultDataDir(),
 			LogLevel:            "info",
 			OpenResultsOnNewTab: false,
+		},
+		Import: Import{
+			SkipPrivateURLs: true,
 		},
 		Server: Server{
 			Address:  "127.0.0.1:4433",

--- a/hister.go
+++ b/hister.go
@@ -163,7 +163,7 @@ var indexCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		setStrArg(cmd, "server-url", &cfg.Server.BaseURL)
 		for _, u := range args {
-			if err := indexURL(u); err != nil {
+			if err := indexURL(u, cfg.Import.SkipPrivateURLs); err != nil {
 				exit(1, "Failed to index URL: "+err.Error())
 			}
 		}
@@ -253,6 +253,7 @@ func init() {
 	indexCmd.Flags().StringP("server-url", "u", dcfg.Server.BaseURL, "hister server URL")
 
 	importCmd.Flags().IntP("min-visit", "m", 1, "only import URLs that were opened at least 'min-visit' times")
+	importCmd.Flags().Bool("include-private", false, "include private/local URLs (e.g. localhost, 192.168.x.x) — overrides import.skip_private_urls in config")
 
 	reindexCmd.Flags().BoolP("exclude-sensitive", "x", false, "don't add documents that contain sensitive content matched by config.SensitiveContentPatterns")
 
@@ -467,7 +468,7 @@ func isPrivateHost(host string) bool {
 	return false
 }
 
-func indexURL(u string) error {
+func indexURL(u string, skipPrivate bool) error {
 	client := &http.Client{
 		// Websites can be slow or unreachable, we don't want to wait too long for each of them, especially if we are indexing a lot of URLs during import.
 		Timeout: 5 * time.Second,
@@ -484,7 +485,7 @@ func indexURL(u string) error {
 		log.Debug().Str("URL", u).Msg("skipping non-http URL")
 		return nil
 	}
-	if isPrivateHost(parsed.Hostname()) {
+	if skipPrivate && isPrivateHost(parsed.Hostname()) {
 		log.Debug().Str("URL", u).Msg("skipping private/local URL")
 		return nil
 	}
@@ -547,6 +548,9 @@ func indexURL(u string) error {
 }
 
 func importHistory(cmd *cobra.Command, args []string) {
+	includePrivate, _ := cmd.Flags().GetBool("include-private")
+	skipPrivate := cfg.Import.SkipPrivateURLs && !includePrivate
+
 	browser := args[0]
 	if browser != "firefox" && browser != "chrome" {
 		exit(1, "Invalid browser type it should be 'firefox' or 'chrome'")
@@ -599,7 +603,7 @@ func importHistory(cmd *cobra.Command, args []string) {
 			exit(1, "Failed to retreive URL: "+err.Error())
 		}
 		fmt.Printf("[%d/%d] %s\n", i, count, u)
-		if err := indexURL(u); err != nil {
+		if err := indexURL(u, skipPrivate); err != nil {
 			log.Warn().Err(err).Msg("Failed to index URL")
 		}
 		i += 1


### PR DESCRIPTION
## Summary

During browser history import, many URLs are inherently un-indexable: localhost dev servers, router admin pages, internal IP dashboards, etc. Attempting to fetch these causes 5-second timeouts per URL, making large imports very slow.

This PR adds a pre-flight check in `indexURL()` that skips such URLs immediately without any network attempt.

### What is skipped by default

- Non-http/https schemes (`file://`, `chrome://`, `about:`, etc.)
- Private/loopback IP ranges: `127.0.0.0/8`, `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `::1`, `fc00::/7`
- Hostnames resolving to `localhost`

### Configurable

Skipping private URLs is **opt-out** — enabled by default but fully configurable:

**config.yml:**
```yaml
import:
  skip_private_urls: false  # set to false to index self-hosted apps on local network
```

**Per-run CLI flag** (overrides config):
```bash
hister import --include-private firefox /path/to/places.sqlite
```

This is useful for self-hosted apps (Home Assistant, Gitea, Nextcloud, etc.) that listen on localhost or a LAN subnet.

## Test plan

- [ ] Run `hister import` — private/local URLs should be silently skipped (debug log only)
- [ ] Run `hister import --include-private` — private URLs should be fetched and indexed
- [ ] Set `import.skip_private_urls: false` in config — same as `--include-private`
- [ ] Verify non-http schemes (`file://`, `chrome://`) are still skipped regardless of flag
- [ ] Run `go build ./...` — should compile without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)