### PR TITLE
refactor(nix): rewrite packaging following best practices

### DIFF
--- a/.github/workflows/update-nix-vendor-hash.yml
+++ b/.github/workflows/update-nix-vendor-hash.yml
@@ -51,7 +51,7 @@ jobs:
           commit-message: "[chore] update Nix hashes for Go/NPM changes"
           title: "Update Nix hashes"
           body: |
-            [chore] update nix/package.nix hashes (vendorHash and/or npmDeps)
+            [chore] update nix/package.nix hashes (vendorHash and/or npmDepsHash)
             
             Triggered by: ${{ github.repository }}@${{ github.sha }}
           delete-branch: true

--- a/nix/update-nix-vendor-hash.sh
+++ b/nix/update-nix-vendor-hash.sh
@@ -17,21 +17,21 @@ update_hash() {
     
     if echo "$output" | grep -q "go-modules.drv"; then
       echo "::notice::Updating vendorHash"
-      sed -i.bak "s|$EXPECTED_HASH|$GOT_HASH|g" "$PACKAGE_FILE"
-      rm -f "$PACKAGE_FILE.bak"
-      echo "updated"
     elif echo "$output" | grep -q "npm-deps.drv"; then
-      echo "::notice::Updating npmDeps hash"
-      sed -i.bak "s|$EXPECTED_HASH|$GOT_HASH|g" "$PACKAGE_FILE"
-      rm -f "$PACKAGE_FILE.bak"
-      echo "updated"
+      echo "::notice::Updating npmDepsHash"
+    else
+      echo "::warning::Unknown hash mismatch, updating anyway"
     fi
+
+    sed -i.bak "s|$EXPECTED_HASH|$GOT_HASH|g" "$PACKAGE_FILE"
+    rm -f "$PACKAGE_FILE.bak"
+    echo "updated"
   fi
 }
 
 echo "::notice::Running nix build to check for hash mismatches..."
 
-# nix hash
+# Attempt 1: typically catches npmDepsHash or vendorHash mismatch
 echo "::group::Build attempt 1"
 OUTPUT=$(nix build .#hister 2>&1 || true)
 echo "$OUTPUT"
@@ -39,7 +39,7 @@ echo "::endgroup::"
 
 RESULT1=$(update_hash "$OUTPUT" "1")
 
-# npm hash
+# Attempt 2: catches the remaining hash if both changed
 echo "::group::Build attempt 2"
 OUTPUT=$(nix build .#hister 2>&1 || true)
 echo "$OUTPUT"


### PR DESCRIPTION
Rewrite `nix/package.nix` following Nix packaging best practices. This supersedes #113 — the original `cd` path bug is no longer relevant since the manual npm build in `preBuild` has been replaced entirely.

### Changes

- **`buildNpmPackage` for frontend**: Replace manual `fetchNpmDeps` + `npm ci` in `preBuild` with a separate `buildNpmPackage` derivation, avoiding redundant npm builds during the `goModules` vendor phase
- **`lib.fileset` source filtering**: Precisely include only Go source and required directories instead of `src = ../.;` which pulls in docs, CI configs, etc.
- **`pkg-config` + `libsqlite3` tag**: Use the proper `go-sqlite3` build tag with pkg-config instead of manually setting `CGO_CFLAGS`/`CGO_LDFLAGS`
- **Cleanup**: Remove unnecessary `nodejs` from `nativeBuildInputs`, empty `postPatch`, and deduplicate `sed` logic in the hash update script

Also updates `nix/update-nix-vendor-hash.sh` and CI workflow to match.