### PR TITLE
[mod] highlight again title fragments with HTML highlighter

### DIFF
--- a/server/indexer/indexer.go
+++ b/server/indexer/indexer.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"html"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -385,7 +386,6 @@ func Search(cfg *config.Config, q *Query) (*Results, error) {
 	switch q.Highlight {
 	case "HTML":
 		req.Highlight = bleve.NewHighlight()
-		req.Highlight.Fields = []string{"text"}
 	case "text":
 		req.Highlight = bleve.NewHighlightWithStyle("ansi")
 	case "tui":
@@ -409,11 +409,12 @@ func Search(cfg *config.Config, q *Query) (*Results, error) {
 			d.Text = t[0]
 		}
 		if t, ok := v.Fragments["title"]; ok {
+			// Bleve HTML Highlighter HTML-escapes the original title (so that fragments are surrounded with `<mark>`)
 			d.Title = t[0]
 		} else {
 			s, ok := v.Fields["title"].(string)
 			if ok {
-				d.Title = s
+				d.Title = html.EscapeString(s)
 			}
 		}
 		if i, ok := v.Fields["favicon"].(string); ok {

--- a/webui/app/src/routes/+page.svelte
+++ b/webui/app/src/routes/+page.svelte
@@ -860,7 +860,7 @@
                       openResult(r.url, r.title || '*title*', e.ctrlKey || e.metaKey);
                     }}
                   >
-                    {r.title || '*title*'}
+                    {@html r.title || '*title*'}
                   </a>
                   <div class="flex items-center gap-2">
                     <span
@@ -973,7 +973,7 @@
                       openResult(r.url, r.title || '*title*', e.ctrlKey || e.metaKey);
                     }}
                   >
-                    {r.title || '*title*'}
+                    {@html r.title || '*title*'}
                   </a>
                   <div class="items-left flex flex-col gap-0 md:flex-row md:items-center md:gap-2">
                     <span


### PR DESCRIPTION
#106 was eventually fixed by removing HTML highlighting from titles. This PR relies on Bleve's (undocumented?) behavior to restore this feature and HTML escape titles correctly:

- If search fragments are found in the title, the whole title is HTML-escaped
- Otherwise it isn't.

Titles are indexed unescaped.

**note:** feel free to close the PR if you think it isn't worth it. I just wanted to figure out what was the root cause of this HTML escaping issue.