### PR TITLE
[feat] add offline queue and batch API for browser extension

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3390,6 +3390,12 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/dexie": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/dexie/-/dexie-4.3.0.tgz",
+      "integrity": "sha512-5EeoQpJvMKHe6zWt/FSIIuRa3CWlZeIl6zKXt+Lz7BU6RoRRLgX9dZEynRfXrkLcldKYCBiz7xekTEylnie1Ug==",
+      "license": "Apache-2.0"
+    },
     "node_modules/dom-serializer": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
@@ -3855,6 +3861,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -5701,6 +5713,34 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-queue": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-8.1.1.tgz",
+      "integrity": "sha512-aNZ+VfjobsWryoiPnEApGGmf5WmNsCo9xu8dfaYamG5qaLP7ClhLN6NgsFe6SwJ2UbLEBK5dv9x8Mn5+RVhMWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^5.0.1",
+        "p-timeout": "^6.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-timeout": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.4.tgz",
+      "integrity": "sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -8309,7 +8349,9 @@
       "name": "@hister/ext",
       "version": "0.11.0",
       "dependencies": {
-        "@hister/components": "^1.0.0"
+        "@hister/components": "^1.0.0",
+        "dexie": "^4.0.11",
+        "p-queue": "^8.1.0"
       },
       "devDependencies": {
         "@sveltejs/vite-plugin-svelte": "^7.0.0",

--- a/server/api.go
+++ b/server/api.go
@@ -195,6 +195,14 @@ func init() {
 			},
 		},
 		{
+			Name:         "Batch add",
+			Path:         "/api/batch",
+			Method:       POST,
+			CSRFRequired: true,
+			Handler:      serveBatch,
+			Description:  "Batch add documents and history items",
+		},
+		{
 			Name:         "API",
 			Path:         "/api",
 			Method:       GET,

--- a/server/indexer/indexer.go
+++ b/server/indexer/indexer.go
@@ -279,6 +279,22 @@ func Add(d *Document) error {
 	return i.AddDocument(d)
 }
 
+func AddBatch(docs []*Document) (indexed, skipped int, errs []error) {
+	batch := newMultiBatch(i)
+	for _, d := range docs {
+		if err := batch.Add(d); err != nil {
+			errs = append(errs, err)
+			skipped++
+		} else {
+			indexed++
+		}
+	}
+	if err := batch.Save(); err != nil {
+		errs = append(errs, err)
+	}
+	return
+}
+
 func (i *indexer) Total() uint64 {
 	q := query.NewMatchAllQuery()
 	req := bleve.NewSearchRequest(q)

--- a/server/server.go
+++ b/server/server.go
@@ -273,8 +273,9 @@ func withCSRF(handler endpointHandler) endpointHandler {
 			handler(c)
 			return
 		}
-		// Allow add requests from the addons
-		if c.Request.URL.Path == c.Config.BasePathPrefix()+"/add" || c.Request.URL.Path == c.Config.BasePathPrefix()+"/api/add" {
+		// Allow add/batch requests from the addons
+		p := strings.TrimPrefix(c.Request.URL.Path, c.Config.BasePathPrefix())
+		if p == "/add" || p == "/api/add" || p == "/api/batch" {
 			if strings.HasPrefix(c.Request.Header.Get("Origin"), "moz-extension://") {
 				handler(c)
 				return
@@ -548,6 +549,75 @@ func doSearch(query *indexer.Query, cfg *config.Config) (*indexer.Results, error
 	duration := float32(time.Since(start).Milliseconds()) / 1000.
 	res.SearchDuration = fmt.Sprintf("%.3f seconds", duration)
 	return res, nil
+}
+
+func serveBatch(c *webContext) {
+	type batchRequest struct {
+		Documents []*indexer.Document `json:"documents"`
+		History   []historyItem       `json:"history"`
+	}
+	type batchResponse struct {
+		Indexed int      `json:"indexed"`
+		Skipped int      `json:"skipped"`
+		Errors  []string `json:"errors,omitempty"`
+	}
+
+	var req batchRequest
+	if err := json.NewDecoder(c.Request.Body).Decode(&req); err != nil {
+		http.Error(c.Response, "invalid JSON body", http.StatusBadRequest)
+		return
+	}
+
+	if len(req.Documents)+len(req.History) == 0 {
+		c.JSON(batchResponse{})
+		return
+	}
+	if len(req.Documents)+len(req.History) > 100 {
+		http.Error(c.Response, "batch size exceeds 100 items", http.StatusBadRequest)
+		return
+	}
+
+	var resp batchResponse
+
+	// Filter and index documents
+	if len(req.Documents) > 0 {
+		docs := make([]*indexer.Document, 0, len(req.Documents))
+		for _, d := range req.Documents {
+			if d.URL == "" {
+				resp.Skipped++
+				resp.Errors = append(resp.Errors, "document missing URL")
+				continue
+			}
+			if c.Config.Rules.IsSkip(d.URL) || strings.HasPrefix(d.URL, c.Config.BaseURL("/")) {
+				resp.Skipped++
+				continue
+			}
+			docs = append(docs, d)
+		}
+		if len(docs) > 0 {
+			indexed, skipped, errs := indexer.AddBatch(docs)
+			resp.Indexed += indexed
+			resp.Skipped += skipped
+			for _, e := range errs {
+				resp.Errors = append(resp.Errors, e.Error())
+			}
+		}
+	}
+
+	// Process history items
+	for _, h := range req.History {
+		if h.Delete {
+			if err := model.DeleteHistoryItem(h.Query, h.URL); err != nil {
+				resp.Errors = append(resp.Errors, err.Error())
+			}
+			continue
+		}
+		if err := model.UpdateHistory(strings.TrimSpace(h.Query), strings.TrimSpace(h.URL), strings.TrimSpace(h.Title)); err != nil {
+			resp.Errors = append(resp.Errors, err.Error())
+		}
+	}
+
+	c.JSON(resp)
 }
 
 func serveAdd(c *webContext) {

--- a/webui/app/src/lib/search.ts
+++ b/webui/app/src/lib/search.ts
@@ -27,6 +27,7 @@ export interface SearchResult {
   text?: string;
   favicon?: string;
   added?: number;
+  queued?: boolean;
 }
 
 export interface SearchResults {

--- a/webui/app/src/routes/+page.svelte
+++ b/webui/app/src/routes/+page.svelte
@@ -17,7 +17,7 @@
     openURL,
   } from '$lib/search';
   import { fetchConfig, apiFetch } from '$lib/api';
-  import type { SearchResults } from '$lib/search';
+  import type { SearchResults, SearchResult } from '$lib/search';
   import { animate } from 'animejs';
   import { Input } from '@hister/components/ui/input';
   import { Button } from '@hister/components/ui/button';
@@ -26,7 +26,7 @@
   import * as Dialog from '@hister/components/ui/dialog';
   import * as Card from '@hister/components/ui/card';
   import * as DropdownMenu from '@hister/components/ui/dropdown-menu';
-  import * as Tooltip from  '@hister/components/ui/tooltip';
+  import * as Tooltip from '@hister/components/ui/tooltip';
   import { ScrollArea } from '@hister/components/ui/scroll-area';
   import { Kbd } from '@hister/components/ui/kbd';
   import {
@@ -203,6 +203,23 @@
     autocomplete = (query && res.query_suggestion) || '';
     highlightIdx = 0;
     resultsShown = true;
+
+    // Request supplemental results from extension's offline queue
+    if (query) {
+      window.dispatchEvent(new CustomEvent('hister:search', { detail: { query } }));
+    }
+  }
+
+  function mergeQueuedResults(queuedResults: SearchResult[]) {
+    if (!lastResults || !queuedResults?.length) return;
+    const existingUrls = new Set((lastResults.documents || []).map((d) => d.url));
+    const newResults = queuedResults.filter((r) => !existingUrls.has(r.url));
+    if (newResults.length > 0) {
+      lastResults = {
+        ...lastResults,
+        documents: [...(lastResults.documents || []), ...newResults],
+      };
+    }
   }
 
   function stripHtml(s: string): string {
@@ -598,9 +615,17 @@
       keyHandler = new KeyHandler(config.hotkeys, hotkeyActions);
       loadHomeStats();
     })();
+
+    // Listen for supplemental results from extension's offline queue
+    const onQueued = ((e: CustomEvent<{ results: SearchResult[] }>) => {
+      mergeQueuedResults(e.detail?.results);
+    }) as EventListener;
+    window.addEventListener('hister:queue-results', onQueued);
+
     return () => {
       wsManager?.close();
       cleanupAnimations();
+      window.removeEventListener('hister:queue-results', onQueued);
     };
   });
 </script>
@@ -690,13 +715,11 @@
         bind:value={query}
         placeholder="Search..."
         class="font-inter text-text-brand placeholder:text-text-brand-muted h-full flex-1 border-0 bg-transparent p-0 text-lg font-medium shadow-none focus-visible:ring-0 md:text-2xl"
-        />
+      />
       <Tooltip.Provider delayDuration={0}>
         <Tooltip.Root>
           <Tooltip.Trigger>
-            <div
-                class="h-3 w-3 shrink-0 {connected ? 'bg-hister-lime' : 'bg-hister-rose'}"
-            ></div>
+            <div class="h-3 w-3 shrink-0 {connected ? 'bg-hister-lime' : 'bg-hister-rose'}"></div>
           </Tooltip.Trigger>
           <Tooltip.Portal>
             <Tooltip.Content>
@@ -1006,6 +1029,12 @@
                         title={formatTimestamp(r.added)}>· {formatRelativeTime(r.added)}</span
                       >
                     {/if}
+                    {#if r.queued}
+                      <Badge
+                        variant="outline"
+                        class="border-hister-indigo text-hister-indigo text-xs">Pending sync</Badge
+                      >
+                    {/if}
                     <Button
                       data-readable
                       variant="link"
@@ -1135,18 +1164,16 @@
           class="font-inter text-text-brand placeholder:text-text-brand-muted h-full min-w-0 flex-1 border-0 bg-transparent p-0 shadow-none focus-visible:ring-0 md:text-lg"
         />
         <Tooltip.Provider delayDuration={0}>
-            <Tooltip.Root>
+          <Tooltip.Root>
             <Tooltip.Trigger class="mr-4">
-                <div
-                    class="h-3 w-3 shrink-0 {connected ? 'bg-hister-lime' : 'bg-hister-rose'}"
-                ></div>
+              <div class="h-3 w-3 shrink-0 {connected ? 'bg-hister-lime' : 'bg-hister-rose'}"></div>
             </Tooltip.Trigger>
             <Tooltip.Portal>
-                <Tooltip.Content>
+              <Tooltip.Content>
                 Server: {connected ? 'Connected' : 'Disconnected'}
-                </Tooltip.Content>
+              </Tooltip.Content>
             </Tooltip.Portal>
-            </Tooltip.Root>
+          </Tooltip.Root>
         </Tooltip.Provider>
       </div>
     </div>

--- a/webui/ext/package.json
+++ b/webui/ext/package.json
@@ -8,7 +8,9 @@
     "dev": "vite build --watch --mode development"
   },
   "dependencies": {
-    "@hister/components": "^1.0.0"
+    "@hister/components": "^1.0.0",
+    "dexie": "^4.0.11",
+    "p-queue": "^8.1.0"
   },
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "^7.0.0",

--- a/webui/ext/src/background/background.ts
+++ b/webui/ext/src/background/background.ts
@@ -1,45 +1,201 @@
-import { sendPageData, sendResult } from '../modules/network';
+import { send, resolve, normalize, headers } from '../modules/network';
+import { enqueue, drain, count, clear as clearAll, pages, remove } from '../modules/queue';
+import { db, type PagePayload, type QueuePayload } from '../modules/db';
+import { getStatus, setStatus, badge } from '../modules/status';
+import { STORAGE_KEYS } from '../modules/constants';
+
+const ALARM = 'histerQueueDrain';
+const DRAIN_INTERVAL_MINUTES = 2;
+const HTTP_FORBIDDEN = 403;
 
 const missingURLMsg = {
   error: 'Missing or invalid Hister server URL. Configure it in the addon popup.',
 };
-// TODO check source
-function cjsMsgHandler(request, sender, sendResponse) {
-  chrome.storage.local
-    .get(['histerURL', 'histerToken', 'indexingEnabled'])
-    .then((data) => {
-      let u = data['histerURL'] || '';
-      const tok = data['histerToken'] || '';
-      const indexingEnabled = data['indexingEnabled'] !== false;
 
-      if (!u) {
-        chrome.tabs.sendMessage(sender.tab.id, missingURLMsg);
+interface ExtMessage {
+  action?: string;
+  query?: string;
+  id?: number;
+  pageData?: PagePayload;
+  resultData?: Record<string, unknown>;
+}
+
+async function settings() {
+  const data = await chrome.storage.local.get(Object.values(STORAGE_KEYS));
+  return {
+    url: (data[STORAGE_KEYS.url] || '') as string,
+    token: (data[STORAGE_KEYS.token] || '') as string,
+    indexingEnabled: data[STORAGE_KEYS.indexingEnabled] !== false,
+  };
+}
+
+async function sync() {
+  await badge(await count());
+}
+
+/** Try to send payload; on failure enqueue and update status. */
+async function trySend(
+  base: string,
+  endpoint: string,
+  payload: QueuePayload,
+  token: string,
+  type: 'pageData' | 'resultData',
+  respond: (response?: unknown) => void,
+) {
+  try {
+    const r = await send(base + endpoint, payload, token);
+    if (r.ok) {
+      setStatus('connected');
+      drain(base, token).catch((e) => console.warn('drain failed', e));
+      respond({ status: 'ok', status_code: r.status });
+      return;
+    }
+    if (r.status === HTTP_FORBIDDEN) {
+      setStatus('error');
+      respond({ status: 'error', status_code: r.status });
+      return;
+    }
+    await enqueue(type, endpoint, payload);
+    setStatus('error');
+    respond({ status: 'queued' });
+  } catch (err) {
+    console.warn('send failed, queuing', err);
+    await enqueue(type, endpoint, payload);
+    setStatus('offline');
+    respond({ status: 'queued' });
+  } finally {
+    await sync();
+  }
+}
+
+type Handler = (
+  req: ExtMessage,
+  sender: chrome.runtime.MessageSender,
+  respond: (response?: unknown) => void,
+) => Promise<void>;
+
+const actions: Record<string, Handler> = {
+  async getStatus(_req, _sender, respond) {
+    respond({ connectionStatus: getStatus(), queueCount: await count() });
+  },
+
+  async retryQueue(_req, _sender, respond) {
+    const before = await count();
+    const s = await settings();
+    if (s.url) await drain(s.url, s.token);
+    const after = await count();
+    respond({ connectionStatus: getStatus(), queueCount: after, drained: after < before });
+  },
+
+  async clear(_req, _sender, respond) {
+    await clearAll();
+    setStatus('connected');
+    await sync();
+    respond({ connectionStatus: getStatus(), queueCount: 0 });
+  },
+
+  async searchQueue(req, _sender, respond) {
+    respond({ results: await pages(req.query) });
+  },
+
+  async getQueueItems(_req, _sender, respond) {
+    const items = await db.queue.orderBy('createdAt').toArray();
+    respond({
+      items: items.map((item) => {
+        const p = item.payload as PagePayload;
+        return {
+          id: item.id,
+          title: p.title || '',
+          url: p.url || '',
+          createdAt: item.createdAt,
+        };
+      }),
+    });
+  },
+
+  async removeQueueItem(req, _sender, respond) {
+    await remove(req.id!);
+    await sync();
+    respond({ connectionStatus: getStatus(), queueCount: await count() });
+  },
+};
+
+function tabId(sender: chrome.runtime.MessageSender): number | undefined {
+  return sender.tab?.id;
+}
+
+function cjsMsgHandler(
+  request: ExtMessage,
+  sender: chrome.runtime.MessageSender,
+  sendResponse: (response?: unknown) => void,
+) {
+  if (request.action && actions[request.action]) {
+    actions[request.action](request, sender, sendResponse).catch((e) =>
+      console.warn('action failed', e),
+    );
+    return true;
+  }
+
+  // Handle pageData / resultData, all async, must return true
+  (async () => {
+    const s = await settings();
+    const tid = tabId(sender);
+
+    if (!s.url) {
+      if (tid) chrome.tabs.sendMessage(tid, missingURLMsg);
+      return;
+    }
+    const u = normalize(s.url);
+    if (request.pageData) {
+      if (!s.indexingEnabled && request.action != 'reindex') {
+        sendResponse({ status: 'disabled' });
         return;
       }
-      if (!u.endsWith('/')) {
-        u += '/';
-      }
-      if (request.pageData) {
-        if (!indexingEnabled && request.action != 'reindex') {
-          sendResponse({ status: 'disabled' });
-          return;
-        }
-        sendPageData(u + 'api/add', request.pageData, tok)
-          .then((r) => sendResponse({ status: 'ok', status_code: r.status }))
-          .catch((err) => sendResponse({ error: err.message }));
-        return true;
-      }
-      if (request.resultData) {
-        sendResult(u + 'api/history', request.resultData, tok)
-          .then((r) => sendResponse({ status: 'ok', status_code: r.status }))
-          .catch((err) => sendResponse({ error: err.message }));
-        return true;
-      }
-    })
-    .catch((error) => {
-      chrome.tabs.sendMessage(sender.tab.id, missingURLMsg);
-    });
+
+      // Resolve favicon before potential enqueue
+      await resolve(request.pageData);
+
+      await trySend(u, 'api/add', request.pageData, s.token, 'pageData', sendResponse);
+      return;
+    }
+    if (request.resultData) {
+      await trySend(u, 'api/history', request.resultData, s.token, 'resultData', sendResponse);
+      return;
+    }
+  })().catch((e) => {
+    console.warn('message handler failed', e);
+    const tid = tabId(sender);
+    if (tid) chrome.tabs.sendMessage(tid, missingURLMsg);
+  });
   return true;
 }
 
 chrome.runtime.onMessage.addListener(cjsMsgHandler);
+
+// Set up alarm for periodic queue drain
+chrome.alarms.create(ALARM, { periodInMinutes: DRAIN_INTERVAL_MINUTES });
+
+async function checkConnection(drainIfOnline = false) {
+  const s = await settings();
+  if (!s.url) return;
+  try {
+    const r = await fetch(normalize(s.url) + 'api/stats', { headers: headers(s.token) });
+    if (r.ok) {
+      setStatus('connected');
+      if (drainIfOnline) await drain(s.url, s.token);
+    } else {
+      setStatus('error');
+    }
+  } catch {
+    setStatus('offline');
+  }
+  await sync();
+}
+
+chrome.alarms.onAlarm.addListener(async (alarm) => {
+  if (alarm.name !== ALARM) return;
+  if ((await count()) === 0) return;
+  await checkConnection(true);
+});
+
+checkConnection();

--- a/webui/ext/src/content/content.ts
+++ b/webui/ext/src/content/content.ts
@@ -1,4 +1,5 @@
 import { PageData, extractPageData, registerResultExtractor } from '../modules/extract';
+import { STORAGE_KEYS } from '../modules/constants';
 
 let d: PageData;
 // ms
@@ -7,7 +8,7 @@ let sleepTime = defaultSleepTime;
 const sleepIncrementRatio = 2;
 
 // @ts-ignore
-var isFirefox = typeof InstallTrigger !== 'undefined';
+const isFirefox = typeof InstallTrigger !== 'undefined';
 
 if (isFirefox) {
   if (document.readyState === 'complete') {
@@ -20,7 +21,7 @@ if (isFirefox) {
 }
 window.addEventListener('navigatesuccess', update);
 
-function extract(sendResponse, actionType) {
+function extract(respond: ((response?: unknown) => void) | null, action?: string) {
   registerResultExtractor(window, (r) => chrome.runtime.sendMessage({ resultData: r }));
   try {
     d = extractPageData();
@@ -28,18 +29,15 @@ function extract(sendResponse, actionType) {
     console.log('failed to extract page data:', e);
     return;
   }
-  let msg = { pageData: d };
-  if (actionType) {
-    msg['action'] = actionType;
+  let msg: { pageData: PageData; action?: string } = { pageData: d };
+  if (action) {
+    msg.action = action;
   }
   chrome.runtime.sendMessage(msg, (resp) => {
-    if (typeof sendResponse === 'function') {
-      sendResponse(resp);
+    if (typeof respond === 'function') {
+      respond(resp);
     }
-    if (!resp || resp.error || resp.status_code != 201) {
-      console.log('failed to submit page data, stopping extraction', resp);
-      return;
-    }
+    // Always schedule next update, even on error (queue handles offline)
     setTimeout(update, sleepTime);
   });
 }
@@ -64,6 +62,23 @@ function update() {
   }
   setTimeout(update, sleepTime);
 }
+
+// Detect if we're on the Hister app page and set up search bridge
+chrome.storage.local.get([STORAGE_KEYS.url], (data) => {
+  const url = (data[STORAGE_KEYS.url] || '') as string;
+  if (!url || !window.location.href.startsWith(url)) return;
+
+  window.addEventListener('hister:search', ((e: CustomEvent<{ query: string }>) => {
+    if (!e.detail?.query) return;
+    chrome.runtime.sendMessage({ action: 'searchQueue', query: e.detail.query }, (resp) => {
+      if (resp?.results?.length) {
+        window.dispatchEvent(
+          new CustomEvent('hister:queue-results', { detail: { results: resp.results } }),
+        );
+      }
+    });
+  }) as EventListener);
+});
 
 // Get message from background page
 // TODO check sender

--- a/webui/ext/src/manifest.json
+++ b/webui/ext/src/manifest.json
@@ -28,7 +28,7 @@
       "extension_ids": []
     }
   ],
-  "permissions": ["tabs", "storage", "webRequest"],
+  "permissions": ["tabs", "storage", "webRequest", "alarms"],
   "host_permissions": ["*://*/*"],
   "chrome_settings_overrides": {
     "search_provider": {

--- a/webui/ext/src/modules/QueuePanel.svelte
+++ b/webui/ext/src/modules/QueuePanel.svelte
@@ -1,0 +1,135 @@
+<script lang="ts">
+  import { Button } from '@hister/components/ui/button';
+  import { timeAgo } from './queue-store.svelte';
+  import type { ConnectionStatus } from './status';
+  import type { QueueItem } from './queue-store.svelte';
+
+  interface Props {
+    status: ConnectionStatus;
+    count: number;
+    expanded: boolean;
+    items: QueueItem[];
+    onretry: () => void;
+    onclear: () => void;
+    ontoggle: () => void;
+    onremove: (id: number) => void;
+    compact?: boolean;
+  }
+
+  let {
+    status,
+    count,
+    expanded,
+    items,
+    onretry,
+    onclear,
+    ontoggle,
+    onremove,
+    compact = false,
+  }: Props = $props();
+
+  const labels: Record<ConnectionStatus, string> = {
+    connected: 'Connected',
+    checking: 'Checking...',
+    offline: 'Server offline',
+    error: 'Connection error',
+  };
+
+  const dots: Record<ConnectionStatus, string> = {
+    connected: 'bg-hister-teal',
+    checking: 'animate-pulse bg-gray-400',
+    offline: 'bg-hister-rose',
+    error: 'bg-hister-coral',
+  };
+</script>
+
+<!-- Status indicator -->
+<div
+  class={compact
+    ? 'border-brutal-border flex items-center gap-2 border-b-[3px] px-5 py-3'
+    : 'bg-card-surface border-brutal-border flex items-center gap-3 border-[3px] px-7 py-4 shadow-[4px_4px_0_var(--brutal-shadow)]'}
+>
+  <span class="inline-block {compact ? 'h-2.5 w-2.5' : 'h-3 w-3'} rounded-full {dots[status]}"
+  ></span>
+  <span class="font-outfit text-text-brand text-sm font-bold">{labels[status]}</span>
+</div>
+
+<!-- Queue list -->
+{#if count > 0}
+  <div class={compact ? 'border-brutal-border border-b-[3px]' : ''}>
+    <div class="flex items-center justify-between {compact ? 'px-5 py-3' : 'px-7 py-4'}">
+      <button
+        onclick={ontoggle}
+        class="font-outfit text-text-brand flex items-center gap-{compact
+          ? '1.5'
+          : '2'} text-sm font-bold"
+      >
+        <span class="text-xs transition-transform {expanded ? 'rotate-90' : ''}">&#9654;</span>
+        {count} page{count !== 1 ? 's' : ''} queued
+      </button>
+      <div class="flex items-center gap-{compact ? '2' : '3'}">
+        <Button
+          variant="outline"
+          size="sm"
+          onclick={onretry}
+          class="border-hister-indigo text-hister-indigo border-2 text-xs {compact
+            ? ''
+            : 'font-bold'}"
+        >
+          Retry now
+        </Button>
+        <button
+          onclick={onclear}
+          class="font-inter text-text-brand-muted text-xs underline hover:no-underline"
+        >
+          Clear
+        </button>
+      </div>
+    </div>
+
+    {#if expanded && items.length > 0}
+      <div
+        class="{compact ? 'border-brutal-border' : 'border-hister-indigo'} {compact
+          ? 'max-h-48'
+          : 'max-h-72'} overflow-y-auto border-t-[3px]"
+      >
+        {#each items as item, i (item.id)}
+          <div
+            class="group flex items-center gap-3 {compact ? 'px-5 py-2.5' : 'px-7 py-3'} {i <
+            items.length - 1
+              ? 'border-brutal-border border-b-2'
+              : ''}"
+          >
+            <div class="min-w-0 flex-1">
+              <p
+                class="font-outfit text-text-brand truncate {compact
+                  ? 'text-xs'
+                  : 'text-sm'} font-bold"
+              >
+                {item.title || 'Untitled'}
+              </p>
+              <p
+                class="font-inter text-text-brand-muted mt-0.5 flex items-center gap-{compact
+                  ? '1.5'
+                  : '2'} truncate text-xs"
+              >
+                <span class="truncate">{item.url}</span>
+                <span class="shrink-0 opacity-50">&middot;</span>
+                <span class="shrink-0 opacity-50">{timeAgo(item.createdAt)}</span>
+              </p>
+            </div>
+            <button
+              onclick={() => onremove(item.id)}
+              class="border-brutal-border text-text-brand hover:bg-hister-rose hover:border-hister-rose flex {compact
+                ? 'h-5 w-5'
+                : 'h-6 w-6'} shrink-0 items-center justify-center border-2 text-xs font-bold transition-colors hover:text-white"
+              title="Remove from queue"
+            >
+              &times;
+            </button>
+          </div>
+        {/each}
+      </div>
+    {/if}
+  </div>
+{/if}

--- a/webui/ext/src/modules/constants.ts
+++ b/webui/ext/src/modules/constants.ts
@@ -1,0 +1,5 @@
+export const STORAGE_KEYS = {
+  url: 'histerURL',
+  token: 'histerToken',
+  indexingEnabled: 'indexingEnabled',
+} as const satisfies Record<string, string>;

--- a/webui/ext/src/modules/db.ts
+++ b/webui/ext/src/modules/db.ts
@@ -1,0 +1,37 @@
+import Dexie, { type EntityTable } from 'dexie';
+
+export interface PagePayload {
+  title?: string;
+  text?: string;
+  url?: string;
+  html?: string;
+  faviconURL?: string;
+  favicon?: string;
+}
+
+export interface HistoryPayload {
+  title?: string;
+  url?: string;
+  query?: string;
+}
+
+export type QueuePayload = PagePayload | HistoryPayload;
+
+export interface QueueItem {
+  id?: number;
+  type: 'pageData' | 'resultData';
+  endpoint: string;
+  payload: QueuePayload;
+  createdAt: number;
+  attempts: number;
+  lastAttempt?: number;
+  error?: string;
+}
+
+export const db = new Dexie('hister') as Dexie & {
+  queue: EntityTable<QueueItem, 'id'>;
+};
+
+db.version(1).stores({
+  queue: '++id, type, createdAt',
+});

--- a/webui/ext/src/modules/network.ts
+++ b/webui/ext/src/modules/network.ts
@@ -1,37 +1,51 @@
-async function fetchFavicon(url) {
+async function fetchFavicon(url: string): Promise<string> {
   const response = await fetch(url);
-  let iconBytes = await response.blob();
-  const reader = new FileReader();
-  reader.readAsDataURL(iconBytes);
-  //let icon = btoa(iconBytes.text());
+  const blob = await response.blob();
   return new Promise((resolve, reject) => {
     const reader = new FileReader();
-    reader.onloadend = () => {
-      resolve(reader.result);
-    };
-    reader.onerror = () => resolve('');
-    reader.readAsDataURL(iconBytes);
+    reader.onloadend = () => resolve(reader.result as string);
+    reader.onerror = reject;
+    reader.readAsDataURL(blob);
   });
 }
 
-async function sendPageData(url, doc, tok) {
-  try {
-    doc['favicon'] = await fetchFavicon(doc.faviconURL);
-  } catch (e) {
-    doc['favicon'] = '';
-  }
-  return sendResult(url, doc, tok);
+function normalize(url: string): string {
+  return url.endsWith('/') ? url : url + '/';
 }
 
-async function sendResult(url, res, tok) {
+function headers(tok: string): HeadersInit {
+  const h: HeadersInit = { 'Content-type': 'application/json; charset=UTF-8' };
+  if (tok) h['X-Access-Token'] = tok;
+  return h;
+}
+
+async function resolvePageData(doc: { favicon?: string; faviconURL?: string }) {
+  try {
+    doc.favicon = await fetchFavicon(doc.faviconURL!);
+  } catch (e) {
+    doc.favicon = '';
+  }
+  return doc;
+}
+
+async function sendResult(url: string, res: object, tok: string) {
   return fetch(url, {
     method: 'POST',
     body: JSON.stringify(res),
-    headers: {
-      'Content-type': 'application/json; charset=UTF-8',
-      'X-Access-Token': tok,
-    },
+    headers: headers(tok),
   });
 }
 
-export { sendPageData, sendResult };
+async function sendBatch(base: string, documents: object[], history: object[], tok: string) {
+  const r = await fetch(normalize(base) + 'api/batch', {
+    method: 'POST',
+    body: JSON.stringify({ documents, history }),
+    headers: headers(tok),
+  });
+  if (!r.ok) {
+    throw new Error(`Batch request failed with status ${r.status}`);
+  }
+  return r.json();
+}
+
+export { sendResult as send, resolvePageData as resolve, sendBatch as batch, normalize, headers };

--- a/webui/ext/src/modules/queue-store.svelte.ts
+++ b/webui/ext/src/modules/queue-store.svelte.ts
@@ -1,0 +1,121 @@
+import type { ConnectionStatus } from './status';
+
+export interface QueueItem {
+  id: number;
+  title: string;
+  url: string;
+  createdAt: number;
+}
+
+export interface Result {
+  message: string;
+  type: 'success' | 'error';
+}
+
+const SECONDS_PER_MINUTE = 60;
+const MINUTES_PER_HOUR = 60;
+const HOURS_PER_DAY = 24;
+
+export function timeAgo(ts: number): string {
+  const seconds = Math.floor((Date.now() - ts) / 1000);
+  if (seconds < SECONDS_PER_MINUTE) return 'just now';
+  const minutes = Math.floor(seconds / SECONDS_PER_MINUTE);
+  if (minutes < MINUTES_PER_HOUR) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / MINUTES_PER_HOUR);
+  if (hours < HOURS_PER_DAY) return `${hours}h ago`;
+  return `${Math.floor(hours / HOURS_PER_DAY)}d ago`;
+}
+
+export function queueStore() {
+  let status = $state<ConnectionStatus>('checking');
+  let count = $state(0);
+  let expanded = $state(false);
+  let items = $state<QueueItem[]>([]);
+
+  function sendAction(
+    action: string,
+    extra?: Record<string, unknown>,
+  ): Promise<Record<string, unknown> | undefined> {
+    return new Promise((resolve) => {
+      chrome.runtime.sendMessage({ action, ...extra }, (resp) => {
+        if (resp) {
+          status = resp.connectionStatus || 'connected';
+          count = resp.queueCount || 0;
+        }
+        resolve(resp);
+      });
+    });
+  }
+
+  async function refresh() {
+    const resp = await chrome.runtime.sendMessage({ action: 'getStatus' });
+    if (resp) {
+      status = resp.connectionStatus || 'checking';
+      count = resp.queueCount || 0;
+    }
+  }
+
+  async function load() {
+    const resp = await chrome.runtime.sendMessage({ action: 'getQueueItems' });
+    if (resp?.items) items = resp.items;
+  }
+
+  async function retry(): Promise<Result> {
+    const resp = await sendAction('retryQueue');
+    if (resp?.drained) {
+      if (expanded) load();
+      return {
+        message:
+          resp.queueCount === 0
+            ? 'Queue drained successfully'
+            : `${resp.queueCount} item${resp.queueCount !== 1 ? 's' : ''} remaining`,
+        type: 'success',
+      };
+    }
+    return {
+      message: 'Retry failed, server may be unreachable',
+      type: 'error',
+    };
+  }
+
+  async function clear(): Promise<Result> {
+    await sendAction('clear');
+    items = [];
+    expanded = false;
+    return { message: 'Queue cleared', type: 'success' };
+  }
+
+  function toggle() {
+    expanded = !expanded;
+    if (expanded) load();
+  }
+
+  async function remove(id: number) {
+    const resp = await sendAction('removeQueueItem', { id });
+    if (resp) {
+      items = items.filter((item) => item.id !== id);
+      if (count === 0) expanded = false;
+    }
+  }
+
+  return {
+    get status() {
+      return status;
+    },
+    get count() {
+      return count;
+    },
+    get expanded() {
+      return expanded;
+    },
+    get items() {
+      return items;
+    },
+    refresh,
+    load,
+    retry,
+    clear,
+    toggle,
+    remove,
+  };
+}

--- a/webui/ext/src/modules/queue.ts
+++ b/webui/ext/src/modules/queue.ts
@@ -1,0 +1,153 @@
+import PQueue from 'p-queue';
+import { db, type QueueItem, type QueuePayload, type PagePayload, type HistoryPayload } from './db';
+import { batch } from './network';
+import { setStatus, badge } from './status';
+
+const MAX_ATTEMPTS = 10;
+const BATCH_CHUNK_SIZE = 100;
+const TEXT_PREVIEW_LENGTH = 200;
+const pq = new PQueue({ concurrency: 1, interval: 30_000, intervalCap: 1 });
+let draining = false;
+
+export async function enqueue(
+  type: QueueItem['type'],
+  endpoint: string,
+  payload: QueuePayload,
+): Promise<void> {
+  await db.queue.add({
+    type,
+    endpoint,
+    payload,
+    createdAt: Date.now(),
+    attempts: 0,
+  });
+}
+
+export async function count(): Promise<number> {
+  return db.queue.count();
+}
+
+interface QueuedPage {
+  url: string;
+  title: string;
+  domain: string;
+  text: string;
+  favicon: string;
+  added: number;
+  queued: boolean;
+}
+
+export async function pages(query?: string): Promise<QueuedPage[]> {
+  let items = await db.queue.where('type').equals('pageData').toArray();
+  if (query) {
+    const q = query.toLowerCase();
+    items = items.filter((item) => {
+      const p = item.payload as PagePayload;
+      return (
+        (p.title && p.title.toLowerCase().includes(q)) ||
+        (p.url && p.url.toLowerCase().includes(q)) ||
+        (p.text && p.text.toLowerCase().includes(q))
+      );
+    });
+  }
+  return items.map((item) => {
+    const p = item.payload as PagePayload;
+    return {
+      url: p.url || '',
+      title: p.title || '',
+      domain: '',
+      text: p.text ? p.text.substring(0, TEXT_PREVIEW_LENGTH) : '',
+      favicon: p.favicon || '',
+      added: Math.floor(item.createdAt / 1000),
+      queued: true,
+    };
+  });
+}
+
+export async function clear(): Promise<void> {
+  pq.clear();
+  await db.queue.clear();
+}
+
+export async function remove(id: number): Promise<void> {
+  await db.queue.delete(id);
+}
+
+export async function drain(base: string, token: string): Promise<void> {
+  if (draining) return;
+  draining = true;
+
+  try {
+    // Resume in case the queue was paused by a previous network error
+    pq.start();
+
+    const items = await db.queue.orderBy('createdAt').toArray();
+    if (items.length === 0) return;
+
+    // Partition into expired vs active in a single pass
+    const expired: number[] = [];
+    const active: QueueItem[] = [];
+    for (const item of items) {
+      if (item.attempts >= MAX_ATTEMPTS) {
+        expired.push(item.id!);
+      } else {
+        active.push(item);
+      }
+    }
+    if (expired.length > 0) {
+      await db.queue.bulkDelete(expired);
+    }
+    if (active.length === 0) return;
+
+    const chunks = Array.from({ length: Math.ceil(active.length / BATCH_CHUNK_SIZE) }, (_, i) =>
+      active.slice(i * BATCH_CHUNK_SIZE, i * BATCH_CHUNK_SIZE + BATCH_CHUNK_SIZE),
+    );
+
+    for (const chunk of chunks) {
+      pq.add(async () => {
+        const docs: PagePayload[] = [];
+        const hist: HistoryPayload[] = [];
+
+        for (const item of chunk) {
+          if (item.type === 'pageData') {
+            docs.push(item.payload as PagePayload);
+          } else {
+            hist.push(item.payload as HistoryPayload);
+          }
+        }
+
+        try {
+          await batch(base, docs, hist, token);
+          await db.queue.bulkDelete(chunk.map((i) => i.id!));
+          setStatus('connected');
+        } catch (err) {
+          if (
+            (err as Error)?.message === 'Failed to fetch' ||
+            (err as Error)?.name === 'TypeError'
+          ) {
+            pq.pause();
+            setStatus('offline');
+            return;
+          }
+          // Server error, increment attempts, drop items over max
+          for (const item of chunk) {
+            if (item.attempts + 1 >= MAX_ATTEMPTS) {
+              await db.queue.delete(item.id!);
+            } else {
+              await db.queue.update(item.id!, {
+                attempts: item.attempts + 1,
+                lastAttempt: Date.now(),
+                error: (err as Error)?.message || 'Unknown error',
+              });
+            }
+          }
+          setStatus('error');
+        }
+
+        await badge(await count());
+      });
+    }
+  } finally {
+    draining = false;
+  }
+}

--- a/webui/ext/src/modules/status.ts
+++ b/webui/ext/src/modules/status.ts
@@ -1,0 +1,30 @@
+export type ConnectionStatus = 'connected' | 'offline' | 'error' | 'checking';
+
+const BADGE_CONFIG = {
+  checking: { text: '', color: '' },
+  offline: { text: 'OFF', color: '#E11D48' },
+  error: { text: 'ERR', color: '#FF6B6B' },
+} as const satisfies Partial<Record<ConnectionStatus, { text: string; color: string }>>;
+
+let status: ConnectionStatus = 'checking';
+
+export function getStatus(): ConnectionStatus {
+  return status;
+}
+
+export function setStatus(s: ConnectionStatus) {
+  status = s;
+}
+
+export async function badge(queueCount: number) {
+  const config = BADGE_CONFIG[status as keyof typeof BADGE_CONFIG];
+  if (config) {
+    await chrome.action.setBadgeText({ text: config.text });
+    if (config.color) await chrome.action.setBadgeBackgroundColor({ color: config.color });
+  } else if (queueCount > 0) {
+    await chrome.action.setBadgeText({ text: String(queueCount) });
+    await chrome.action.setBadgeBackgroundColor({ color: '#5D5FEF' });
+  } else {
+    await chrome.action.setBadgeText({ text: '' });
+  }
+}

--- a/webui/ext/src/options/Options.svelte
+++ b/webui/ext/src/options/Options.svelte
@@ -2,6 +2,9 @@
   import { Button } from '@hister/components/ui/button';
   import * as Card from '@hister/components/ui/card';
   import SettingsInput from './SettingsInput.svelte';
+  import { queueStore } from '../modules/queue-store.svelte';
+  import QueuePanel from '../modules/QueuePanel.svelte';
+  import { STORAGE_KEYS } from '../modules/constants';
 
   const defaultURL = 'http://127.0.0.1:4433/';
 
@@ -10,17 +13,33 @@
   let message = $state('');
   let messageType: 'success' | 'error' = $state('success');
 
-  chrome.storage.local.get(['histerURL', 'histerToken'], (data) => {
-    if (!data['histerURL']) {
-      chrome.storage.local.set({ histerURL: defaultURL });
+  const queue = queueStore();
+
+  chrome.storage.local.get([STORAGE_KEYS.url, STORAGE_KEYS.token], (data) => {
+    if (!data[STORAGE_KEYS.url]) {
+      chrome.storage.local.set({ [STORAGE_KEYS.url]: defaultURL });
     }
-    url = data['histerURL'] || defaultURL;
-    token = data['histerToken'] || '';
+    url = data[STORAGE_KEYS.url] || defaultURL;
+    token = data[STORAGE_KEYS.token] || '';
   });
+
+  queue.refresh();
+
+  async function retry() {
+    const r = await queue.retry();
+    message = r.message;
+    messageType = r.type;
+  }
+
+  async function clear() {
+    const r = await queue.clear();
+    message = r.message;
+    messageType = r.type;
+  }
 
   function save(e: Event) {
     e.preventDefault();
-    chrome.storage.local.set({ histerURL: url, histerToken: token }).then(() => {
+    chrome.storage.local.set({ [STORAGE_KEYS.url]: url, [STORAGE_KEYS.token]: token }).then(() => {
       message = 'Settings saved';
       messageType = 'success';
     });
@@ -36,6 +55,17 @@
   </div>
 
   <div class="mx-auto max-w-2xl space-y-8 px-8 py-10">
+    <QueuePanel
+      status={queue.status}
+      count={queue.count}
+      expanded={queue.expanded}
+      items={queue.items}
+      onretry={retry}
+      onclear={clear}
+      ontoggle={queue.toggle}
+      onremove={queue.remove}
+    />
+
     <!-- Connection settings card -->
     <Card.Root
       class="bg-card-surface border-hister-indigo gap-0 overflow-hidden rounded-none border-[3px] py-0 shadow-[6px_6px_0_var(--hister-indigo)]"

--- a/webui/ext/src/popup/Popup.svelte
+++ b/webui/ext/src/popup/Popup.svelte
@@ -4,6 +4,9 @@
   import { Switch } from '@hister/components/ui/switch';
   import * as Card from '@hister/components/ui/card';
   import SettingsInput from '../options/SettingsInput.svelte';
+  import { queueStore } from '../modules/queue-store.svelte';
+  import QueuePanel from '../modules/QueuePanel.svelte';
+  import { STORAGE_KEYS } from '../modules/constants';
 
   const defaultURL = 'http://127.0.0.1:4433/';
 
@@ -14,15 +17,31 @@
   let message = $state('');
   let messageType: 'success' | 'error' = $state('success');
 
-  chrome.storage.local.get(['histerURL', 'histerToken', 'indexingEnabled'], (data) => {
-    if (!data['histerURL']) {
-      chrome.storage.local.set({ histerURL: defaultURL });
+  const queue = queueStore();
+
+  chrome.storage.local.get(Object.values(STORAGE_KEYS), (data) => {
+    if (!data[STORAGE_KEYS.url]) {
+      chrome.storage.local.set({ [STORAGE_KEYS.url]: defaultURL });
     }
-    url = data['histerURL'] || defaultURL;
-    token = data['histerToken'] || '';
-    indexingEnabled = data['indexingEnabled'] !== false;
+    url = data[STORAGE_KEYS.url] || defaultURL;
+    token = data[STORAGE_KEYS.token] || '';
+    indexingEnabled = data[STORAGE_KEYS.indexingEnabled] !== false;
     showTokenInput = !token;
   });
+
+  queue.refresh();
+
+  async function retry() {
+    const r = await queue.retry();
+    message = r.message;
+    messageType = r.type;
+  }
+
+  async function clear() {
+    const r = await queue.clear();
+    message = r.message;
+    messageType = r.type;
+  }
 
   function save(e: Event) {
     e.preventDefault();
@@ -53,7 +72,11 @@
           .json()
           .then(() => {
             chrome.storage.local
-              .set({ histerURL: url, histerToken: token, indexingEnabled: indexingEnabled })
+              .set({
+                [STORAGE_KEYS.url]: url,
+                [STORAGE_KEYS.token]: token,
+                [STORAGE_KEYS.indexingEnabled]: indexingEnabled,
+              })
               .then(() => {
                 message = 'Settings saved';
                 messageType = 'success';
@@ -102,6 +125,18 @@
   <div class="bg-hister-indigo border-brutal-border border-b-[3px] px-5 py-3">
     <span class="font-outfit text-lg font-black tracking-widest text-white uppercase">Hister</span>
   </div>
+
+  <QueuePanel
+    status={queue.status}
+    count={queue.count}
+    expanded={queue.expanded}
+    items={queue.items}
+    onretry={retry}
+    onclear={clear}
+    ontoggle={queue.toggle}
+    onremove={queue.remove}
+    compact
+  />
 
   <!-- Settings card -->
   <Card.Root

--- a/webui/ext/tsconfig.json
+++ b/webui/ext/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES6",
+    "lib": ["ES2017", "DOM"],
     "module": "ES2015",
     "moduleResolution": "bundler",
     "skipLibCheck": true,


### PR DESCRIPTION
Closes: https://github.com/asciimoo/hister/issues/157

Before this, if the Hister server was unreachable when you visited a page, that
page was just silently dropped, you'd never know it wasn't indexed.

This PR fixes that by giving the extension a proper offline queue backed by
IndexedDB (via Dexie)

When a send fails, the page or history item gets stored locally. A Chrome alarm
fires every two minutes and tries to "drain" the queue whenever it sees the
server is back online. You can also hit "Retry now" manually from the popup

Items that keep failing stay in the queue until you clear or remove them
individually

To make draining efficient, the server now has a `/api/batch` endpoint that
accepts up to 100 documents and history items in a single request. The CORS
bypass that already existed for `/api/add` was extended to cover `/api/batch`
as well

The search page also picks up queued items now. When you search, the content
script asks the background worker to run the query against the local queue and
sends any matches back to the page, where they show up with a "Pending sync"
badge so you know they haven't hit the server yet

On the extension side there's a new `QueuePanel` component for the popup that
shows connection status, how many pages are waiting, and lets you expand the
list to see or remove individual items
