### PR TITLE
[fix] patch workspace shebangs in nix frontend derivation

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -18,6 +18,9 @@ let
     npmDeps = importNpmLock { npmRoot = ../.; };
     npmConfigHook = importNpmLock.npmConfigHook;
     dontNpmBuild = false;
+    preBuild = ''
+      patchShebangs webui
+    '';
     installPhase = ''
       runHook preInstall
       mkdir -p $out


### PR DESCRIPTION
Fixes: https://github.com/asciimoo/hister/actions/runs/23017418873/job/66844321137

The `importnpmlock.npmconfighook` only patches shebangs in the root `node_modules/` directory

With npm workspaces, npm creates workspace-level bin entries at `webui/app/node_modules/.bin/` which are not traversed by the hook

Add `preBuild` step to patch all workspace `node_modules/.bin` entries under webui/ before the build phase, fixing the vite shebang error in CI