### PR TITLE
[fix] dedupe priority results vs standard search results

### DIFF
--- a/server/model/history.go
+++ b/server/model/history.go
@@ -35,6 +35,7 @@ type HistoryLink struct {
 type URLCount struct {
 	URL   string `json:"url"`
 	Title string `json:"title"`
+	Text  string `gorm:"-" json:"text,omitempty"`
 	Count uint   `json:"count"`
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -721,13 +721,16 @@ func doSearch(query *indexer.Query, cfg *config.Config, rules *config.Rules, use
 	hr, err := model.GetURLsByQuery(userID, oq)
 	if err == nil && len(hr) > 0 {
 		res.History = hr
-		priorityURLs := make(map[string]struct{}, len(hr))
+		priorityByURL := make(map[string]*model.URLCount, len(hr))
 		for _, h := range hr {
-			priorityURLs[h.URL] = struct{}{}
+			priorityByURL[h.URL] = h
 		}
 		filtered := res.Documents[:0]
 		for _, d := range res.Documents {
-			if _, ok := priorityURLs[d.URL]; ok {
+			if h, ok := priorityByURL[d.URL]; ok {
+				if h.Text == "" {
+					h.Text = d.Text
+				}
 				continue
 			}
 			filtered = append(filtered, d)

--- a/server/server.go
+++ b/server/server.go
@@ -721,6 +721,18 @@ func doSearch(query *indexer.Query, cfg *config.Config, rules *config.Rules, use
 	hr, err := model.GetURLsByQuery(userID, oq)
 	if err == nil && len(hr) > 0 {
 		res.History = hr
+		priorityURLs := make(map[string]struct{}, len(hr))
+		for _, h := range hr {
+			priorityURLs[h.URL] = struct{}{}
+		}
+		filtered := res.Documents[:0]
+		for _, d := range res.Documents {
+			if _, ok := priorityURLs[d.URL]; ok {
+				continue
+			}
+			filtered = append(filtered, d)
+		}
+		res.Documents = filtered
 	}
 	if oq != "" {
 		res.QuerySuggestion = model.GetQuerySuggestion(userID, oq)

--- a/webui/app/src/lib/types.ts
+++ b/webui/app/src/lib/types.ts
@@ -6,4 +6,5 @@ export interface HistoryItem {
   updated_at?: string;
   added?: number;
   favicon?: string;
+  text?: string;
 }

--- a/webui/app/src/routes/+page.svelte
+++ b/webui/app/src/routes/+page.svelte
@@ -1028,6 +1028,13 @@
                         <Eye class="size-3" /><span>view</span>
                       </Button>
                     </div>
+                    {#if r.text}
+                      <p
+                        class="font-inter text-text-brand-secondary text-sm leading-[1.4] md:text-base"
+                      >
+                        {@html r.text}
+                      </p>
+                    {/if}
                   </div>
                 </article>
                 {#if showActionsForResult === 'history:' + r.url}


### PR DESCRIPTION
Closes #2

When a URL appears in both the priority (history) list and the standard search results, drop the standard entry so it isn't shown twice. The priority entry keeps its position and styling