### PR TITLE
[fix] prevent Svelte 5 proxy from being stored in Chrome storage for `customHeaders`

### DIFF
--- a/webui/ext/src/background/background.ts
+++ b/webui/ext/src/background/background.ts
@@ -21,7 +21,7 @@ function cjsMsgHandler(request, sender, sendResponse) {
       let u = data['histerURL'] || '';
       const tok = data['histerToken'] || '';
       const indexingEnabled = data['indexingEnabled'] !== false;
-      const customHeaders = data['histerCustomHeaders'] || [];
+      const customHeaders = Array.isArray(data['histerCustomHeaders']) ? data['histerCustomHeaders'] : [];
 
       if (!u) {
         chrome.tabs.sendMessage(sender.tab.id, missingURLMsg);

--- a/webui/ext/src/options/Options.svelte
+++ b/webui/ext/src/options/Options.svelte
@@ -21,7 +21,7 @@
     }
     url = data['histerURL'] || defaultURL;
     token = data['histerToken'] || '';
-    customHeaders = data['histerCustomHeaders'] || [];
+    customHeaders = Array.isArray(data['histerCustomHeaders']) ? data['histerCustomHeaders'] : [];
   });
 
   function addHeader() {
@@ -36,7 +36,7 @@
     e.preventDefault();
     const headersToSave = customHeaders.filter((h) => h.name.trim() !== '');
     chrome.storage.local
-      .set({ histerURL: url, histerToken: token, histerCustomHeaders: headersToSave })
+      .set({ histerURL: url, histerToken: token, histerCustomHeaders: $state.snapshot(headersToSave) })
       .then(() => {
         customHeaders = headersToSave;
         message = 'Settings saved';

--- a/webui/ext/src/popup/Popup.svelte
+++ b/webui/ext/src/popup/Popup.svelte
@@ -42,7 +42,7 @@
       }
       url = data['histerURL'] || defaultURL;
       token = data['histerToken'] || '';
-      customHeaders = data['histerCustomHeaders'] || [];
+      customHeaders = Array.isArray(data['histerCustomHeaders']) ? data['histerCustomHeaders'] : [];
       indexingEnabled = data['indexingEnabled'] !== false;
       showTokenInput = !token;
 
@@ -89,7 +89,7 @@
           .json()
           .then(() => {
             chrome.storage.local
-              .set({ histerURL: url, histerToken: token, histerCustomHeaders: customHeaders })
+              .set({ histerURL: url, histerToken: token, histerCustomHeaders: $state.snapshot(customHeaders) })
               .then(() => {
                 setSuccessMessage('Settings saved');
                 showTokenInput = !token;


### PR DESCRIPTION
Use `$state.snapshot()` when saving `customHeaders` to `chrome.storage.local` and add `Array.isArray` guards on load to handle any previously-corrupted values