### PR TITLE
fix(querybuilder): handle UTF-8 queries in lexer

### DIFF
--- a/server/indexer/querybuilder/parser.go
+++ b/server/indexer/querybuilder/parser.go
@@ -22,13 +22,13 @@ type Token struct {
 }
 
 type Lexer struct {
-	input string
+	input []rune
 	pos   int
 	char  rune
 }
 
 func New(input string) *Lexer {
-	l := &Lexer{input: input}
+	l := &Lexer{input: []rune(input)}
 	l.readChar()
 	return l
 }
@@ -54,7 +54,7 @@ func (l *Lexer) readChar() {
 	if l.pos >= len(l.input) {
 		l.char = 0
 	} else {
-		l.char = rune(l.input[l.pos])
+		l.char = l.input[l.pos]
 	}
 	l.pos++
 }
@@ -63,7 +63,7 @@ func (l *Lexer) peekChar() rune {
 	if l.pos >= len(l.input) {
 		return 0
 	}
-	return rune(l.input[l.pos])
+	return l.input[l.pos]
 }
 
 func (l *Lexer) skipWhitespace() {
@@ -148,7 +148,7 @@ func parseAlternationParts(value string) ([]Token, error) {
 	var sb strings.Builder
 	depth := 0
 
-	for i, ch := range value {
+	for _, ch := range value {
 		if ch == '(' {
 			depth++
 			sb.WriteRune(ch)
@@ -165,22 +165,12 @@ func parseAlternationParts(value string) ([]Token, error) {
 		} else {
 			sb.WriteRune(ch)
 		}
-
-		if i == len(value)-1 {
-			optStr := strings.TrimSpace(sb.String())
-			if optStr != "" {
-				token := Token{Type: TokenWord, Value: optStr}
-				parts = append(parts, token)
-			}
-		}
 	}
 
-	if len(parts) == 0 {
-		optStr := strings.TrimSpace(sb.String())
-		if optStr != "" {
-			token := Token{Type: TokenWord, Value: optStr}
-			parts = append(parts, token)
-		}
+	optStr := strings.TrimSpace(sb.String())
+	if optStr != "" {
+		token := Token{Type: TokenWord, Value: optStr}
+		parts = append(parts, token)
 	}
 
 	return parts, nil

--- a/server/indexer/querybuilder/parser_test.go
+++ b/server/indexer/querybuilder/parser_test.go
@@ -1,0 +1,92 @@
+package querybuilder
+
+import "testing"
+
+func Test_tokenize_arabic_word(t *testing.T) {
+	tokens, err := Tokenize("سلام")
+	if err != nil {
+		t.Fatalf("Tokenize returned error: %v", err)
+	}
+	if len(tokens) != 1 {
+		t.Fatalf("expected 1 token, got %d", len(tokens))
+	}
+	if tokens[0].Type != TokenWord {
+		t.Fatalf("expected TokenWord, got %v", tokens[0].Type)
+	}
+	if tokens[0].Value != "سلام" {
+		t.Fatalf("expected token value %q, got %q", "سلام", tokens[0].Value)
+	}
+}
+
+func Test_tokenize_english_word(t *testing.T) {
+	tokens, err := Tokenize("hello")
+	if err != nil {
+		t.Fatalf("Tokenize returned error: %v", err)
+	}
+	if len(tokens) != 1 {
+		t.Fatalf("expected 1 token, got %d", len(tokens))
+	}
+	if tokens[0].Type != TokenWord {
+		t.Fatalf("expected TokenWord, got %v", tokens[0].Type)
+	}
+	if tokens[0].Value != "hello" {
+		t.Fatalf("expected token value %q, got %q", "hello", tokens[0].Value)
+	}
+}
+
+func Test_tokenize_english_quoted_phrase(t *testing.T) {
+	tokens, err := Tokenize(`"hello world"`)
+	if err != nil {
+		t.Fatalf("Tokenize returned error: %v", err)
+	}
+	if len(tokens) != 1 {
+		t.Fatalf("expected 1 token, got %d", len(tokens))
+	}
+	if tokens[0].Type != TokenQuoted {
+		t.Fatalf("expected TokenQuoted, got %v", tokens[0].Type)
+	}
+	if tokens[0].Value != "hello world" {
+		t.Fatalf("expected token value %q, got %q", "hello world", tokens[0].Value)
+	}
+}
+
+func Test_tokenize_english_alternation(t *testing.T) {
+	tokens, err := Tokenize("(hello|world)")
+	if err != nil {
+		t.Fatalf("Tokenize returned error: %v", err)
+	}
+	if len(tokens) != 1 {
+		t.Fatalf("expected 1 token, got %d", len(tokens))
+	}
+	if tokens[0].Type != TokenAlternation {
+		t.Fatalf("expected TokenAlternation, got %v", tokens[0].Type)
+	}
+	if len(tokens[0].Parts) != 2 {
+		t.Fatalf("expected 2 alternation parts, got %d", len(tokens[0].Parts))
+	}
+	if tokens[0].Parts[0].Value != "hello" {
+		t.Fatalf("expected first alternation part %q, got %q", "hello", tokens[0].Parts[0].Value)
+	}
+	if tokens[0].Parts[1].Value != "world" {
+		t.Fatalf("expected second alternation part %q, got %q", "world", tokens[0].Parts[1].Value)
+	}
+}
+
+func Test_tokenize_alternation_keeps_last_arabic_part(t *testing.T) {
+	tokens, err := Tokenize("(hello|مرحبا)")
+	if err != nil {
+		t.Fatalf("Tokenize returned error: %v", err)
+	}
+	if len(tokens) != 1 {
+		t.Fatalf("expected 1 token, got %d", len(tokens))
+	}
+	if tokens[0].Type != TokenAlternation {
+		t.Fatalf("expected TokenAlternation, got %v", tokens[0].Type)
+	}
+	if len(tokens[0].Parts) != 2 {
+		t.Fatalf("expected 2 alternation parts, got %d", len(tokens[0].Parts))
+	}
+	if tokens[0].Parts[1].Value != "مرحبا" {
+		t.Fatalf("expected last alternation part %q, got %q", "مرحبا", tokens[0].Parts[1].Value)
+	}
+}


### PR DESCRIPTION
## Summary
- switch query lexer input from byte-wise string indexing to rune-aware tokenization
- fix alternation part parsing so the final option is preserved with multibyte text
- add regression tests for Arabic and English tokenization cases

## Validation
- `go test ./server/indexer/querybuilder`
- search manually

<img width="769" height="525" alt="image" src="https://github.com/user-attachments/assets/e2cee862-1c2b-4d5e-9a5f-53a08be7192f" />
