### PR TITLE
[enh] display search duration in seconds

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -339,7 +339,8 @@ func doSearch(query *indexer.Query, cfg *config.Config) (*indexer.Results, error
 	if oq != "" {
 		res.QuerySuggestion = model.GetQuerySuggestion(oq)
 	}
-	res.SearchDuration = fmt.Sprintf("%v", time.Since(start))
+	duration := float32(time.Since(start).Milliseconds()) / 1000.
+	res.SearchDuration = fmt.Sprintf("%.3f seconds", duration)
 	return res, nil
 }
 


### PR DESCRIPTION
Fixes #88.

The output now looks like `0.127 seconds` (previously: `127.534424ms`). This is the format used by Google when it displayed search duration (https://webapps.stackexchange.com/questions/67520/google-search-result-returns-number-of-result-with-time-fraction-what-does-it-re).