### PR TITLE
[fix] add client module to nix package inputs

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -36,6 +36,7 @@ buildGoModule (finalAttrs: {
       ../go.mod
       ../go.sum
       ../hister.go
+      ../client
       ../server
       ../config
       ../ui


### PR DESCRIPTION
On current main, `nix build github:asciimoo/hister` fails because it can't find the client/ go module. Looks like #94 introduced that module, so it needs to be included in the nix package inputs for the package definition to continue building. This PR adds that input.