### PR TITLE
[feat] add yt-dlp extractor

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -4,6 +4,8 @@
   buildNpmPackage,
   importNpmLock,
   sqlite,
+  yt-dlp,
+  makeBinaryWrapper,
   pkg-config,
   histerRev ? "unknown",
 }:
@@ -23,8 +25,8 @@ let
     '';
     installPhase = ''
       runHook preInstall
-      mkdir -p $out
-      cp -r webui/app/build/* $out/
+      mkdir -p "$out"
+      cp -r webui/app/build/* "$out/"
       runHook postInstall
     '';
   };
@@ -50,7 +52,7 @@ buildGoModule (finalAttrs: {
   vendorHash = "sha256-lvVg90jFRDzo5XzPWMRRJp+VrJ/Q+Nwu1dc7T2i7T6I=";
   proxyVendor = true;
 
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [ pkg-config makeBinaryWrapper ];
   buildInputs = [ sqlite ];
 
   tags = [ "libsqlite3" ];
@@ -68,6 +70,11 @@ buildGoModule (finalAttrs: {
   ];
 
   subPackages = [ "." ];
+
+  postInstall = ''
+    wrapProgram $out/bin/hister \
+      --prefix PATH : ${lib.makeBinPath [ yt-dlp ]}
+  '';
 
   passthru = {
     inherit frontend;

--- a/server/extractor/extractor.go
+++ b/server/extractor/extractor.go
@@ -18,6 +18,7 @@ import (
 	"github.com/asciimoo/hister/server/document"
 	"github.com/asciimoo/hister/server/extractor/extractors/godoc"
 	"github.com/asciimoo/hister/server/extractor/extractors/stackoverflow"
+	"github.com/asciimoo/hister/server/extractor/extractors/ytdlp"
 	"github.com/asciimoo/hister/server/types"
 )
 
@@ -58,6 +59,7 @@ var ErrNoExtractor = errors.New("no extractor found")
 var extractors = []Extractor{
 	&stackoverflow.StackoverflowExtractor{},
 	&godoc.GoDocExtractor{},
+	&ytdlp.YtdlpExtractor{},
 	&readabilityExtractor{},
 	&defaultExtractor{},
 }

--- a/server/extractor/extractors/ytdlp/format.go
+++ b/server/extractor/extractors/ytdlp/format.go
@@ -1,0 +1,23 @@
+package ytdlp
+
+import "fmt"
+
+// formatDuration converts seconds to a human-readable "HH:MM:SS" or "MM:SS" string.
+func formatDuration(seconds float64) string {
+	total := int(seconds)
+	h := total / 3600
+	m := (total % 3600) / 60
+	s := total % 60
+	if h > 0 {
+		return fmt.Sprintf("%d:%02d:%02d", h, m, s)
+	}
+	return fmt.Sprintf("%d:%02d", m, s)
+}
+
+// formatDate converts "YYYYMMDD" to "YYYY-MM-DD".
+func formatDate(d string) string {
+	if len(d) == 8 {
+		return d[:4] + "-" + d[4:6] + "-" + d[6:]
+	}
+	return d
+}

--- a/server/extractor/extractors/ytdlp/format_test.go
+++ b/server/extractor/extractors/ytdlp/format_test.go
@@ -1,0 +1,37 @@
+package ytdlp
+
+import "testing"
+
+func TestFormatDuration(t *testing.T) {
+	tests := []struct {
+		seconds float64
+		want    string
+	}{
+		{0, "0:00"},
+		{19, "0:19"},
+		{65, "1:05"},
+		{3661, "1:01:01"},
+		{7200, "2:00:00"},
+	}
+	for _, tt := range tests {
+		if got := formatDuration(tt.seconds); got != tt.want {
+			t.Errorf("formatDuration(%v) = %q, want %q", tt.seconds, got, tt.want)
+		}
+	}
+}
+
+func TestFormatDate(t *testing.T) {
+	tests := []struct {
+		input, want string
+	}{
+		{"20050424", "2005-04-24"},
+		{"20230415", "2023-04-15"},
+		{"short", "short"},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		if got := formatDate(tt.input); got != tt.want {
+			t.Errorf("formatDate(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}

--- a/server/extractor/extractors/ytdlp/types.go
+++ b/server/extractor/extractors/ytdlp/types.go
@@ -1,0 +1,102 @@
+package ytdlp
+
+import "time"
+
+// subtitleTrack represents a single subtitle format entry from yt-dlp.
+type subtitleTrack struct {
+	Ext  string `json:"ext"`
+	URL  string `json:"url"`
+	Name string `json:"name"`
+}
+
+// chapter represents a video chapter from yt-dlp.
+type chapter struct {
+	StartTime float64 `json:"start_time"`
+	EndTime   float64 `json:"end_time"`
+	Title     string  `json:"title"`
+}
+
+// videoInfo holds the subset of yt-dlp JSON output we care about.
+type videoInfo struct {
+	Title             string                     `json:"title"`
+	Description       string                     `json:"description"`
+	Uploader          string                     `json:"uploader"`
+	Channel           string                     `json:"channel"`
+	Duration          float64                    `json:"duration"`
+	ViewCount         int64                      `json:"view_count"`
+	LikeCount         int64                      `json:"like_count"`
+	UploadDate        string                     `json:"upload_date"`
+	Thumbnail         string                     `json:"thumbnail"`
+	WebpageURL        string                     `json:"webpage_url"`
+	Categories        []string                   `json:"categories"`
+	Tags              []string                   `json:"tags"`
+	Chapters          []chapter                  `json:"chapters"`
+	Subtitles         map[string][]subtitleTrack `json:"subtitles"`
+	AutomaticCaptions map[string][]subtitleTrack `json:"automatic_captions"`
+	PlaylistTitle     string                     `json:"playlist_title"`
+	PlaylistIndex     *int                       `json:"playlist_index"`
+	PlaylistCount     *int                       `json:"playlist_count"`
+}
+
+// videoPreviewData is the structured JSON returned to the frontend
+// when Template is "video".
+type videoPreviewData struct {
+	Title             string           `json:"title"`
+	Uploader          string           `json:"uploader"`
+	Duration          float64          `json:"duration"`
+	DurationFormatted string           `json:"durationFormatted"`
+	UploadDate        string           `json:"uploadDate"`
+	ViewCount         int64            `json:"viewCount"`
+	LikeCount         int64            `json:"likeCount"`
+	Categories        []string         `json:"categories"`
+	Tags              []string         `json:"tags"`
+	Description       string           `json:"description"`
+	Thumbnail         string           `json:"thumbnail"`
+	Chapters          []chapterPreview `json:"chapters,omitempty"`
+	Playlist          *playlistPreview `json:"playlist,omitempty"`
+	Transcript        string           `json:"transcript,omitempty"`
+	WebpageURL        string           `json:"webpageUrl"`
+}
+
+type chapterPreview struct {
+	Title     string `json:"title"`
+	StartTime string `json:"startTime"`
+}
+
+type playlistPreview struct {
+	Title string `json:"title"`
+	Index int    `json:"index"`
+	Count int    `json:"count"`
+}
+
+// cachedInfo stores a fetched videoInfo with a timestamp for expiry.
+type cachedInfo struct {
+	info      *videoInfo
+	fetchedAt time.Time
+}
+
+// knownDomains lists domains that yt-dlp commonly supports.
+// The Match function checks whether the URL's hostname equals or is
+// a subdomain of each entry (e.g. "youtube.com" matches "www.youtube.com").
+var knownDomains = []string{
+	"youtube.com",
+	"youtu.be",
+	"vimeo.com",
+	"dailymotion.com",
+	"twitch.tv",
+	"bilibili.com",
+	"nicovideo.jp",
+	"soundcloud.com",
+	"bandcamp.com",
+	"mixcloud.com",
+	"ted.com",
+	"archive.org",
+	"media.ccc.de",
+	"tiktok.com",
+}
+
+// knownHostSubstrings lists hostname fragments matched with strings.Contains
+// for platforms with user-chosen subdomains (e.g. instance.peertube.live).
+var knownHostSubstrings = []string{
+	"peertube",
+}

--- a/server/extractor/extractors/ytdlp/vtt.go
+++ b/server/extractor/extractors/ytdlp/vtt.go
@@ -1,0 +1,132 @@
+package ytdlp
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"unicode"
+)
+
+// fetchSubtitleText uses yt-dlp to download subtitles and strips timing/formatting
+// to return plain transcript text. It prefers manual subtitles over auto-captions.
+func (e *YtdlpExtractor) fetchSubtitleText(info *videoInfo) string {
+	lang := e.subLanguage()
+
+	// Check whether any subtitles are available at all.
+	hasManual := len(info.Subtitles[lang]) > 0
+	hasAuto := len(info.AutomaticCaptions[lang]) > 0
+	if !hasManual && !hasAuto {
+		return ""
+	}
+
+	dir, err := os.MkdirTemp("", "hister-subs-*")
+	if err != nil {
+		return ""
+	}
+	defer os.RemoveAll(dir) //nolint:errcheck // best-effort cleanup
+
+	ctx, cancel := context.WithTimeout(context.Background(), e.timeout())
+	defer cancel()
+
+	outTpl := filepath.Join(dir, "sub")
+	args := []string{
+		"--skip-download",
+		"--no-playlist",
+		"--no-warnings",
+		"--sub-lang", lang,
+		"--convert-subs", "vtt",
+		"-o", outTpl,
+	}
+	if hasManual {
+		args = append(args, "--write-sub")
+	} else {
+		args = append(args, "--write-auto-sub")
+	}
+	args = append(args, e.cookieArgs()...)
+	args = append(args, info.WebpageURL)
+
+	// #nosec G204 -- binary path and args are admin-configured, not user input.
+	cmd := exec.CommandContext(ctx, e.binary(), args...)
+	if err := cmd.Run(); err != nil {
+		return ""
+	}
+
+	// yt-dlp writes the subtitle file as sub.<lang>.vtt in the temp dir.
+	matches, _ := filepath.Glob(filepath.Join(dir, "*.vtt"))
+	if len(matches) == 0 {
+		return ""
+	}
+
+	data, err := os.ReadFile(matches[0])
+	if err != nil {
+		return ""
+	}
+
+	return parseVTT(string(data))
+}
+
+// parseVTT extracts plain text lines from WebVTT content,
+// stripping headers, timestamps, and deduplicating repeated lines.
+func parseVTT(raw string) string {
+	var lines []string
+	seen := make(map[string]struct{})
+
+	for line := range strings.SplitSeq(raw, "\n") {
+		line = strings.TrimSpace(line)
+		// Skip empty lines, WEBVTT header, NOTE blocks, timestamp lines,
+		// and numeric cue identifiers.
+		if line == "" || strings.HasPrefix(line, "WEBVTT") ||
+			strings.HasPrefix(line, "NOTE") || strings.HasPrefix(line, "Kind:") ||
+			strings.HasPrefix(line, "Language:") || strings.Contains(line, " --> ") ||
+			isNumeric(line) {
+			continue
+		}
+		// Strip VTT tags like <c>, </c>, <00:00:01.234>, etc.
+		clean := stripVTTTags(line)
+		clean = strings.TrimSpace(clean)
+		if clean == "" {
+			continue
+		}
+		if _, dup := seen[clean]; !dup {
+			seen[clean] = struct{}{}
+			lines = append(lines, clean)
+		}
+	}
+
+	return strings.Join(lines, " ")
+}
+
+// isNumeric reports whether s consists entirely of digits (WebVTT cue identifiers).
+func isNumeric(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		if !unicode.IsDigit(r) {
+			return false
+		}
+	}
+	return true
+}
+
+// stripVTTTags removes VTT/HTML-style tags from text.
+func stripVTTTags(s string) string {
+	var b strings.Builder
+	inTag := false
+	for _, r := range s {
+		if r == '<' {
+			inTag = true
+			continue
+		}
+		if r == '>' {
+			inTag = false
+			continue
+		}
+		if !inTag {
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}

--- a/server/extractor/extractors/ytdlp/vtt_test.go
+++ b/server/extractor/extractors/ytdlp/vtt_test.go
@@ -1,0 +1,26 @@
+package ytdlp
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseVTT(t *testing.T) {
+	result := parseVTT(sampleVTT)
+
+	if !strings.Contains(result, "elephants") {
+		t.Errorf("parseVTT missing 'elephants', got: %q", result)
+	}
+	if !strings.Contains(result, "really long trunks") {
+		t.Errorf("parseVTT missing 'really long trunks', got: %q", result)
+	}
+	if strings.Contains(result, "<c>") {
+		t.Error("parseVTT should strip VTT tags")
+	}
+	if strings.Contains(result, "-->") {
+		t.Error("parseVTT should strip timestamps")
+	}
+	if strings.Contains(result, "WEBVTT") {
+		t.Error("parseVTT should strip WEBVTT header")
+	}
+}

--- a/server/extractor/extractors/ytdlp/ytdlp.go
+++ b/server/extractor/extractors/ytdlp/ytdlp.go
@@ -1,0 +1,401 @@
+// Package ytdlp provides an extractor for video pages using the yt-dlp tool.
+package ytdlp
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os/exec"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/rs/zerolog/log"
+
+	"github.com/asciimoo/hister/config"
+	"github.com/asciimoo/hister/server/document"
+	"github.com/asciimoo/hister/server/types"
+)
+
+const (
+	cacheTTL     = 10 * time.Minute
+	maxCacheSize = 500
+	maxThumbSize = 5 << 20 // 5 MB
+)
+
+// YtdlpExtractor extracts video metadata using yt-dlp.
+type YtdlpExtractor struct {
+	cfg   *config.Extractor
+	cache sync.Map // URL -> *cachedInfo
+}
+
+func (e *YtdlpExtractor) Name() string {
+	return "Ytdlp"
+}
+
+func (e *YtdlpExtractor) GetConfig() *config.Extractor {
+	if e.cfg == nil {
+		return &config.Extractor{
+			Enable: false,
+			Options: map[string]any{
+				"binary":          "yt-dlp",
+				"timeout":         15,
+				"fetch_subtitles": false,
+				"sub_language":    "en",
+			},
+		}
+	}
+	return e.cfg
+}
+
+func (e *YtdlpExtractor) SetConfig(c *config.Extractor) error {
+	for k := range c.Options {
+		switch k {
+		case "binary", "timeout", "fetch_subtitles", "sub_language",
+			"cookies_file", "cookies_from_browser", "extra_args":
+		default:
+			return fmt.Errorf("unknown option %q", k)
+		}
+	}
+	e.cfg = c
+	return nil
+}
+
+func (e *YtdlpExtractor) binary() string {
+	if b, ok := e.GetConfig().Options["binary"].(string); ok && b != "" {
+		return b
+	}
+	return "yt-dlp"
+}
+
+func (e *YtdlpExtractor) timeout() time.Duration {
+	cfg := e.GetConfig()
+	switch v := cfg.Options["timeout"].(type) {
+	case int:
+		return time.Duration(v) * time.Second
+	case float64:
+		return time.Duration(v) * time.Second
+	}
+	return 15 * time.Second
+}
+
+func (e *YtdlpExtractor) fetchSubtitlesEnabled() bool {
+	v, ok := e.GetConfig().Options["fetch_subtitles"].(bool)
+	return ok && v
+}
+
+func (e *YtdlpExtractor) subLanguage() string {
+	if s, ok := e.GetConfig().Options["sub_language"].(string); ok && s != "" {
+		return s
+	}
+	return "en"
+}
+
+// cookieArgs returns yt-dlp CLI flags for cookie authentication based on config.
+func (e *YtdlpExtractor) cookieArgs() []string {
+	var args []string
+	if f, ok := e.GetConfig().Options["cookies_file"].(string); ok && f != "" {
+		args = append(args, "--cookies", f)
+	}
+	if b, ok := e.GetConfig().Options["cookies_from_browser"].(string); ok && b != "" {
+		args = append(args, "--cookies-from-browser", b)
+	}
+	return args
+}
+
+func (e *YtdlpExtractor) Match(d *document.Document) bool {
+	u, err := url.Parse(d.URL)
+	if err != nil {
+		return false
+	}
+	host := strings.ToLower(u.Hostname())
+	matched := false
+	for _, domain := range knownDomains {
+		if host == domain || strings.HasSuffix(host, "."+domain) {
+			matched = true
+			break
+		}
+	}
+	if !matched {
+		for _, sub := range knownHostSubstrings {
+			if strings.Contains(host, sub) {
+				matched = true
+				break
+			}
+		}
+	}
+	if !matched {
+		return false
+	}
+	// Reject bare homepages — yt-dlp cannot extract anything from a site root
+	// with no path or query parameters (e.g. "https://www.youtube.com/").
+	path := strings.TrimRight(u.Path, "/")
+	if path == "" && u.RawQuery == "" {
+		return false
+	}
+	return true
+}
+
+// getInfo returns cached videoInfo or fetches it via yt-dlp.
+func (e *YtdlpExtractor) getInfo(videoURL string) (*videoInfo, error) {
+	if cached, ok := e.cache.Load(videoURL); ok {
+		ci := cached.(*cachedInfo)
+		if time.Since(ci.fetchedAt) < cacheTTL {
+			return ci.info, nil
+		}
+		e.cache.Delete(videoURL)
+	}
+
+	info, err := e.fetchInfo(videoURL)
+	if err != nil {
+		return nil, err
+	}
+
+	e.pruneCache()
+	e.cache.Store(videoURL, &cachedInfo{info: info, fetchedAt: time.Now()})
+	return info, nil
+}
+
+// pruneCache evicts expired entries and, if still over maxCacheSize, evicts the oldest.
+func (e *YtdlpExtractor) pruneCache() {
+	var count int
+	var oldestKey string
+	var oldestTime time.Time
+
+	e.cache.Range(func(key, value any) bool {
+		ci := value.(*cachedInfo)
+		if time.Since(ci.fetchedAt) >= cacheTTL {
+			e.cache.Delete(key)
+			return true
+		}
+		count++
+		if oldestKey == "" || ci.fetchedAt.Before(oldestTime) {
+			oldestKey = key.(string)
+			oldestTime = ci.fetchedAt
+		}
+		return true
+	})
+
+	if count >= maxCacheSize && oldestKey != "" {
+		e.cache.Delete(oldestKey)
+	}
+}
+
+func (e *YtdlpExtractor) fetchInfo(videoURL string) (*videoInfo, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), e.timeout())
+	defer cancel()
+
+	args := []string{
+		"--dump-json",
+		"--no-download",
+		"--no-playlist",
+		"--no-warnings",
+	}
+	args = append(args, e.cookieArgs()...)
+	if extra, ok := e.GetConfig().Options["extra_args"].([]any); ok {
+		for _, a := range extra {
+			if s, ok := a.(string); ok {
+				args = append(args, s)
+			}
+		}
+	}
+	args = append(args, videoURL)
+
+	// #nosec G204 -- binary path and args are admin-configured, not user input.
+	cmd := exec.CommandContext(ctx, e.binary(), args...)
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("yt-dlp failed: %w", err)
+	}
+	var info videoInfo
+	if err := json.Unmarshal(out, &info); err != nil {
+		return nil, fmt.Errorf("failed to parse yt-dlp output: %w", err)
+	}
+	return &info, nil
+}
+
+// downloadThumbnail fetches the thumbnail image and returns it as a base64 data URI.
+func (e *YtdlpExtractor) downloadThumbnail(thumbnailURL string) string {
+	if thumbnailURL == "" {
+		return ""
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), e.timeout())
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, thumbnailURL, nil)
+	if err != nil {
+		return ""
+	}
+	cli := &http.Client{Timeout: e.timeout()}
+	resp, err := cli.Do(req)
+	if err != nil {
+		return ""
+	}
+	defer func() {
+		if cerr := resp.Body.Close(); cerr != nil {
+			log.Warn().Err(cerr).Msg("failed to close thumbnail response body")
+		}
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		return ""
+	}
+
+	data, err := io.ReadAll(io.LimitReader(resp.Body, maxThumbSize))
+	if err != nil {
+		return ""
+	}
+
+	contentType := resp.Header.Get("Content-Type")
+	if contentType == "" {
+		contentType = "image/jpeg"
+	}
+	return fmt.Sprintf("data:%s;base64,%s", contentType, base64.StdEncoding.EncodeToString(data))
+}
+
+func (e *YtdlpExtractor) Extract(d *document.Document) (types.ExtractorState, error) {
+	info, err := e.getInfo(d.URL)
+	if err != nil {
+		return types.ExtractorContinue, err
+	}
+
+	if info.Title != "" {
+		d.Title = info.Title
+	}
+
+	var text strings.Builder
+	if info.Description != "" {
+		text.WriteString(info.Description)
+	}
+	if info.Uploader != "" {
+		text.WriteString("\n\nUploader: ")
+		text.WriteString(info.Uploader)
+	}
+	if len(info.Tags) > 0 {
+		text.WriteString("\nTags: ")
+		text.WriteString(strings.Join(info.Tags, ", "))
+	}
+	if len(info.Categories) > 0 {
+		text.WriteString("\nCategories: ")
+		text.WriteString(strings.Join(info.Categories, ", "))
+	}
+	if len(info.Chapters) > 0 {
+		text.WriteString("\n\nChapters:\n")
+		for _, ch := range info.Chapters {
+			fmt.Fprintf(&text, "  %s %s\n", formatDuration(ch.StartTime), ch.Title)
+		}
+	}
+	if info.PlaylistTitle != "" {
+		text.WriteString("\nPlaylist: ")
+		text.WriteString(info.PlaylistTitle)
+		if info.PlaylistIndex != nil && info.PlaylistCount != nil {
+			fmt.Fprintf(&text, " (%d/%d)", *info.PlaylistIndex, *info.PlaylistCount)
+		}
+	}
+
+	if e.fetchSubtitlesEnabled() {
+		if transcript := e.fetchSubtitleText(info); transcript != "" {
+			text.WriteString("\n\nTranscript:\n")
+			text.WriteString(transcript)
+		}
+	}
+
+	d.Text = strings.TrimSpace(text.String())
+
+	// Store structured metadata.
+	if d.Metadata == nil {
+		d.Metadata = make(map[string]any)
+	}
+	if thumb := e.downloadThumbnail(info.Thumbnail); thumb != "" {
+		d.Metadata["thumbnail"] = thumb
+	}
+	if info.Duration > 0 {
+		d.Metadata["duration"] = info.Duration
+	}
+	if info.UploadDate != "" {
+		d.Metadata["upload_date"] = formatDate(info.UploadDate)
+	}
+	if info.Uploader != "" {
+		d.Metadata["uploader"] = info.Uploader
+	}
+	if info.ViewCount > 0 {
+		d.Metadata["view_count"] = info.ViewCount
+	}
+
+	return types.ExtractorStop, nil
+}
+
+func (e *YtdlpExtractor) Preview(d *document.Document) (types.PreviewResponse, types.ExtractorState, error) {
+	info, err := e.getInfo(d.URL)
+	if err != nil {
+		return types.PreviewResponse{}, types.ExtractorContinue, err
+	}
+
+	// Use cached thumbnail from metadata, or download it.
+	thumbDataURI := ""
+	if d.Metadata != nil {
+		if t, ok := d.Metadata["thumbnail"].(string); ok {
+			thumbDataURI = t
+		}
+	}
+	if thumbDataURI == "" {
+		thumbDataURI = e.downloadThumbnail(info.Thumbnail)
+	}
+
+	// Build structured preview data for the frontend.
+	preview := videoPreviewData{
+		Title:             info.Title,
+		Uploader:          info.Uploader,
+		Duration:          info.Duration,
+		DurationFormatted: formatDuration(info.Duration),
+		UploadDate:        formatDate(info.UploadDate),
+		ViewCount:         info.ViewCount,
+		LikeCount:         info.LikeCount,
+		Categories:        info.Categories,
+		Tags:              info.Tags,
+		Description:       info.Description,
+		Thumbnail:         thumbDataURI,
+		WebpageURL:        info.WebpageURL,
+	}
+
+	if len(info.Chapters) > 0 {
+		preview.Chapters = make([]chapterPreview, len(info.Chapters))
+		for i, ch := range info.Chapters {
+			preview.Chapters[i] = chapterPreview{
+				Title:     ch.Title,
+				StartTime: formatDuration(ch.StartTime),
+			}
+		}
+	}
+
+	if info.PlaylistTitle != "" {
+		preview.Playlist = &playlistPreview{
+			Title: info.PlaylistTitle,
+		}
+		if info.PlaylistIndex != nil {
+			preview.Playlist.Index = *info.PlaylistIndex
+		}
+		if info.PlaylistCount != nil {
+			preview.Playlist.Count = *info.PlaylistCount
+		}
+	}
+
+	if e.fetchSubtitlesEnabled() {
+		preview.Transcript = e.fetchSubtitleText(info)
+	}
+
+	data, err := json.Marshal(preview)
+	if err != nil {
+		return types.PreviewResponse{}, types.ExtractorContinue, err
+	}
+
+	return types.PreviewResponse{
+		Content:  string(data),
+		Template: "video",
+	}, types.ExtractorStop, nil
+}

--- a/server/extractor/extractors/ytdlp/ytdlp_test.go
+++ b/server/extractor/extractors/ytdlp/ytdlp_test.go
@@ -1,0 +1,472 @@
+package ytdlp
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/asciimoo/hister/config"
+	"github.com/asciimoo/hister/server/document"
+	"github.com/asciimoo/hister/server/types"
+)
+
+// sampleJSONTemplate is based on real yt-dlp --dump-json output from
+// https://www.youtube.com/watch?v=jNQXAC9IVRw ("Me at the zoo").
+// %s placeholders: 1=thumbnail URL, 2=subtitle URL.
+const sampleJSONTemplate = `{
+  "id": "jNQXAC9IVRw",
+  "title": "Me at the zoo",
+  "description": "The first video on YouTube.\n\n00:00 Intro\n00:05 The cool thing\n00:17 End",
+  "uploader": "jawed",
+  "channel": "jawed",
+  "duration": 19,
+  "view_count": 387196767,
+  "like_count": 18694393,
+  "upload_date": "20050424",
+  "thumbnail": "%s/thumb.jpg",
+  "webpage_url": "https://www.youtube.com/watch?v=jNQXAC9IVRw",
+  "categories": ["Film & Animation"],
+  "tags": ["me at the zoo", "jawed karim", "first youtube video"],
+  "chapters": [
+    {"start_time": 0.0, "title": "Intro", "end_time": 5.0},
+    {"start_time": 5.0, "title": "The cool thing", "end_time": 17.0},
+    {"start_time": 17.0, "title": "End", "end_time": 19}
+  ],
+  "subtitles": {
+    "en": [
+      {"ext": "vtt", "url": "%s/subs.vtt", "name": "English"}
+    ]
+  },
+  "automatic_captions": {},
+  "playlist_title": "First Videos",
+  "playlist_index": 1,
+  "playlist_count": 10
+}`
+
+const sampleVTT = `WEBVTT
+Kind: captions
+Language: en
+
+00:00:00.000 --> 00:00:05.000
+All right, so here we are in front of the <c>elephants</c>
+
+00:00:05.000 --> 00:00:10.000
+The cool thing about these guys is that they have really
+
+00:00:10.000 --> 00:00:17.000
+really really long trunks
+`
+
+// writeFakeBinary creates a shell script that handles both --dump-json and
+// --write-sub/--write-auto-sub invocations, returning its path.
+func writeFakeBinary(t *testing.T, jsonContent string) string {
+	t.Helper()
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "fake-yt-dlp")
+	// When called with --dump-json, output JSON.
+	// When called with --write-sub or --write-auto-sub, write a .vtt file
+	// next to the -o path.
+	script := `#!/bin/sh
+case "$*" in
+  *--dump-json*)
+    cat <<'YTDLP_EOF'
+` + jsonContent + `
+YTDLP_EOF
+    ;;
+  *--write-sub*|*--write-auto-sub*)
+    out=""
+    next=0
+    for arg in "$@"; do
+      if [ "$next" = 1 ]; then
+        out="$arg"
+        next=0
+      fi
+      case "$arg" in -o) next=1 ;; esac
+    done
+    if [ -n "$out" ]; then
+      cat > "${out}.en.vtt" <<'VTT_EOF'
+` + sampleVTT + `
+VTT_EOF
+    fi
+    ;;
+esac
+`
+	if err := os.WriteFile(bin, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return bin
+}
+
+// startTestServer returns an httptest.Server that serves fake thumbnails and subtitles.
+func startTestServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/subs.vtt":
+			w.Header().Set("Content-Type", "text/vtt")
+			_, _ = fmt.Fprint(w, sampleVTT)
+		case "/thumb.jpg":
+			w.Header().Set("Content-Type", "image/jpeg")
+			_, _ = w.Write([]byte{0xFF, 0xD8, 0xFF, 0xD9})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// newTestExtractor creates an extractor with a fake binary and test HTTP server.
+func newTestExtractor(t *testing.T, fetchSubs bool) (*YtdlpExtractor, *httptest.Server) {
+	t.Helper()
+	srv := startTestServer(t)
+	jsonContent := fmt.Sprintf(sampleJSONTemplate, srv.URL, srv.URL)
+
+	e := &YtdlpExtractor{}
+	if err := e.SetConfig(&config.Extractor{
+		Enable: true,
+		Options: map[string]any{
+			"binary":          writeFakeBinary(t, jsonContent),
+			"timeout":         5,
+			"fetch_subtitles": fetchSubs,
+			"sub_language":    "en",
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	return e, srv
+}
+
+// writeFakeBinaryCounter creates a fake binary that counts invocations of --dump-json calls.
+func writeFakeBinaryCounter(t *testing.T, jsonContent, counterFile string) string {
+	t.Helper()
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "fake-yt-dlp")
+	script := fmt.Sprintf(`#!/bin/sh
+case "$*" in
+  *--dump-json*)
+    count=$(cat %q)
+    count=$((count + 1))
+    echo "$count" > %q
+    cat <<'YTDLP_EOF'
+%s
+YTDLP_EOF
+    ;;
+  *--write-sub*|*--write-auto-sub*)
+    out=""
+    next=0
+    for arg in "$@"; do
+      if [ "$next" = 1 ]; then
+        out="$arg"
+        next=0
+      fi
+      case "$arg" in -o) next=1 ;; esac
+    done
+    if [ -n "$out" ]; then
+      cat > "${out}.en.vtt" <<'VTT_EOF'
+%s
+VTT_EOF
+    fi
+    ;;
+esac
+`, counterFile, counterFile, jsonContent, sampleVTT)
+	if err := os.WriteFile(bin, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return bin
+}
+
+func TestMatch(t *testing.T) {
+	e := &YtdlpExtractor{}
+	tests := []struct {
+		url  string
+		want bool
+	}{
+		{"https://www.youtube.com/watch?v=abc123", true},
+		{"https://youtu.be/abc123", true},
+		{"https://vimeo.com/123456", true},
+		{"https://www.dailymotion.com/video/x7tgad0", true},
+		{"https://www.twitch.tv/videos/123456", true},
+		{"https://soundcloud.com/artist/track", true},
+		{"https://artist.bandcamp.com/track/song", true},
+		{"https://www.tiktok.com/@user/video/123", true},
+		{"https://www.ted.com/talks/some_talk", true},
+		{"https://archive.org/details/something", true},
+		{"https://videos.peertube.example.com/w/abc", true},
+		{"https://www.youtube.com/", false},
+		{"https://www.youtube.com", false},
+		{"https://youtube.com/", false},
+		{"https://vimeo.com/", false},
+		{"https://tiktok.com", false},
+		{"https://example.com/page", false},
+		{"https://stackoverflow.com/questions/123", false},
+		{"https://example.com/path/youtube.com/fake", false},
+	}
+	for _, tt := range tests {
+		d := &document.Document{URL: tt.url}
+		if got := e.Match(d); got != tt.want {
+			t.Errorf("Match(%q) = %v, want %v", tt.url, got, tt.want)
+		}
+	}
+}
+
+func TestExtract(t *testing.T) {
+	e, _ := newTestExtractor(t, false)
+	d := &document.Document{URL: "https://www.youtube.com/watch?v=jNQXAC9IVRw"}
+
+	state, err := e.Extract(d)
+	if err != nil {
+		t.Fatalf("Extract returned error: %v", err)
+	}
+	if state != types.ExtractorStop {
+		t.Fatalf("Extract returned state %v, want ExtractorStop", state)
+	}
+
+	// Title.
+	if d.Title != "Me at the zoo" {
+		t.Errorf("Title = %q, want %q", d.Title, "Me at the zoo")
+	}
+
+	// Text content.
+	for _, want := range []string{
+		"The first video on YouTube.",
+		"Uploader: jawed",
+		"me at the zoo",
+		"Film & Animation",
+		"Chapters:",
+		"0:05 The cool thing",
+		"Playlist: First Videos (1/10)",
+	} {
+		if !strings.Contains(d.Text, want) {
+			t.Errorf("Text missing %q", want)
+		}
+	}
+	if strings.Contains(d.Text, "Transcript") {
+		t.Error("Text should not contain transcript when fetch_subtitles is false")
+	}
+
+	// Metadata.
+	thumb, ok := d.Metadata["thumbnail"].(string)
+	if !ok || !strings.HasPrefix(thumb, "data:image/jpeg;base64,") {
+		t.Error("metadata missing cached thumbnail data URI")
+	}
+	if dur, _ := d.Metadata["duration"].(float64); dur != 19 {
+		t.Errorf("metadata duration = %v, want 19", d.Metadata["duration"])
+	}
+	if date, _ := d.Metadata["upload_date"].(string); date != "2005-04-24" {
+		t.Errorf("metadata upload_date = %v, want 2005-04-24", d.Metadata["upload_date"])
+	}
+	if up, _ := d.Metadata["uploader"].(string); up != "jawed" {
+		t.Errorf("metadata uploader = %v, want jawed", d.Metadata["uploader"])
+	}
+	if views, _ := d.Metadata["view_count"].(int64); views != 387196767 {
+		t.Errorf("metadata view_count = %v, want 387196767", d.Metadata["view_count"])
+	}
+}
+
+func TestExtractWithSubtitles(t *testing.T) {
+	e, _ := newTestExtractor(t, true)
+	d := &document.Document{URL: "https://www.youtube.com/watch?v=jNQXAC9IVRw"}
+
+	if _, err := e.Extract(d); err != nil {
+		t.Fatalf("Extract returned error: %v", err)
+	}
+	if !strings.Contains(d.Text, "Transcript:") {
+		t.Error("Text missing transcript section")
+	}
+	if !strings.Contains(d.Text, "elephants") {
+		t.Error("Text missing subtitle content 'elephants'")
+	}
+}
+
+func TestPreview(t *testing.T) {
+	e, _ := newTestExtractor(t, false)
+	d := &document.Document{URL: "https://www.youtube.com/watch?v=jNQXAC9IVRw"}
+
+	resp, state, err := e.Preview(d)
+	if err != nil {
+		t.Fatalf("Preview returned error: %v", err)
+	}
+	if state != types.ExtractorStop {
+		t.Fatalf("Preview returned state %v, want ExtractorStop", state)
+	}
+	if resp.Template != "video" {
+		t.Errorf("Template = %q, want %q", resp.Template, "video")
+	}
+
+	var preview videoPreviewData
+	if err := json.Unmarshal([]byte(resp.Content), &preview); err != nil {
+		t.Fatalf("Preview content is not valid JSON: %v", err)
+	}
+
+	// Core fields.
+	if preview.Title != "Me at the zoo" {
+		t.Errorf("Title = %q, want %q", preview.Title, "Me at the zoo")
+	}
+	if preview.Uploader != "jawed" {
+		t.Errorf("Uploader = %q, want %q", preview.Uploader, "jawed")
+	}
+	if preview.DurationFormatted != "0:19" {
+		t.Errorf("DurationFormatted = %q, want %q", preview.DurationFormatted, "0:19")
+	}
+	if preview.UploadDate != "2005-04-24" {
+		t.Errorf("UploadDate = %q, want %q", preview.UploadDate, "2005-04-24")
+	}
+	if preview.ViewCount != 387196767 {
+		t.Errorf("ViewCount = %d, want 387196767", preview.ViewCount)
+	}
+	if preview.WebpageURL != "https://www.youtube.com/watch?v=jNQXAC9IVRw" {
+		t.Errorf("WebpageURL = %q", preview.WebpageURL)
+	}
+	if !strings.HasPrefix(preview.Thumbnail, "data:image/jpeg;base64,") {
+		t.Error("Thumbnail missing data URI")
+	}
+
+	// Chapters.
+	if len(preview.Chapters) != 3 {
+		t.Fatalf("expected 3 chapters, got %d", len(preview.Chapters))
+	}
+	if preview.Chapters[0].Title != "Intro" || preview.Chapters[0].StartTime != "0:00" {
+		t.Errorf("chapter[0] = %+v, want Intro@0:00", preview.Chapters[0])
+	}
+	if preview.Chapters[1].Title != "The cool thing" || preview.Chapters[1].StartTime != "0:05" {
+		t.Errorf("chapter[1] = %+v, want 'The cool thing'@0:05", preview.Chapters[1])
+	}
+
+	// Playlist.
+	if preview.Playlist == nil {
+		t.Fatal("expected playlist info, got nil")
+	}
+	if preview.Playlist.Title != "First Videos" || preview.Playlist.Index != 1 || preview.Playlist.Count != 10 {
+		t.Errorf("playlist = %+v, want First Videos 1/10", preview.Playlist)
+	}
+}
+
+func TestPreviewWithSubtitles(t *testing.T) {
+	e, _ := newTestExtractor(t, true)
+	d := &document.Document{URL: "https://www.youtube.com/watch?v=jNQXAC9IVRw"}
+
+	resp, _, err := e.Preview(d)
+	if err != nil {
+		t.Fatalf("Preview returned error: %v", err)
+	}
+
+	var preview videoPreviewData
+	if err := json.Unmarshal([]byte(resp.Content), &preview); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if !strings.Contains(preview.Transcript, "elephants") {
+		t.Errorf("transcript missing 'elephants', got: %q", preview.Transcript)
+	}
+}
+
+func TestCaching(t *testing.T) {
+	dir := t.TempDir()
+	counterFile := filepath.Join(dir, "count")
+	if err := os.WriteFile(counterFile, []byte("0"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	srv := startTestServer(t)
+	jsonContent := fmt.Sprintf(sampleJSONTemplate, srv.URL, srv.URL)
+
+	e := &YtdlpExtractor{}
+	if err := e.SetConfig(&config.Extractor{
+		Enable: true,
+		Options: map[string]any{
+			"binary":          writeFakeBinaryCounter(t, jsonContent, counterFile),
+			"timeout":         5,
+			"fetch_subtitles": false,
+			"sub_language":    "en",
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	url := "https://www.youtube.com/watch?v=test_cache"
+
+	d1 := &document.Document{URL: url}
+	if _, err := e.Extract(d1); err != nil {
+		t.Fatalf("first Extract failed: %v", err)
+	}
+
+	// Second call should use cache.
+	d2 := &document.Document{URL: url}
+	if _, _, err := e.Preview(d2); err != nil {
+		t.Fatalf("Preview failed: %v", err)
+	}
+
+	countBytes, err := os.ReadFile(counterFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count := strings.TrimSpace(string(countBytes)); count != "1" {
+		t.Errorf("yt-dlp was called %s times, want 1 (caching broken)", count)
+	}
+}
+
+func TestExtractFailure(t *testing.T) {
+	e := &YtdlpExtractor{}
+	if err := e.SetConfig(&config.Extractor{
+		Enable: true,
+		Options: map[string]any{
+			"binary":          "/nonexistent/yt-dlp",
+			"timeout":         2,
+			"fetch_subtitles": false,
+			"sub_language":    "en",
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	d := &document.Document{URL: "https://www.youtube.com/watch?v=test"}
+	state, err := e.Extract(d)
+	if err == nil {
+		t.Fatal("expected error from missing binary")
+	}
+	if state != types.ExtractorContinue {
+		t.Errorf("expected ExtractorContinue on failure, got %v", state)
+	}
+}
+
+func TestConfig(t *testing.T) {
+	e := &YtdlpExtractor{}
+
+	if e.Name() != "Ytdlp" {
+		t.Errorf("Name() = %q, want %q", e.Name(), "Ytdlp")
+	}
+
+	cfg := e.GetConfig()
+	if cfg.Enable {
+		t.Error("expected default config to have Enable=false")
+	}
+	if cfg.Options["binary"] != "yt-dlp" {
+		t.Errorf("default binary = %v, want yt-dlp", cfg.Options["binary"])
+	}
+
+	err := e.SetConfig(&config.Extractor{
+		Enable: true,
+		Options: map[string]any{
+			"binary":          "/usr/local/bin/yt-dlp",
+			"timeout":         30,
+			"fetch_subtitles": true,
+			"sub_language":    "de",
+		},
+	})
+	if err != nil {
+		t.Errorf("SetConfig with valid options failed: %v", err)
+	}
+
+	err = e.SetConfig(&config.Extractor{
+		Enable:  true,
+		Options: map[string]any{"unknown": "value"},
+	})
+	if err == nil {
+		t.Error("SetConfig with unknown option should return error")
+	}
+}

--- a/server/indexer/indexer.go
+++ b/server/indexer/indexer.go
@@ -686,6 +686,9 @@ func resFromHit(h *search.DocumentMatch) *document.Document {
 	}
 	for k, v := range h.Fields {
 		if mk, found := strings.CutPrefix(k, "metadata."); found {
+			if d.Metadata == nil {
+				d.Metadata = make(map[string]any)
+			}
 			d.Metadata[mk] = v
 		}
 	}

--- a/webui/app/src/lib/components/VideoPreview.svelte
+++ b/webui/app/src/lib/components/VideoPreview.svelte
@@ -1,0 +1,180 @@
+<script lang="ts">
+  import { Button } from '@hister/components/ui/button';
+  import { Badge } from '@hister/components/ui/badge';
+  import { Separator } from '@hister/components/ui/separator';
+  import { Clock, Calendar, Eye, ThumbsUp, ExternalLink } from 'lucide-svelte';
+
+  interface Chapter {
+    title: string;
+    startTime: string;
+  }
+
+  interface Playlist {
+    title: string;
+    index: number;
+    count: number;
+  }
+
+  interface VideoData {
+    title: string;
+    uploader: string;
+    duration: number;
+    durationFormatted: string;
+    uploadDate: string;
+    viewCount: number;
+    likeCount: number;
+    categories: string[];
+    tags: string[];
+    description: string;
+    thumbnail: string;
+    chapters?: Chapter[];
+    playlist?: Playlist;
+    transcript?: string;
+    webpageUrl: string;
+  }
+
+  let { data }: { data: VideoData } = $props();
+
+  let showTranscript = $state(false);
+
+  function formatNumber(n: number): string {
+    if (n >= 1_000_000_000) return (n / 1_000_000_000).toFixed(1) + 'B';
+    if (n >= 1_000_000) return (n / 1_000_000).toFixed(1) + 'M';
+    if (n >= 1_000) return (n / 1_000).toFixed(1) + 'K';
+    return n.toString();
+  }
+</script>
+
+<article class="not-prose font-inter space-y-4">
+  {#if data.thumbnail}
+    <figure>
+      <img
+        src={data.thumbnail}
+        alt={data.title}
+        class="border-brutal-border w-full border-2 object-cover"
+      />
+      <figcaption class="mt-2">
+        <Button
+          variant="outline"
+          class="brutal-press font-outfit w-full text-sm font-bold tracking-wide uppercase"
+          onclick={() => window.open(data.webpageUrl, '_blank', 'noopener,noreferrer')}
+        >
+          <ExternalLink class="mr-1 size-4" />
+          Open Externally
+        </Button>
+      </figcaption>
+    </figure>
+  {/if}
+
+  {#if data.uploader}
+    <p class="font-outfit text-text-brand text-base font-bold">{data.uploader}</p>
+  {/if}
+
+  <dl class="text-text-brand-secondary flex flex-wrap gap-x-4 gap-y-1.5 text-xs">
+    {#if data.durationFormatted}
+      <div class="flex items-center gap-1">
+        <Clock class="text-hister-teal size-3.5" />
+        <dt class="sr-only">Duration</dt>
+        <dd>{data.durationFormatted}</dd>
+      </div>
+    {/if}
+    {#if data.uploadDate}
+      <div class="flex items-center gap-1">
+        <Calendar class="text-hister-teal size-3.5" />
+        <dt class="sr-only">Uploaded</dt>
+        <dd>{data.uploadDate}</dd>
+      </div>
+    {/if}
+    {#if data.viewCount}
+      <div class="flex items-center gap-1">
+        <Eye class="text-hister-teal size-3.5" />
+        <dt class="sr-only">Views</dt>
+        <dd>{formatNumber(data.viewCount)} views</dd>
+      </div>
+    {/if}
+    {#if data.likeCount}
+      <div class="flex items-center gap-1">
+        <ThumbsUp class="text-hister-teal size-3.5" />
+        <dt class="sr-only">Likes</dt>
+        <dd>{formatNumber(data.likeCount)} likes</dd>
+      </div>
+    {/if}
+  </dl>
+
+  {#if data.playlist}
+    <aside class="bg-muted-surface border-border-brand border px-3 py-1.5 text-xs">
+      <strong>Playlist:</strong>
+      {data.playlist.title}
+      {#if data.playlist.index && data.playlist.count}
+        <span class="text-text-brand-muted">({data.playlist.index}/{data.playlist.count})</span>
+      {/if}
+    </aside>
+  {/if}
+
+  {#if data.categories?.length || data.tags?.length}
+    <nav class="flex flex-wrap gap-1.5" aria-label="Video tags">
+      {#each data.categories || [] as cat}
+        <Badge
+          variant="secondary"
+          class="bg-hister-indigo/15 text-hister-indigo border-hister-indigo/30 text-[11px]"
+          >{cat}</Badge
+        >
+      {/each}
+      {#each data.tags || [] as tag}
+        <Badge variant="outline" class="text-hister-teal border-hister-teal/30 text-[11px]"
+          >{tag}</Badge
+        >
+      {/each}
+    </nav>
+  {/if}
+
+  {#if data.chapters?.length}
+    <Separator />
+    <section>
+      <h3 class="font-outfit text-text-brand mb-2 text-sm font-bold tracking-wide uppercase">
+        Chapters
+      </h3>
+      <ol class="list-none space-y-0.5 pl-0">
+        {#each data.chapters as ch}
+          <li class="text-text-brand-secondary flex gap-3 text-xs">
+            <code class="text-hister-teal w-14 shrink-0">{ch.startTime}</code>
+            <span class="text-text-brand">{ch.title}</span>
+          </li>
+        {/each}
+      </ol>
+    </section>
+  {/if}
+
+  <!-- Description -->
+  {#if data.description}
+    <Separator />
+    <section>
+      <h3 class="font-outfit text-text-brand mb-2 text-sm font-bold tracking-wide uppercase">
+        Description
+      </h3>
+      <p class="text-text-brand-secondary text-xs leading-relaxed whitespace-pre-wrap">
+        {data.description}
+      </p>
+    </section>
+  {/if}
+
+  {#if data.transcript}
+    <Separator />
+    <section>
+      <Button
+        variant="link"
+        class="font-outfit text-text-brand p-0 text-sm font-bold tracking-wide uppercase"
+        onclick={() => (showTranscript = !showTranscript)}
+      >
+        {showTranscript ? 'Hide Transcript' : 'Show Transcript'}
+      </Button>
+      {#if showTranscript}
+        <p
+          class="text-text-brand-secondary mt-2 max-h-80 overflow-y-auto text-xs leading-relaxed whitespace-pre-wrap"
+        >
+          {data.transcript}
+        </p>
+      {/if}
+    </section>
+  {/if}
+</article>

--- a/webui/app/src/routes/+page.svelte
+++ b/webui/app/src/routes/+page.svelte
@@ -28,6 +28,7 @@
   import * as DropdownMenu from '@hister/components/ui/dropdown-menu';
   import * as Tooltip from '@hister/components/ui/tooltip';
   import { ScrollArea } from '@hister/components/ui/scroll-area';
+  import VideoPreview from '$lib/components/VideoPreview.svelte';
   import { Kbd } from '@hister/components/ui/kbd';
   import {
     Search,
@@ -81,15 +82,28 @@
   let showPopup = $state(false);
   let popupTitle = $state('');
   let popupContent = $state('');
+  let popupTemplate = $state('');
+  let popupTemplateData = $state<any>(null);
   let actionsQuery = $state('');
   let actionsMessage: string | null = $state(null);
   let actionsError = $state(false);
   let showActionsForResult: string | null = $state(null);
 
+  function parseTemplateData(content: string): any | null {
+    try {
+      return JSON.parse(content);
+    } catch (e) {
+      console.warn('Failed to parse template data:', e);
+      return null;
+    }
+  }
+
   // Desktop split-pane readability panel state
   let panelUrl = $state('');
   let panelTitle = $state('');
   let panelContent = $state('');
+  let panelTemplate = $state('');
+  let panelTemplateData = $state<any>(null);
   let panelAdded = $state<number | null>(null);
   let panelLoading = $state(false);
   let isDesktop = $state(false);
@@ -277,6 +291,8 @@
     panelAdded = null;
     panelLoading = true;
     panelContent = '';
+    panelTemplate = '';
+    panelTemplateData = null;
     try {
       const resp = await apiFetch(`/preview?url=${encodeURIComponent(url)}`);
       if (!resp.ok) {
@@ -285,7 +301,10 @@
         const data = await resp.json();
         panelTitle = data.title || title;
         panelAdded = data.added ?? null;
-        panelContent = data.content || '<p>No content available</p>';
+        panelTemplate = data.template || '';
+        panelTemplateData = panelTemplate === 'video' ? parseTemplateData(data.content) : null;
+        panelContent =
+          panelTemplate === 'video' ? '' : data.content || '<p>No content available</p>';
       }
     } catch (err) {
       panelContent = `<p class="text-hister-rose">Failed to load: ${err}</p>`;
@@ -315,7 +334,9 @@
       }
       const data = await resp.json();
       popupTitle = data.title || title;
-      popupContent = data.content || '<p>No content available</p>';
+      popupTemplate = data.template || '';
+      popupTemplateData = popupTemplate === 'video' ? parseTemplateData(data.content) : null;
+      popupContent = popupTemplate === 'video' ? '' : data.content || '<p>No content available</p>';
       showPopup = true;
     } catch (err) {
       popupTitle = 'Error';
@@ -692,7 +713,11 @@
       >
     </Dialog.Header>
     <div class="font-inter text-text-brand-secondary prose max-w-none text-sm">
-      {@html popupContent}
+      {#if popupTemplate === 'video' && popupTemplateData}
+        <VideoPreview data={popupTemplateData} />
+      {:else}
+        {@html popupContent}
+      {/if}
     </div>
   </Dialog.Content>
 </Dialog.Root>
@@ -1222,7 +1247,7 @@
             <div class="flex flex-1 items-center justify-center">
               <span class="font-inter text-text-brand-muted text-sm">Loading…</span>
             </div>
-          {:else if panelContent}
+          {:else if panelContent || panelTemplateData}
             <div
               class="border-border-brand-muted flex shrink-0 items-start gap-2 border-b-[2px] px-4 py-2.5"
             >
@@ -1255,7 +1280,11 @@
               <div
                 class="font-inter text-text-brand-secondary prose dark:prose-invert prose-a:text-hister-teal max-w-none p-4 text-sm"
               >
-                {@html panelContent}
+                {#if panelTemplate === 'video' && panelTemplateData}
+                  <VideoPreview data={panelTemplateData} />
+                {:else}
+                  {@html panelContent}
+                {/if}
               </div>
             </ScrollArea>
           {:else}

--- a/webui/ext/src/content/content.ts
+++ b/webui/ext/src/content/content.ts
@@ -26,7 +26,12 @@ if (isFirefox) {
 } else {
   window.addEventListener('load', extract);
 }
-window.addEventListener('navigatesuccess', update);
+
+// Detect SPA navigations via the Navigation API (fires on window.navigation,
+// not on window). Falls back to polling for browsers without it.
+if (typeof window.navigation !== 'undefined') {
+  window.navigation.addEventListener('navigatesuccess', update);
+}
 
 function extract(sendResponse, actionType) {
   if (!isContextValid()) return;
@@ -48,9 +53,11 @@ function extract(sendResponse, actionType) {
       sendResponse(resp);
     }
     if (!resp || resp.error || resp.status_code != 201) {
-      console.log('failed to submit page data, stopping extraction', resp);
-      return;
+      console.log('failed to submit page data', resp);
     }
+    // Always start polling for URL/content changes, even if the initial
+    // submission failed (e.g. skip rule). The page may navigate to a
+    // non-skipped URL later (SPA).
     setTimeout(update, sleepTime);
   });
 }


### PR DESCRIPTION
Add a new yt-dlp extractor that fetches video metadata (title, description, chapters, thumbnails, subtitles) for YouTube, Vimeo, TikTok, and other supported platforms

The extractor is **disabled by default** and requires `yt-dlp` to be installed

Enable it in config (e.g):

```yaml
extractors:
  ytdlp:
    enable: true
    options:
      binary: yt-dlp               # path to binary
      timeout: 15                  # seconds
      fetch_subtitles: false       # download & index transcripts
      sub_language: en
      cookies_file: ""             # path to cookies.txt
      cookies_from_browser: ""     # e.g. "chrome"
      extra_args: []               # additional CLI flags
```
