### PR TITLE
[enh] add opensearch suggestions endpoint

### DIFF
--- a/server/api.go
+++ b/server/api.go
@@ -67,6 +67,14 @@ func init() {
 			Handler:      serveSearch,
 			Description:  "Search websocket endpoint",
 		},
+		{
+			Name:         "Suggest",
+			Path:         "/suggest",
+			Method:       GET,
+			CSRFRequired: false,
+			Handler:      serveSuggest,
+			Description:  "OpenSearch suggestions endpoint",
+		},
 		// tmp added for backward compatibility
 		{
 			Name:         "Add",

--- a/server/server.go
+++ b/server/server.go
@@ -1099,6 +1099,15 @@ func serveOpensearch(c *webContext) {
 const suggestLimit = 10
 
 func serveSuggest(c *webContext) {
+	// Sec-Fetch-Site is set by browsers and forbidden to JS, so a cross-site
+	// fetch() can't spoof it. Browser address-bar flows either omit the header
+	// (Firefox) or send "none" (Chrome); reject anything explicitly cross-site.
+	switch c.Request.Header.Get("Sec-Fetch-Site") {
+	case "", "none", "same-origin", "same-site":
+	default:
+		c.Response.WriteHeader(http.StatusForbidden)
+		return
+	}
 	q := c.Request.URL.Query().Get("q")
 	suggestions := []string{}
 	if q != "" {

--- a/server/server.go
+++ b/server/server.go
@@ -213,6 +213,7 @@ func registerEndpoints(cfg *config.Config) http.Handler {
 	mux.HandleFunc("GET /static/", createHandler(cfg, serveStatic))
 	mux.HandleFunc("GET /favicon.ico", createHandler(cfg, serveFavicon))
 	mux.HandleFunc("GET /opensearch.xml", createHandler(cfg, serveOpensearch))
+	mux.HandleFunc("GET /suggest", createHandler(cfg, serveSuggest))
 	mux.HandleFunc("/", createHandler(cfg, serveSPA))
 	// If base_url contains a non-root path prefix (e.g. https://x.com/subfolder),
 	// accept requests both with and without that prefix.
@@ -1088,10 +1089,41 @@ func serveOpensearch(c *webContext) {
   <ShortName>Hister</ShortName>
   <Description>Search your history with Hister</Description>
   <Url type="text/html" template="%s/?q={searchTerms}"/>
-</OpenSearchDescription>`, baseURL)
+  <Url type="application/x-suggestions+json" template="%s/suggest?q={searchTerms}"/>
+</OpenSearchDescription>`, baseURL, baseURL)
 	c.Response.Header().Set("Content-Type", "application/xml")
 	if _, err := c.Response.Write([]byte(xml)); err != nil {
 		log.Warn().Err(err).Msg("failed to write opensearch response")
+	}
+}
+
+const suggestLimit = 10
+
+func serveSuggest(c *webContext) {
+	q := c.Request.URL.Query().Get("q")
+	suggestions := []string{}
+	if q != "" {
+		res, err := indexer.Search(c.Config, &indexer.Query{
+			Text:   c.effectiveRules().ResolveAliases(q),
+			UserID: c.UserID,
+			Limit:  suggestLimit,
+		})
+		if err != nil {
+			log.Warn().Err(err).Msg("suggest search failed")
+		}
+		if res != nil {
+			for _, d := range res.Documents {
+				title := strings.TrimSpace(d.Title)
+				if title == "" {
+					title = d.URL
+				}
+				suggestions = append(suggestions, title)
+			}
+		}
+	}
+	c.Response.Header().Set("Content-Type", "application/x-suggestions+json")
+	if err := json.NewEncoder(c.Response).Encode([]any{q, suggestions}); err != nil {
+		log.Warn().Err(err).Msg("failed to write suggest response")
 	}
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -213,7 +213,6 @@ func registerEndpoints(cfg *config.Config) http.Handler {
 	mux.HandleFunc("GET /static/", createHandler(cfg, serveStatic))
 	mux.HandleFunc("GET /favicon.ico", createHandler(cfg, serveFavicon))
 	mux.HandleFunc("GET /opensearch.xml", createHandler(cfg, serveOpensearch))
-	mux.HandleFunc("GET /suggest", createHandler(cfg, serveSuggest))
 	mux.HandleFunc("/", createHandler(cfg, serveSPA))
 	// If base_url contains a non-root path prefix (e.g. https://x.com/subfolder),
 	// accept requests both with and without that prefix.
@@ -1121,8 +1120,13 @@ func serveSuggest(c *webContext) {
 			}
 		}
 	}
+	jr, err := json.Marshal([]any{q, suggestions})
+	if err != nil {
+		log.Warn().Err(err).Msg("failed to marshal suggest response")
+		return
+	}
 	c.Response.Header().Set("Content-Type", "application/x-suggestions+json")
-	if err := json.NewEncoder(c.Response).Encode([]any{q, suggestions}); err != nil {
+	if _, err := c.Response.Write(jr); err != nil {
 		log.Warn().Err(err).Msg("failed to write suggest response")
 	}
 }


### PR DESCRIPTION
Closes #14

Expose /suggest returning the OpenSearch suggestions JSON format (`[query, [title, ...]]`) so browsers like Firefox can fetch live completions from their search bar. The opensearch.xml descriptor advertises the new URL alongside the existing HTML search template.