### PR TITLE
[enh] add concurrency controls, graceful shutdown, and thread safety …

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -76,6 +76,8 @@ type Indexer struct {
 	DetectLanguages bool         `yaml:"detect_languages" mapstructure:"detect_languages"`
 	Directories     []*Directory `yaml:"directories" mapstructure:"directories"`
 	MaxFileSize     int64        `yaml:"max_file_size_mb" mapstructure:"max_file_size_mb"`
+	MaxWatchDirs    int          `yaml:"max_watch_dirs" mapstructure:"max_watch_dirs"`
+	IndexWorkers    int          `yaml:"index_workers" mapstructure:"index_workers"`
 }
 
 type Hotkeys struct {
@@ -296,6 +298,8 @@ func CreateDefaultConfig() *Config {
 		Indexer: Indexer{
 			DetectLanguages: true,
 			MaxFileSize:     1,
+			MaxWatchDirs:    1000,
+			IndexWorkers:    5,
 		},
 		Hotkeys: Hotkeys{
 			Web: map[string]string{

--- a/files/files.go
+++ b/files/files.go
@@ -9,7 +9,6 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
-	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -18,6 +17,7 @@ import (
 	"github.com/rs/zerolog/log"
 
 	"github.com/asciimoo/hister/config"
+	"github.com/asciimoo/hister/xsync"
 )
 
 func ExpandHome(path string) string {
@@ -31,7 +31,7 @@ func ExpandHome(path string) string {
 	return path
 }
 
-// Debounce so we don't spam the index as write events can file multiple times before closing a file after editing
+// Debounce so we don't spam the index as write events can fire multiple times before closing a file after editing
 const debounceTime = 200 * time.Millisecond
 
 // findMatchingDir returns the Directory config whose expanded path contains filePath, or nil.
@@ -45,11 +45,6 @@ func findMatchingDir(dirs []*config.Directory, filePath string) *config.Director
 	return nil
 }
 
-// skipDirs lists directory names that are skipped by default during watching.
-// These are well-known dependency/cache directories whose names are unambiguous
-// and can contain tens of thousands of entries, easily exhausting OS watch limits.
-// Hidden directories (starting with ".") are always skipped separately.
-// Users can exclude additional directories via the per-directory excludes config.
 var skipDirs = map[string]struct{}{
 	"node_modules":     {},
 	"bower_components": {},
@@ -59,8 +54,6 @@ var skipDirs = map[string]struct{}{
 }
 
 // shouldSkipDir reports whether a directory should be excluded from watching.
-// It skips hidden directories, well-known dependency/cache directories, and
-// directories matching any exclude pattern from the config.
 func shouldSkipDir(name string, excludes []string, includeHidden bool) bool {
 	if !includeHidden {
 		if strings.HasPrefix(name, ".") {
@@ -78,18 +71,26 @@ func shouldSkipDir(name string, excludes []string, includeHidden bool) bool {
 	return false
 }
 
-// ShouldSkipDir is the exported form of shouldSkipDir for use by the indexer.
+// ShouldSkipDir is the exported form of shouldSkipDir.
 func ShouldSkipDir(name string, excludes []string, includeHidden bool) bool {
 	return shouldSkipDir(name, excludes, includeHidden)
 }
 
-// walkAndWatch registers all subdirectories of each configured directory with
-// the fsnotify watcher, skipping hidden dirs and user-configured excludes.
-func walkAndWatch(watcher *fsnotify.Watcher, dirs []*config.Directory) {
+// walkAndWatch registers subdirectories with the fsnotify watcher, up to maxWatchDirs total.
+func walkAndWatch(watcher *fsnotify.Watcher, dirs []*config.Directory, maxWatchDirs int, watched *xsync.Set[string]) {
 	for _, dir := range dirs {
 		expanded := ExpandHome(dir.Path)
+		if watched.Len() >= maxWatchDirs {
+			log.Warn().
+				Int("limit", maxWatchDirs).
+				Str("path", expanded).
+				Msg("Watch directory limit reached; remaining directories will not be watched for live changes")
+			return
+		}
 		if err := watcher.Add(expanded); err != nil {
 			log.Error().Err(err).Str("path", expanded).Msg("Failed to add path to file watcher")
+		} else {
+			watched.Add(expanded)
 		}
 		excludes := dir.Excludes
 		_ = filepath.WalkDir(expanded, func(path string, d fs.DirEntry, err error) error {
@@ -100,20 +101,31 @@ func walkAndWatch(watcher *fsnotify.Watcher, dirs []*config.Directory) {
 			if !d.IsDir() {
 				return nil
 			}
-			if path != expanded && shouldSkipDir(d.Name(), excludes, dir.IncludeHidden) {
+			if path == expanded {
+				return nil
+			}
+			if shouldSkipDir(d.Name(), excludes, dir.IncludeHidden) {
 				return filepath.SkipDir
+			}
+			if watched.Len() >= maxWatchDirs {
+				log.Warn().
+					Int("limit", maxWatchDirs).
+					Str("path", path).
+					Msg("Watch directory limit reached; skipping remaining subdirectories")
+				return filepath.SkipAll
 			}
 			if err := watcher.Add(path); err != nil {
 				log.Warn().Err(err).Str("path", path).Msg("Failed to watch subdirectory")
+			} else {
+				watched.Add(path)
 			}
 			return nil
 		})
 	}
+	log.Debug().Int("directories", watched.Len()).Msg("File watcher registered directories")
 }
 
-// handleWrite debounces a file-write event and invokes the callback after the
-// debounce period.
-func handleWrite(event fsnotify.Event, dirs []*config.Directory, mu *sync.Mutex, debounced map[string]*time.Timer, callback func(string)) {
+func handleWrite(ctx context.Context, event fsnotify.Event, dirs []*config.Directory, mu *sync.Mutex, debounced map[string]*time.Timer, work chan<- string) {
 	dir := findMatchingDir(dirs, event.Name)
 	if dir == nil || !dir.IsMatching(event.Name) {
 		return
@@ -127,15 +139,18 @@ func handleWrite(event fsnotify.Event, dirs []*config.Directory, mu *sync.Mutex,
 			mu.Lock()
 			delete(debounced, name)
 			mu.Unlock()
-			callback(name)
+			select {
+			case work <- name:
+			case <-ctx.Done():
+			default:
+				log.Debug().Str("path", name).Msg("Index worker queue full; dropping file event")
+			}
 		})
 	}
 	mu.Unlock()
 }
 
-// handleCreate processes a file or directory creation event: new directories
-// are added to the watcher, new files matching filters are passed to the callback.
-func handleCreate(event fsnotify.Event, dirs []*config.Directory, watcher *fsnotify.Watcher, callback func(string)) {
+func handleCreate(ctx context.Context, event fsnotify.Event, dirs []*config.Directory, watcher *fsnotify.Watcher, maxWatchDirs int, watched *xsync.Set[string], work chan<- string) {
 	st, err := os.Stat(event.Name)
 	if err != nil {
 		return
@@ -145,9 +160,18 @@ func handleCreate(event fsnotify.Event, dirs []*config.Directory, watcher *fsnot
 		if dir == nil || shouldSkipDir(filepath.Base(event.Name), dir.Excludes, dir.IncludeHidden) {
 			return
 		}
-		if !slices.Contains(watcher.WatchList(), event.Name) {
+		if !watched.Has(event.Name) {
+			if watched.Len() >= maxWatchDirs {
+				log.Warn().
+					Int("limit", maxWatchDirs).
+					Str("path", event.Name).
+					Msg("Watch directory limit reached; new directory will not be watched")
+				return
+			}
 			if err := watcher.Add(event.Name); err != nil {
 				log.Warn().Err(err).Str("path", event.Name).Msg("Failed to watch new directory")
+			} else {
+				watched.Add(event.Name)
 			}
 		}
 		return
@@ -156,10 +180,23 @@ func handleCreate(event fsnotify.Event, dirs []*config.Directory, watcher *fsnot
 	if dir == nil || !dir.IsMatching(event.Name) {
 		return
 	}
-	callback(event.Name)
+	select {
+	case work <- event.Name:
+	case <-ctx.Done():
+	default:
+		log.Debug().Str("path", event.Name).Msg("Index worker queue full; dropping file event")
+	}
 }
 
-func WatchDirectories(ctx context.Context, dirs []*config.Directory, callback func(string)) error {
+// WatchDirectories watches configured directories for file changes and calls
+// callback for each changed file.
+func WatchDirectories(ctx context.Context, dirs []*config.Directory, workers int, maxWatchDirs int, callback func(string)) error {
+	if workers < 1 {
+		workers = 1
+	}
+	if maxWatchDirs < 1 {
+		maxWatchDirs = 1
+	}
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
 		return fmt.Errorf("failed to create file watcher: %w", err)
@@ -170,28 +207,71 @@ func WatchDirectories(ctx context.Context, dirs []*config.Directory, callback fu
 		}
 	}()
 
+	// innerCtx is cancelled and pending timers are stopped before work is closed,
+	// ensuring timer closures never send on a closed channel.
+	innerCtx, cancelInner := context.WithCancel(ctx)
+	defer cancelInner()
+
+	work := make(chan string, workers*4)
+
 	var mu sync.Mutex
 	debounced := make(map[string]*time.Timer)
 
+	var closeOnce sync.Once
+	closeWork := func() {
+		closeOnce.Do(func() {
+			cancelInner()
+			mu.Lock()
+			for name, t := range debounced {
+				t.Stop()
+				delete(debounced, name)
+			}
+			mu.Unlock()
+			close(work)
+		})
+	}
+
+	// Start the worker pool.
+	var wg sync.WaitGroup
+	for range workers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for path := range work {
+				callback(path)
+			}
+		}()
+	}
+
+	var watched xsync.Set[string]
+
 	log.Debug().Msg("Starting file watcher")
-	walkAndWatch(watcher, dirs)
+	walkAndWatch(watcher, dirs, maxWatchDirs, &watched)
 
 	for {
 		select {
 		case <-ctx.Done():
+			closeWork()
+			wg.Wait()
 			return ctx.Err()
 		case event, ok := <-watcher.Events:
 			if !ok {
+				closeWork()
+				wg.Wait()
 				return nil
 			}
 			switch {
 			case event.Has(fsnotify.Write):
-				handleWrite(event, dirs, &mu, debounced, callback)
+				handleWrite(innerCtx, event, dirs, &mu, debounced, work)
 			case event.Has(fsnotify.Create):
-				handleCreate(event, dirs, watcher, callback)
+				handleCreate(innerCtx, event, dirs, watcher, maxWatchDirs, &watched, work)
+			case event.Has(fsnotify.Remove), event.Has(fsnotify.Rename):
+				watched.Delete(event.Name)
 			}
 		case err, ok := <-watcher.Errors:
 			if !ok {
+				closeWork()
+				wg.Wait()
 				return nil
 			}
 			log.Error().Err(err).Msg("Watcher failed to process event")

--- a/hister.go
+++ b/hister.go
@@ -17,6 +17,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/asciimoo/hister/client"
@@ -88,19 +89,33 @@ var listenCmd = &cobra.Command{
 		if cfg.App.AccessToken != "" && strings.HasPrefix(cfg.BaseURL(""), "http://") {
 			log.Warn().Msg("Using authentication token without https. Token is sent plain-text in network requests.")
 		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		var wg sync.WaitGroup
 		if len(cfg.Indexer.Directories) > 0 {
-			indexer.IndexAll(cfg.Indexer.Directories)
-			go func() {
-				if err := files.WatchDirectories(context.Background(), cfg.Indexer.Directories, func(path string) {
+			wg.Go(func() {
+				if err := indexer.IndexAll(ctx, cfg.Indexer.Directories, cfg.Indexer.IndexWorkers); err != nil && !errors.Is(err, context.Canceled) {
+					log.Error().Err(err).Msg("Initial indexing failed")
+				}
+				select {
+				case <-ctx.Done():
+					return
+				default:
+				}
+				if err := files.WatchDirectories(ctx, cfg.Indexer.Directories, cfg.Indexer.IndexWorkers, cfg.Indexer.MaxWatchDirs, func(path string) {
 					if err := indexer.IndexFile(path); err != nil {
 						log.Debug().Err(err).Str("path", path).Msg("Failed to index file")
 					}
-				}); err != nil {
+				}); err != nil && !errors.Is(err, context.Canceled) {
 					log.Error().Err(err).Msg("File watcher failed")
 				}
-			}()
+			})
 		}
-		server.Listen(cfg)
+		server.Listen(cfg, func() {
+			cancel()
+			wg.Wait()
+			indexer.Close()
+		})
 	},
 }
 

--- a/server/indexer/files.go
+++ b/server/indexer/files.go
@@ -1,11 +1,13 @@
 package indexer
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
+	"sync"
 	"unicode/utf8"
 
 	"github.com/rs/zerolog/log"
@@ -15,13 +17,16 @@ import (
 )
 
 var (
-	ErrEmptyFile    = errors.New("empty file")
-	ErrBinaryFile   = errors.New("binary file")
-	ErrFileTooLarge = errors.New("file too large")
-	ErrReadFile     = errors.New("cannot read file")
+	ErrEmptyFile      = errors.New("empty file")
+	ErrBinaryFile     = errors.New("binary file")
+	ErrFileTooLarge   = errors.New("file too large")
+	ErrReadFile       = errors.New("cannot read file")
+	ErrAlreadyIndexed = errors.New("already indexed")
 
 	maxFileSize int64 = 1024 * 1024 // 1MB default
 )
+
+const indexBatchSize = 50
 
 type ReadFileError struct {
 	Msg string
@@ -35,16 +40,30 @@ func (e *ReadFileError) Error() string {
 	return fmt.Sprintf("%s: %s", ErrReadFile.Error(), e.Msg)
 }
 
-func IndexAll(dirs []*config.Directory) {
+func IndexAll(ctx context.Context, dirs []*config.Directory, workers int) error {
+	if workers < 1 {
+		workers = 1
+	}
 	for _, dir := range dirs {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
 		expanded := files.ExpandHome(dir.Path)
-		if err := indexDirectory(expanded, dir); err != nil {
+		if err := indexDirectory(ctx, expanded, dir, workers); err != nil {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			default:
+			}
 			log.Error().Err(err).Str("directory", expanded).Msg("Failed to index directory")
 		}
 	}
+	return nil
 }
 
-func indexDirectory(dir string, cfg *config.Directory) error {
+func indexDirectory(ctx context.Context, dir string, cfg *config.Directory, workers int) error {
 	info, err := os.Stat(dir)
 	if err != nil {
 		return fmt.Errorf("cannot access directory: %w", err)
@@ -53,12 +72,34 @@ func indexDirectory(dir string, cfg *config.Directory) error {
 		return fmt.Errorf("not a directory: %s", dir)
 	}
 
-	indexed := 0
-	skipped := 0
-
 	log.Debug().Str("directory", dir).Msg("Indexing directory")
 
-	err = filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+	sem := make(chan struct{}, workers)
+
+	var (
+		mu           sync.Mutex
+		batch        = NewMultiBatch()
+		indexed      int
+		skipped      int
+		pendingFlush bool
+		wg           sync.WaitGroup
+		walkErr      error
+	)
+
+	// Must be called with mu held.
+	flushBatch := func() error {
+		err := batch.Save()
+		batch = NewMultiBatch()
+		pendingFlush = false
+		return err
+	}
+
+	walkErr = filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
 		if err != nil {
 			log.Warn().Err(err).Str("path", path).Msg("Error accessing path")
 			return nil
@@ -72,58 +113,108 @@ func indexDirectory(dir string, cfg *config.Directory) error {
 		if !cfg.IsMatching(d.Name()) {
 			return nil
 		}
-		if err := IndexFile(path); err != nil {
-			log.Debug().Err(err).Str("path", path).Msg("Skipping file")
-			skipped++
-		} else {
-			indexed++
+
+		select {
+		case sem <- struct{}{}:
+		case <-ctx.Done():
+			return ctx.Err()
 		}
+
+		wg.Add(1)
+		go func(p string) {
+			defer wg.Done()
+			defer func() { <-sem }()
+
+			doc, err := readFileDoc(p)
+			if err != nil {
+				log.Debug().Err(err).Str("path", p).Msg("Skipping file")
+				mu.Lock()
+				skipped++
+				mu.Unlock()
+				return
+			}
+
+			mu.Lock()
+			defer mu.Unlock()
+
+			if err := batch.Add(doc); err != nil {
+				log.Warn().Err(err).Str("path", p).Msg("Failed to add file to batch")
+				skipped++
+				return
+			}
+			indexed++
+			pendingFlush = true
+			if indexed%indexBatchSize == 0 {
+				if err := flushBatch(); err != nil {
+					log.Warn().Err(err).Msg("Failed to flush index batch")
+				}
+			}
+		}(path)
+
 		return nil
 	})
 
+	wg.Wait()
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	if pendingFlush {
+		if err := flushBatch(); err != nil {
+			log.Warn().Err(err).Msg("Failed to flush final index batch")
+		}
+	}
+
 	log.Debug().Str("directory", dir).Int("indexed", indexed).Int("skipped", skipped).Msg("Directory indexing complete")
-	return err
+	return walkErr
 }
 
-func IndexFile(path string) error {
+func readFileDoc(path string) (*Document, error) {
 	info, err := os.Stat(path)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if info.Size() == 0 {
-		return ErrEmptyFile
+		return nil, ErrEmptyFile
 	}
 	if info.Size() > maxFileSize {
-		return fmt.Errorf("%w: %d bytes", ErrFileTooLarge, info.Size())
+		return nil, fmt.Errorf("%w: %d bytes", ErrFileTooLarge, info.Size())
 	}
 
 	absPath, err := filepath.Abs(path)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	fileURL := "file://" + absPath
 
-	// Skip if already indexed with the same modification time
 	existing := GetByURL(fileURL)
 	if existing != nil && existing.Added == info.ModTime().Unix() {
-		return nil
+		return nil, ErrAlreadyIndexed
 	}
 
 	content, err := os.ReadFile(path)
 	if err != nil {
-		return &ReadFileError{
-			Msg: err.Error(),
-		}
+		return nil, &ReadFileError{Msg: err.Error()}
 	}
 	if !utf8.Valid(content) {
-		return ErrBinaryFile
+		return nil, ErrBinaryFile
 	}
 
-	doc := &Document{
+	return &Document{
 		URL:   fileURL,
 		Text:  string(content),
 		Added: info.ModTime().Unix(),
-	}
+	}, nil
+}
 
+// IndexFile indexes a single file. Used by the file watcher.
+func IndexFile(path string) error {
+	doc, err := readFileDoc(path)
+	if err != nil {
+		if errors.Is(err, ErrAlreadyIndexed) {
+			return nil
+		}
+		return err
+	}
 	return i.AddDocument(doc)
 }

--- a/server/indexer/indexer.go
+++ b/server/indexer/indexer.go
@@ -16,6 +16,7 @@ import (
 	"github.com/asciimoo/hister/server/indexer/querybuilder"
 	"github.com/asciimoo/hister/server/indexer/types"
 	"github.com/asciimoo/hister/server/model"
+	"github.com/asciimoo/hister/xsync"
 
 	"github.com/blevesearch/bleve/v2"
 	"github.com/blevesearch/bleve/v2/analysis/analyzer/custom"
@@ -36,8 +37,8 @@ import (
 var Version = 3
 
 type indexer struct {
-	idx          bleve.IndexAlias       // used only for Search()
-	indexers     map[string]bleve.Index // default and language specific indexers
+	idx          bleve.IndexAlias               // used only for Search()
+	indexers     xsync.Map[string, bleve.Index] // default and language specific indexers
 	dir          string
 	langDetector LanguageDetector
 }
@@ -137,11 +138,9 @@ func initializeIndexer(basePath string, detectLanguages bool) (*indexer, error) 
 	idx.SetName(defaultIndexerName)
 	i = &indexer{
 		idx: bleve.NewIndexAlias(idx),
-		indexers: map[string]bleve.Index{
-			defaultIndexerName: idx,
-		},
 		dir: basePath,
 	}
+	i.indexers.Store(defaultIndexerName, idx)
 	if !detectLanguages {
 		i.langDetector = NewNullLanguageDetector()
 	} else {
@@ -167,7 +166,7 @@ func initializeIndexer(basePath string, detectLanguages bool) (*indexer, error) 
 		}
 		langIdx.SetName(fn)
 		i.idx.Add(langIdx)
-		i.indexers[fn] = langIdx
+		i.indexers.Store(fn, langIdx)
 	}
 	return i, nil
 }
@@ -259,14 +258,14 @@ func Reindex(basePath string, rules *config.Rules, skipSensitiveChecks bool, det
 	}
 	idx.Close()
 	tmpIdx.Close()
-	for n := range idx.indexers {
+	for n := range idx.indexers.All {
 		idxPath := filepath.Join(basePath, n)
 		if err := os.RemoveAll(idxPath); err != nil {
 			return err
 		}
 	}
 	var renameError error
-	for n := range tmpIdx.indexers {
+	for n := range tmpIdx.indexers.All {
 		idxPath := filepath.Join(basePath, n)
 		tmpIdxPath := filepath.Join(tmpBasePath, n)
 		if err := os.Rename(tmpIdxPath, idxPath); err != nil {
@@ -342,37 +341,43 @@ func GetLatestDocuments(limit int, latest string) *Results {
 
 func (i *indexer) getOrCreate(lang string) bleve.Index {
 	if lang == UnknownLanguage || lang == "" {
-		return i.indexers[defaultIndexerName]
+		idx, _ := i.indexers.Load(defaultIndexerName)
+		return idx
 	}
 	idxName := fmt.Sprintf(langIndexerName, lang)
-	idx, ok := i.indexers[idxName]
-	if !ok {
-		err := i.addIndexer(idxName, lang)
-		if err != nil {
-			log.Warn().Err(err).Str("Name", idxName).Msg("Failed to create language indexer")
-			return i.indexers[defaultIndexerName]
-		}
-		idx = i.indexers[idxName]
+	idx, err := i.indexers.LoadOrCompute(idxName, func() (bleve.Index, error) {
+		return i.createIndex(idxName, lang)
+	})
+	if err != nil {
+		log.Warn().Err(err).Str("Name", idxName).Msg("Failed to create language indexer")
+		fallback, _ := i.indexers.Load(defaultIndexerName)
+		return fallback
 	}
 	return idx
 }
 
-func (i *indexer) addIndexer(name, lang string) error {
+func (i *indexer) createIndex(name, lang string) (bleve.Index, error) {
 	mapping := createMapping(lang)
 	idx, err := bleve.NewUsing(filepath.Join(i.dir, name), mapping, bleve.Config.DefaultIndexType, bleve.Config.DefaultMemKVStore, bleveConfig)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	idx.SetName(name)
-	i.indexers[name] = idx
-	return nil
+	i.idx.Add(idx)
+	return idx, nil
 }
 
 func (i *indexer) Close() {
-	for name, idx := range i.indexers {
+	for name, idx := range i.indexers.All {
 		if err := idx.Close(); err != nil {
 			log.Warn().Err(err).Str("index", name).Msg("failed to close index")
 		}
+	}
+}
+
+func Close() {
+	if i != nil {
+		i.Close()
 	}
 }
 
@@ -389,7 +394,7 @@ func newMultiBatch(idx *indexer) *MultiBatch {
 
 func (b *MultiBatch) Add(d *Document) error {
 	if !d.processed {
-		if err := d.Process(i.langDetector); err != nil {
+		if err := d.Process(b.indexer.langDetector); err != nil {
 			return err
 		}
 	}
@@ -401,8 +406,7 @@ func (b *MultiBatch) Add(d *Document) error {
 }
 
 func (b *MultiBatch) Delete(u string) error {
-	// Delete from all language indices
-	for _, idx := range b.indexer.indexers {
+	for _, idx := range b.indexer.indexers.All {
 		if err := idx.Delete(u); err != nil {
 			return err
 		}
@@ -421,7 +425,7 @@ func (b *MultiBatch) Save() error {
 }
 
 func Delete(u string) error {
-	for _, idx := range i.indexers {
+	for _, idx := range i.indexers.All {
 		if err := idx.Delete(u); err != nil {
 			return err
 		}

--- a/server/server.go
+++ b/server/server.go
@@ -3,6 +3,7 @@ package server
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"crypto/rand"
 	"encoding/json"
 	"errors"
@@ -13,10 +14,12 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"os/signal"
 	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/asciimoo/hister/config"
@@ -143,7 +146,7 @@ func recParseStaticFiles(entries []iofs.DirEntry, dir, baseDir string) error {
 	return nil
 }
 
-func Listen(cfg *config.Config) {
+func Listen(cfg *config.Config, onShutdown func()) {
 	sessionStore = sessions.NewCookieStore(cfg.SecretKey()[:32])
 	sessionStore.Options = &sessions.Options{
 		Path:     "/",
@@ -165,11 +168,39 @@ func Listen(cfg *config.Config) {
 	handler := registerEndpoints(cfg)
 	handler = withLogging(handler)
 
+	ctx, stop := signal.NotifyContext(
+		context.Background(),
+		syscall.SIGINT,
+		syscall.SIGTERM,
+	)
+	defer stop()
+
+	srv := &http.Server{Addr: cfg.Server.Address, Handler: handler}
+	shutdownDone := make(chan struct{})
+
+	go func() {
+		<-ctx.Done()
+		stop()
+		log.Info().Msg("Shutting down server...")
+
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		if err := srv.Shutdown(shutdownCtx); err != nil {
+			log.Error().Err(err).Msg("Server shutdown error")
+		}
+		if onShutdown != nil {
+			onShutdown()
+		}
+		close(shutdownDone)
+	}()
+
 	log.Info().Str("Address", cfg.Server.Address).Str("URL", cfg.BaseURL("/")).Msg("Starting webserver")
-	err := http.ListenAndServe(cfg.Server.Address, handler)
-	if err != nil {
+	if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 		log.Error().Err(err).Msg("Webserver failed to listen on " + cfg.Server.Address)
+		stop() // cancel context so shutdown goroutine runs cleanup
 	}
+	<-shutdownDone
 }
 
 func registerEndpoints(cfg *config.Config) http.Handler {

--- a/xsync/map.go
+++ b/xsync/map.go
@@ -1,0 +1,60 @@
+package xsync
+
+import (
+	"sync"
+)
+
+// Map is a concurrency-safe map backed by sync.Map with typed accessors.
+type Map[K comparable, V any] struct {
+	m  sync.Map
+	mu sync.Mutex // serializes LoadOrCompute creation
+}
+
+// Load returns the value for key and whether it was found.
+func (m *Map[K, V]) Load(key K) (V, bool) {
+	v, ok := m.m.Load(key)
+	if !ok {
+		var zero V
+		return zero, false
+	}
+	return v.(V), true
+}
+
+// Store sets the value for key.
+func (m *Map[K, V]) Store(key K, value V) {
+	m.m.Store(key, value)
+}
+
+// Delete removes the key. Returns true if it was present.
+func (m *Map[K, V]) Delete(key K) bool {
+	_, loaded := m.m.LoadAndDelete(key)
+	return loaded
+}
+
+// LoadOrCompute returns the existing value for key if present. Otherwise it
+// calls create, stores its result, and returns it. The create function is
+// called at most once per key, even under concurrent access.
+func (m *Map[K, V]) LoadOrCompute(key K, create func() (V, error)) (V, error) {
+	if v, ok := m.m.Load(key); ok {
+		return v.(V), nil
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if v, ok := m.m.Load(key); ok {
+		return v.(V), nil
+	}
+	v, err := create()
+	if err != nil {
+		var zero V
+		return zero, err
+	}
+	m.m.Store(key, v)
+	return v, nil
+}
+
+// All is a range iterator over all key-value pairs.
+func (m *Map[K, V]) All(yield func(K, V) bool) {
+	m.m.Range(func(key, value any) bool {
+		return yield(key.(K), value.(V))
+	})
+}

--- a/xsync/set.go
+++ b/xsync/set.go
@@ -1,0 +1,49 @@
+package xsync
+
+import (
+	"sync"
+	"sync/atomic"
+)
+
+// Set is a concurrency-safe set backed by sync.Map with an O(1) Len.
+type Set[T comparable] struct {
+	m   sync.Map
+	len atomic.Int64
+}
+
+// Add inserts v into the set. Returns true if the value was added, false if it
+// was already present.
+func (s *Set[T]) Add(v T) bool {
+	if _, loaded := s.m.LoadOrStore(v, struct{}{}); loaded {
+		return false
+	}
+	s.len.Add(1)
+	return true
+}
+
+// Has reports whether v is in the set.
+func (s *Set[T]) Has(v T) bool {
+	_, ok := s.m.Load(v)
+	return ok
+}
+
+// Delete removes v from the set. Returns true if the value was present.
+func (s *Set[T]) Delete(v T) bool {
+	if _, loaded := s.m.LoadAndDelete(v); !loaded {
+		return false
+	}
+	s.len.Add(-1)
+	return true
+}
+
+// Len returns the number of elements in the set.
+func (s *Set[T]) Len() int {
+	return int(s.len.Load())
+}
+
+// All is a range iterator over all elements in the set.
+func (s *Set[T]) All(yield func(T) bool) {
+	s.m.Range(func(key, _ any) bool {
+		return yield(key.(T))
+	})
+}


### PR DESCRIPTION
…to file indexing

- Add worker pool with bounded channel for file indexing and watching
- Add context cancellation and graceful shutdown to IndexAll and WatchDirectories
- Add signal handling (SIGINT/SIGTERM) with clean HTTP server shutdown
- Add configurable max_watch_dirs and index_workers settings
- Add SyncSet and SyncMap concurrency primitives in xsync package
- Add thread-safe language indexer creation with LoadOrCompute
- Add watch directory limit to prevent file descriptor exhaustion
- Add batched index writes with periodic flushing during initial indexing
- Fix missing IndexAlias registration when creating language-specific indexes
- Fix thread-safety of indexer map access with sync.Map-backed SyncMap