### PR TITLE
Add a WinGet publication workflow

### DIFF
--- a/.github/workflows/winget-publish.yml
+++ b/.github/workflows/winget-publish.yml
@@ -17,4 +17,4 @@ jobs:
         with:
           identifier: asciimoo.hister
           installers-regex: '\.exe$'
-          token: ${{ secrets.WINGET_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/winget-publish.yml
+++ b/.github/workflows/winget-publish.yml
@@ -1,15 +1,20 @@
 name: Publish to WinGet
 
 on:
-  push:
-    branches: ['master'] # Trigger on pushes to master branch
-    tags: ['v*.*.*'] # Trigger on semantic version tags (e.g., v1.0.0)
+  release:
+    types: [published]
+
+permissions:
+  contents: read
 
 jobs:
   publish:
-    runs-on: ubuntu-slim
+    if: github.repository == 'asciimoo/hister'
+    name: Publish to WinGet
+    runs-on: ubuntu-latest
     steps:
-      - uses: vedantmgoyal9/winget-releaser@main
+      - uses: vedantmgoyal9/winget-releaser@v2
         with:
           identifier: asciimoo.hister
+          installers-regex: '\.exe$'
           token: ${{ secrets.WINGET_TOKEN }}

--- a/.github/workflows/winget-publish.yml
+++ b/.github/workflows/winget-publish.yml
@@ -1,0 +1,15 @@
+name: Publish to WinGet
+
+on:
+  push:
+    branches: ['master'] # Trigger on pushes to master branch
+    tags: ['v*.*.*'] # Trigger on semantic version tags (e.g., v1.0.0)
+
+jobs:
+  publish:
+    runs-on: ubuntu-slim
+    steps:
+      - uses: vedantmgoyal9/winget-releaser@main
+        with:
+          identifier: asciimoo.hister
+          token: ${{ secrets.WINGET_TOKEN }}

--- a/.github/workflows/winget-publish.yml
+++ b/.github/workflows/winget-publish.yml
@@ -2,7 +2,7 @@ name: Publish to WinGet
 
 on:
   release:
-    types: [published]
+    types: [released]
 
 permissions:
   contents: read
@@ -11,9 +11,9 @@ jobs:
   publish:
     if: github.repository == 'asciimoo/hister'
     name: Publish to WinGet
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
-      - uses: vedantmgoyal9/winget-releaser@v2
+      - uses: vedantmgoyal9/winget-releaser@main
         with:
           identifier: asciimoo.hister
           installers-regex: '\.exe$'


### PR DESCRIPTION
### Summary

Hister is in an active development cycle, with frequent new releases. Keeping our local installation of Hister up to date needs to keep a constant eye on the new releases page. Adding Hister to the WinGet catalogue would help Windows users keep Hister up to date.
I have already manually published versions `0.11.0` and `0.12.0` [in the WinGet catalogue](https://github.com/microsoft/winget-pkgs/tree/master/manifests/a/asciimoo/hister).
**This PR aims to automate this process by adding a workflow to publish automatically new releases of Hister in the WinGet catalogue.**

### How does the workflow work?

The workflow relies on [the GitHub action `vedantmgoyal9/winget-releaser`](https://github.com/vedantmgoyal9/winget-releaser). This action is triggered when a release is published, with a filter for Windows installers (`.exe` files).

A guard (`if: github.repository == 'asciimoo/hister'`) prevents forks of this GitHub repository from accidentally publishing releases to the WinGet catalogue.

[Here is an example of a pull request](https://github.com/microsoft/winget-pkgs/pull/357569) created during a test of the workflow.

### Prerequisites

This workflow requires a `WINGET_TOKEN` secret: a classic Personal Access Token with the `public_repo` scope, used to create a pull request on `microsoft/winget-pkgs`.

### Usage of AI

I used Claude Code to help me with this task. It enabled me to create the `.yaml` file.
I wrote the description for this PR myself.