### PR TITLE
[enh] strip debug symbols from release binary

### DIFF
--- a/.goreleaser-rolling.yml
+++ b/.goreleaser-rolling.yml
@@ -18,6 +18,8 @@ builds:
       - arm64
     flags:
       - -tags=netgo,osusergo
+    ldflags:
+      - -s -w
     ignore:
       - goos: windows
         goarch: arm64

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -15,6 +15,8 @@ builds:
       - arm64
     flags:
       - -tags=netgo,osusergo
+    ldflags:
+      - -s -w
     ignore:
       - goos: windows
         goarch: arm64


### PR DESCRIPTION
12.9 MB (-7.53%) smaller

```
➜ ls ./hister
╭───┬────────┬──────┬──────────┬─────────────╮
│ # │  name  │ type │   size   │  modified   │
├───┼────────┼──────┼──────────┼─────────────┤
│ 0 │ hister │ file │ 171.1 MB │ 3 hours ago │
╰───┴────────┴──────┴──────────┴─────────────╯
➜ ls ./hister
╭───┬────────┬──────┬──────────┬──────────╮
│ # │  name  │ type │   size   │ modified │
├───┼────────┼──────┼──────────┼──────────┤
│ 0 │ hister │ file │ 158.2 MB │ now      │
╰───┴────────┴──────┴──────────┴──────────╯
```