### PR TITLE
fix(nix): correct cd path in preBuild to return to project root

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -38,7 +38,7 @@ buildGoModule (finalAttrs: {
     export NPM_CONFIG_CACHE=$TMPDIR/npm-cache
     npm ci --offline
     npm run build
-    cd ../..
+    cd ../../..
 
     export CGO_CFLAGS="-I${sqlite.dev}/include"
     export CGO_LDFLAGS="-L${sqlite.out}/lib -lsqlite3"


### PR DESCRIPTION
In `nix/package.nix`, the `preBuild` script does `cd server/static/js` to build npm dependencies, then `cd ../..` to return. However, `cd ../..` from `server/static/js` only goes back to `server/`, not the project root. This causes `buildGoModule` to run in the wrong directory, producing an empty build output.

Fix: change `cd ../..` to `cd ../../..` to correctly return to the project root.