### PR TITLE
[fix] include full end date in date range search

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -461,7 +461,12 @@ func serveSearch(c *webContext) {
 		for param, field := range map[string]*int64{"date_from": &query.DateFrom, "date_to": &query.DateTo} {
 			if v := c.Request.URL.Query().Get(param); v != "" {
 				if t, err := time.Parse("2006-01-02", v); err == nil {
-					*field = t.Unix()
+					ts := t.Unix()
+					if param == "date_to" {
+						// Include the entire end date by advancing to end of day (23:59:59)
+						ts += 24*60*60 - 1
+					}
+					*field = ts
 				}
 			}
 		}


### PR DESCRIPTION
## Summary

Fixes date range search returning empty results when start and end dates are the same day.

## Why this matters

In `server/server.go:463`, both `date_from` and `date_to` are parsed with `time.Parse("2006-01-02", v)` which produces midnight (00:00:00) of the given date. When searching "March 19 to March 19", both timestamps are identical. The bleve `NumericRangeQuery` at `indexer.go:568` then creates a range where `min == max`, which matches nothing since the bounds are exclusive.

## Changes

- `server/server.go`: When parsing `date_to`, add 86399 seconds (23:59:59) to the timestamp so the range covers the entire end date

## Testing

`go build ./...` passes. The fix is a 4-line addition to the date parsing loop.

Fixes #243

This contribution was developed with AI assistance (Claude Code).