### PR TITLE
[ci] offer auto-format via `@github-actions format` PR comment

### DIFF
--- a/.github/scripts/offer-format.sh
+++ b/.github/scripts/offer-format.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MARKER='<!-- hister-format-prompt -->'
+BODY="$MARKER
+Formatting check failed. Comment \`@github-actions format\` to auto-fix and push to this PR.
+
+- Only the repo owner or the PR author can trigger this.
+- For PRs from forks, **Allow edits from maintainers** must be enabled."
+
+EXISTING=$(gh api "repos/$REPO/issues/$PR/comments" --paginate \
+  --jq ".[] | select(.body | startswith(\"$MARKER\")) | .id" | head -n1)
+
+if [ -n "$EXISTING" ]; then
+  gh api -X PATCH "repos/$REPO/issues/comments/$EXISTING" -f body="$BODY" >/dev/null
+else
+  gh api -X POST "repos/$REPO/issues/$PR/comments" -f body="$BODY" >/dev/null
+fi

--- a/.github/workflows/format-on-demand.yml
+++ b/.github/workflows/format-on-demand.yml
@@ -1,0 +1,183 @@
+# Auto-format on PR comment.
+#
+# Triggered when an authorized user posts a comment that STARTS with
+# `@github-actions format` on a PR. Runs prettier + golangci-lint --fix,
+# commits, and pushes to the PR branch.
+#
+
+name: Format on demand
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: format-on-demand-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  format:
+    if: >
+      github.event.issue.pull_request &&
+      startsWith(github.event.comment.body, '@github-actions format') &&
+      (github.event.comment.user.login == github.repository_owner ||
+       github.event.comment.user.login == github.event.issue.user.login)
+    runs-on: ubuntu-latest
+    steps:
+      - name: React 👀 to trigger comment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api -X POST \
+            "repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions" \
+            -f content=eyes >/dev/null
+
+      - name: Generate app token
+        id: app-token
+        if: vars.FORMAT_BOT_APP_ID != ''
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.FORMAT_BOT_APP_ID }}
+          private-key: ${{ secrets.FORMAT_BOT_APP_PRIVATE_KEY }}
+
+      - name: Fetch PR metadata
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api "repos/${{ github.repository }}/pulls/${{ github.event.issue.number }}" > pr.json
+          {
+            echo "head_ref=$(jq -r .head.ref pr.json)"
+            echo "head_repo=$(jq -r .head.repo.full_name pr.json)"
+            echo "head_sha=$(jq -r .head.sha pr.json)"
+            echo "base_repo=$(jq -r .base.repo.full_name pr.json)"
+            echo "maintainer_can_modify=$(jq -r .maintainer_can_modify pr.json)"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Pick token
+        id: token
+        env:
+          APP_TOKEN: ${{ steps.app-token.outputs.token }}
+          FALLBACK: ${{ secrets.GITHUB_TOKEN }}
+          IS_FORK: ${{ steps.pr.outputs.head_repo != steps.pr.outputs.base_repo }}
+        run: |
+          if [ "$IS_FORK" = "true" ] || [ -z "$APP_TOKEN" ]; then
+            echo "value=$FALLBACK" >> "$GITHUB_OUTPUT"
+          else
+            echo "::add-mask::$APP_TOKEN"
+            echo "value=$APP_TOKEN" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Bail if fork without "Allow edits from maintainers"
+        if: >
+          steps.pr.outputs.head_repo != steps.pr.outputs.base_repo &&
+          steps.pr.outputs.maintainer_can_modify != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api -X POST \
+            "repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/comments" \
+            -f body="Can't push to your fork — please enable **Allow edits from maintainers** on this PR and re-comment \`@github-actions format\`."
+          gh api -X POST \
+            "repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions" \
+            -f content=confused >/dev/null
+          exit 1
+
+      - name: Checkout PR head
+        uses: actions/checkout@v6.0.2
+        with:
+          repository: ${{ steps.pr.outputs.head_repo }}
+          ref: ${{ steps.pr.outputs.head_ref }}
+          token: ${{ steps.token.outputs.value }}
+          fetch-depth: 0
+
+      - name: Set up Node
+        uses: actions/setup-node@v6.3.0
+        with:
+          node-version: latest
+
+      - name: Set up Go
+        uses: actions/setup-go@v6.3.0
+        with:
+          go-version: 'stable'
+
+      - name: Install npm deps
+        run: npm ci
+
+      - name: Build SPA (needed for golangci-lint embeds)
+        run: sh webui/build.sh
+
+      - name: Run prettier
+        run: npm run format
+
+      - name: Run golangci-lint --fix
+        uses: golangci/golangci-lint-action@v9.2.0
+        with:
+          args: --fix
+
+      - name: Commit & push
+        id: commit
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -A
+          if git diff --cached --quiet; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          git commit -m "style: auto-format via @github-actions format"
+          git push origin HEAD:"${{ steps.pr.outputs.head_ref }}"
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Hide stale format-prompt comments (always)
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          MARKER='<!-- hister-format-prompt -->'
+          gh api \
+            "repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/comments" \
+            --paginate \
+            --jq ".[] | select(.body | startswith(\"$MARKER\")) | .node_id" \
+          | while read -r NODE; do
+              [ -z "$NODE" ] && continue
+              gh api graphql -f query='
+                mutation($id:ID!){
+                  minimizeComment(input:{subjectId:$id, classifier:RESOLVED}){
+                    minimizedComment { isMinimized }
+                  }
+                }' -f id="$NODE" >/dev/null || true
+            done
+
+      - name: Hide trigger comment (only on success)
+        if: success()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE: ${{ github.event.comment.node_id }}
+        run: |
+          gh api graphql -f query='
+            mutation($id:ID!){
+              minimizeComment(input:{subjectId:$id, classifier:RESOLVED}){
+                minimizedComment { isMinimized }
+              }
+            }' -f id="$NODE" >/dev/null || true
+
+      - name: React result on trigger comment
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ "${{ steps.commit.outputs.changed }}" = "true" ]; then
+            content=rocket
+          elif [ "${{ steps.commit.outputs.changed }}" = "false" ]; then
+            content="+1"
+          else
+            content=confused
+          fi
+          gh api -X POST \
+            "repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions" \
+            -f content="$content" >/dev/null

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,6 +7,9 @@ jobs:
   golangci-lint:
     name: golangci-lint
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.2
@@ -43,9 +46,20 @@ jobs:
         if: steps.changes.outputs.skip != 'true'
         uses: golangci/golangci-lint-action@v9.2.0
 
+      - name: Offer auto-format on failure
+        if: failure() && steps.changes.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: .github/scripts/offer-format.sh
+
   npm-format:
     name: NPM formatting
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.2
@@ -84,6 +98,14 @@ jobs:
             git diff
             exit 1
           fi
+
+      - name: Offer auto-format on failure
+        if: failure() && steps.changes.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: .github/scripts/offer-format.sh
 
   no-merge-commits:
     name: No merge commits


### PR DESCRIPTION
When the lint workflow's Go or npm format checks fail, the bot posts a prompt inviting the repo owner or PR author to reply with `@github-actions format`

A new workflow picks up the mention, runs prettier + golangci-lint --fix on the PR head, commits, pushes, then minimizes the stale prompt and (on success) the trigger comment

----

@asciimoo For the format-fix commit to **re-trigger `PR Lint`** on same-repo PRs, pushes must be authenticated as a GitHub App rather than `GITHUB_TOKEN` (the latter intentionally does not trigger workflows, to prevent loops)

[Create a GitHub App](https://github.com/settings/apps/new) for webhook uncheck **Active** (we don't need events), under **Repository permissions** give it **Contents: Read & write** and **Pull requests: Read & write**, and for "Where can this app be installed" pick **Only on this account**

After creation, on the App's **General** settings page, note the **App ID** (shown under "About", alongside Client ID) and click **Generate a private key** to download the PEM. Then in the left sidebar hit **Install App** -> **Install** next to your account -> **Only select repositories** -> pick `asciimoo/hister`

In [repo settings](https://github.com/asciimoo/hister/settings) -> **Secrets and variables** -> **Actions**:

**Variables** tab -> **New repository variable**: `FORMAT_BOT_APP_ID` = *(the numeric app id)*

**Secrets** tab -> **New repository secret**: `FORMAT_BOT_APP_PRIVATE_KEY` = *(paste the full PEM contents, including the `-----BEGIN/END-----` lines)*

That's it, the workflow auto-detects these and uses them
