### PR TITLE
[fix] improve list-urls performances and fix missing entries

### DIFF
--- a/server/indexer/indexer.go
+++ b/server/indexer/indexer.go
@@ -432,22 +432,25 @@ func GetByURL(u string) *Document {
 
 func Iterate(fn func(*Document)) {
 	q := query.NewMatchAllQuery()
-	resultNum := 20
-	page := 0
+	req := bleve.NewSearchRequest(q)
+	req.Fields = []string{"url"}
+	req.Size = 20
+	req.SortBy([]string{"_id"})
+	latest := ""
 	for {
-		req := bleve.NewSearchRequest(q)
-		req.Size = resultNum
-		req.From = page * resultNum
-		req.Fields = allFields
+		if latest != "" {
+			req.SetSearchAfter([]string{latest})
+		}
 		res, err := i.idx.Search(req)
-		if err != nil || len(res.Hits) < 1 {
+		n := len(res.Hits)
+		if err != nil || n < 1 {
 			return
 		}
 		for _, h := range res.Hits {
 			d := docFromHit(h)
 			fn(d)
 		}
-		page += 1
+		latest = res.Hits[n-1].Fields["url"].(string)
 	}
 }
 


### PR DESCRIPTION
The complexity of `list-urls` seems to be O(exp(n)) (one can notice that batches of 20 URLs are printed slower and slower). It takes more than 1m35s to output about 1700 URLs:

```shell
$ time ./hister list-urls >/dev/null
real        0m37,301s
user        1m1,578s
sys         0m7,346s
```
There is also an issue with paging, because there are duplicate URLs in the output, and some URLs are also missing.

This PR improves performances drastically and also fix the paging issue. There is a nice side-effect: URLs are now alphabetically sorted.

```shell
$ time ./hister list-urls >/dev/null
real         0m1,778s
user         0m3,935s
sys          0m0,808s
```



**suggestion:** it would be great if some unit tests were added, typically to avoid this kind of issue. I'm not familiar enough with go to write unit tests for this feature from scratch, but would be glad to add some once a few indexer tests are written by someone more experimented ;)