### PR TITLE
[enh] add JSON-LD metadata extractor

### DIFF
--- a/server/extractor/extractor.go
+++ b/server/extractor/extractor.go
@@ -17,6 +17,7 @@ import (
 	"github.com/asciimoo/hister/config"
 	"github.com/asciimoo/hister/server/document"
 	"github.com/asciimoo/hister/server/extractor/extractors/godoc"
+	"github.com/asciimoo/hister/server/extractor/extractors/jsonld"
 	"github.com/asciimoo/hister/server/extractor/extractors/stackoverflow"
 	"github.com/asciimoo/hister/server/extractor/extractors/ytdlp"
 	"github.com/asciimoo/hister/server/types"
@@ -85,6 +86,7 @@ func List() []ExtractorInfo {
 }
 
 var extractors = []Extractor{
+	&jsonld.JSONLDExtractor{},
 	&stackoverflow.StackoverflowExtractor{},
 	&godoc.GoDocExtractor{},
 	&ytdlp.YtdlpExtractor{},

--- a/server/extractor/extractors/jsonld/jsonld.go
+++ b/server/extractor/extractors/jsonld/jsonld.go
@@ -1,0 +1,283 @@
+// Package jsonld provides an extractor that parses application/ld+json
+// script tags and writes normalized metadata to the document.
+package jsonld
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/rs/zerolog/log"
+	"golang.org/x/net/html"
+
+	"github.com/asciimoo/hister/config"
+	"github.com/asciimoo/hister/server/document"
+	"github.com/asciimoo/hister/server/types"
+)
+
+// JSONLDExtractor extracts schema.org metadata from JSON-LD script tags.
+type JSONLDExtractor struct {
+	cfg *config.Extractor
+}
+
+// Name returns the extractor's identifier.
+func (e *JSONLDExtractor) Name() string {
+	return "JSONLD"
+}
+
+// Description returns a short summary of what this extractor does.
+func (e *JSONLDExtractor) Description() string {
+	return "Parses application/ld+json script tags and stores normalized schema.org metadata on the document."
+}
+
+// GetConfig returns the extractor's current configuration.
+func (e *JSONLDExtractor) GetConfig() *config.Extractor {
+	if e.cfg == nil {
+		return &config.Extractor{Enable: true, Options: map[string]any{}}
+	}
+	return e.cfg
+}
+
+// SetConfig applies cfg to the extractor. Returns an error for unknown options.
+func (e *JSONLDExtractor) SetConfig(c *config.Extractor) error {
+	for k := range c.Options {
+		return fmt.Errorf("unknown option %q", k)
+	}
+	e.cfg = c
+	return nil
+}
+
+// Match returns true when the document has non-empty HTML.
+func (e *JSONLDExtractor) Match(d *document.Document) bool {
+	return len(d.HTML) > 0
+}
+
+// preferredTypes lists @type values that make a node a good source for
+// normalized metadata, in descending priority order.
+var preferredTypes = []string{
+	"Article", "NewsArticle", "BlogPosting",
+	"WebPage", "Product", "Recipe",
+	"VideoObject", "Event", "Person", "Organization",
+}
+
+// Extract parses every application/ld+json script block, flattens @graph/array
+// wrappers and writes normalized fields to d.Metadata. Always returns Continue
+// so body-text extractors still run.
+func (e *JSONLDExtractor) Extract(d *document.Document) (types.ExtractorState, error) {
+	blobs := findJSONLDBlobs(d.HTML)
+	if len(blobs) == 0 {
+		return types.ExtractorContinue, nil
+	}
+
+	var nodes []map[string]any
+	for _, blob := range blobs {
+		var parsed any
+		if err := json.Unmarshal([]byte(blob), &parsed); err != nil {
+			log.Debug().Err(err).Str("URL", d.URL).Msg("Failed to parse JSON-LD blob")
+			continue
+		}
+		nodes = append(nodes, flatten(parsed)...)
+	}
+	if len(nodes) == 0 {
+		return types.ExtractorContinue, nil
+	}
+
+	if d.Metadata == nil {
+		d.Metadata = make(map[string]any)
+	}
+	d.Metadata["jsonld"] = nodes
+
+	best := pickBest(nodes)
+	setString(d.Metadata, "jsonld_type", typeString(best))
+	setString(d.Metadata, "jsonld_headline", firstString(best, "headline", "name"))
+	setString(d.Metadata, "jsonld_description", firstString(best, "description"))
+	setString(d.Metadata, "jsonld_author", authorName(best["author"]))
+	setString(d.Metadata, "jsonld_published", firstString(best, "datePublished"))
+	setString(d.Metadata, "jsonld_modified", firstString(best, "dateModified"))
+	setString(d.Metadata, "jsonld_image", imageURL(best["image"]))
+
+	return types.ExtractorContinue, nil
+}
+
+// Preview is not implemented; Readability/Default handle rendering.
+func (e *JSONLDExtractor) Preview(d *document.Document) (types.PreviewResponse, types.ExtractorState, error) {
+	return types.PreviewResponse{}, types.ExtractorContinue, nil
+}
+
+// findJSONLDBlobs returns the raw text content of every
+// <script type="application/ld+json"> element in rawHTML.
+func findJSONLDBlobs(rawHTML string) []string {
+	z := html.NewTokenizer(strings.NewReader(rawHTML))
+	var blobs []string
+	var buf bytes.Buffer
+	capturing := false
+	for {
+		tt := z.Next()
+		switch tt {
+		case html.ErrorToken:
+			if errors.Is(z.Err(), io.EOF) {
+				return blobs
+			}
+			return blobs
+		case html.StartTagToken:
+			tn, hasAttr := z.TagName()
+			if string(tn) != "script" || !hasAttr {
+				continue
+			}
+			if isJSONLDScript(z) {
+				capturing = true
+				buf.Reset()
+			}
+		case html.TextToken:
+			if capturing {
+				buf.Write(z.Text())
+			}
+		case html.EndTagToken:
+			if !capturing {
+				continue
+			}
+			tn, _ := z.TagName()
+			if string(tn) == "script" {
+				s := strings.TrimSpace(buf.String())
+				if s != "" {
+					blobs = append(blobs, s)
+				}
+				capturing = false
+				buf.Reset()
+			}
+		}
+	}
+}
+
+func isJSONLDScript(z *html.Tokenizer) bool {
+	for {
+		key, val, more := z.TagAttr()
+		if string(key) == "type" && strings.EqualFold(strings.TrimSpace(string(val)), "application/ld+json") {
+			return true
+		}
+		if !more {
+			return false
+		}
+	}
+}
+
+// flatten turns an arbitrary JSON-LD payload into a flat slice of object
+// nodes, unwrapping @graph wrappers and top-level arrays.
+func flatten(v any) []map[string]any {
+	switch t := v.(type) {
+	case map[string]any:
+		if g, ok := t["@graph"]; ok {
+			return flatten(g)
+		}
+		return []map[string]any{t}
+	case []any:
+		var out []map[string]any
+		for _, item := range t {
+			out = append(out, flatten(item)...)
+		}
+		return out
+	}
+	return nil
+}
+
+// pickBest returns the first node whose @type matches one of preferredTypes,
+// falling back to the first node.
+func pickBest(nodes []map[string]any) map[string]any {
+	for _, want := range preferredTypes {
+		for _, n := range nodes {
+			if typeMatches(n["@type"], want) {
+				return n
+			}
+		}
+	}
+	return nodes[0]
+}
+
+func typeMatches(v any, want string) bool {
+	switch t := v.(type) {
+	case string:
+		return t == want
+	case []any:
+		for _, item := range t {
+			if s, ok := item.(string); ok && s == want {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func typeString(n map[string]any) string {
+	switch t := n["@type"].(type) {
+	case string:
+		return t
+	case []any:
+		for _, item := range t {
+			if s, ok := item.(string); ok && s != "" {
+				return s
+			}
+		}
+	}
+	return ""
+}
+
+func firstString(n map[string]any, keys ...string) string {
+	for _, k := range keys {
+		if s, ok := n[k].(string); ok {
+			if s = strings.TrimSpace(s); s != "" {
+				return s
+			}
+		}
+	}
+	return ""
+}
+
+// authorName extracts a human-readable author name from string, object, or
+// array shapes.
+func authorName(v any) string {
+	switch t := v.(type) {
+	case string:
+		return strings.TrimSpace(t)
+	case map[string]any:
+		if s, ok := t["name"].(string); ok {
+			return strings.TrimSpace(s)
+		}
+	case []any:
+		for _, item := range t {
+			if s := authorName(item); s != "" {
+				return s
+			}
+		}
+	}
+	return ""
+}
+
+// imageURL extracts an image URL from string, object (schema.org ImageObject),
+// or array shapes.
+func imageURL(v any) string {
+	switch t := v.(type) {
+	case string:
+		return strings.TrimSpace(t)
+	case map[string]any:
+		if s, ok := t["url"].(string); ok {
+			return strings.TrimSpace(s)
+		}
+	case []any:
+		for _, item := range t {
+			if s := imageURL(item); s != "" {
+				return s
+			}
+		}
+	}
+	return ""
+}
+
+func setString(m map[string]any, key, value string) {
+	if value == "" {
+		return
+	}
+	m[key] = value
+}

--- a/server/extractor/extractors/jsonld/jsonld.go
+++ b/server/extractor/extractors/jsonld/jsonld.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/url"
 	"strings"
 
 	"github.com/rs/zerolog/log"
@@ -15,8 +16,13 @@ import (
 
 	"github.com/asciimoo/hister/config"
 	"github.com/asciimoo/hister/server/document"
+	"github.com/asciimoo/hister/server/sanitizer"
 	"github.com/asciimoo/hister/server/types"
 )
+
+// scriptTypeMarker is the substring we look for to cheaply rule out pages
+// that cannot contain JSON-LD before running the tokenizer.
+const scriptTypeMarker = "application/ld+json"
 
 // JSONLDExtractor extracts schema.org metadata from JSON-LD script tags.
 type JSONLDExtractor struct {
@@ -50,9 +56,11 @@ func (e *JSONLDExtractor) SetConfig(c *config.Extractor) error {
 	return nil
 }
 
-// Match returns true when the document has non-empty HTML.
+// Match reports whether the document's HTML plausibly contains a JSON-LD
+// script. strings.Contains is orders of magnitude cheaper than tokenizing
+// the whole HTML, so pages without JSON-LD skip the extractor entirely.
 func (e *JSONLDExtractor) Match(d *document.Document) bool {
-	return len(d.HTML) > 0
+	return len(d.HTML) > 0 && strings.Contains(d.HTML, scriptTypeMarker)
 }
 
 // preferredTypes lists @type values that make a node a good source for
@@ -91,13 +99,13 @@ func (e *JSONLDExtractor) Extract(d *document.Document) (types.ExtractorState, e
 	d.Metadata["jsonld"] = nodes
 
 	best := pickBest(nodes)
-	setString(d.Metadata, "jsonld_type", typeString(best))
-	setString(d.Metadata, "jsonld_headline", firstString(best, "headline", "name"))
-	setString(d.Metadata, "jsonld_description", firstString(best, "description"))
-	setString(d.Metadata, "jsonld_author", authorName(best["author"]))
-	setString(d.Metadata, "jsonld_published", firstString(best, "datePublished"))
-	setString(d.Metadata, "jsonld_modified", firstString(best, "dateModified"))
-	setString(d.Metadata, "jsonld_image", imageURL(best["image"]))
+	setString(d.Metadata, "jsonld_type", sanitizer.SanitizeText(typeString(best)))
+	setString(d.Metadata, "jsonld_headline", sanitizer.SanitizeText(firstString(best, "headline", "name")))
+	setString(d.Metadata, "jsonld_description", sanitizer.SanitizeText(firstString(best, "description")))
+	setString(d.Metadata, "jsonld_author", sanitizer.SanitizeText(authorName(best["author"])))
+	setString(d.Metadata, "jsonld_published", sanitizer.SanitizeText(firstString(best, "datePublished")))
+	setString(d.Metadata, "jsonld_modified", sanitizer.SanitizeText(firstString(best, "dateModified")))
+	setString(d.Metadata, "jsonld_image", sanitizeURL(imageURL(best["image"])))
 
 	return types.ExtractorContinue, nil
 }
@@ -280,4 +288,24 @@ func setString(m map[string]any, key, value string) {
 		return
 	}
 	m[key] = value
+}
+
+// sanitizeURL keeps only absolute http(s) URLs. Anything else relative
+// paths, data: URIs, javascript: is dropped.
+func sanitizeURL(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ""
+	}
+	u, err := url.Parse(s)
+	if err != nil {
+		return ""
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return ""
+	}
+	if u.Host == "" {
+		return ""
+	}
+	return u.String()
 }

--- a/server/extractor/extractors/jsonld/jsonld.go
+++ b/server/extractor/extractors/jsonld/jsonld.go
@@ -93,6 +93,8 @@ func (e *JSONLDExtractor) Extract(d *document.Document) (types.ExtractorState, e
 		return types.ExtractorContinue, nil
 	}
 
+	sanitizeNodes(nodes)
+
 	if d.Metadata == nil {
 		d.Metadata = make(map[string]any)
 	}
@@ -288,6 +290,42 @@ func setString(m map[string]any, key, value string) {
 		return
 	}
 	m[key] = value
+}
+
+// sanitizeNodes walks the parsed JSON-LD tree in place and runs every
+// string leaf through sanitizer.SanitizeText so the raw dump stored at
+// d.Metadata["jsonld"] cannot carry untrusted HTML into downstream
+// consumers. @-prefixed keys (@context, @type, @id) are left untouched
+// because they are structural identifiers, not free-form text.
+func sanitizeNodes(nodes []map[string]any) {
+	for _, n := range nodes {
+		sanitizeMap(n)
+	}
+}
+
+func sanitizeMap(m map[string]any) {
+	for k, v := range m {
+		if strings.HasPrefix(k, "@") {
+			continue
+		}
+		m[k] = sanitizeValue(v)
+	}
+}
+
+func sanitizeValue(v any) any {
+	switch t := v.(type) {
+	case string:
+		return sanitizer.SanitizeText(t)
+	case map[string]any:
+		sanitizeMap(t)
+		return t
+	case []any:
+		for i, item := range t {
+			t[i] = sanitizeValue(item)
+		}
+		return t
+	}
+	return v
 }
 
 // sanitizeURL keeps only absolute http(s) URLs. Anything else relative

--- a/server/extractor/extractors/jsonld/jsonld_test.go
+++ b/server/extractor/extractors/jsonld/jsonld_test.go
@@ -165,12 +165,59 @@ func TestNoJSONLD(t *testing.T) {
 	}
 }
 
-func TestEmptyHTMLDoesNotMatch(t *testing.T) {
+func TestMatchSkipsPagesWithoutJSONLD(t *testing.T) {
 	e := &JSONLDExtractor{}
 	if e.Match(&document.Document{HTML: ""}) {
 		t.Error("Match should be false for empty HTML")
 	}
-	if !e.Match(&document.Document{HTML: "<html></html>"}) {
-		t.Error("Match should be true for non-empty HTML")
+	if e.Match(&document.Document{HTML: "<html><body><p>hi</p></body></html>"}) {
+		t.Error("Match should be false for HTML without the ld+json marker")
+	}
+	if !e.Match(&document.Document{HTML: `<script type="application/ld+json">{}</script>`}) {
+		t.Error("Match should be true when the marker is present")
+	}
+}
+
+func TestSanitizeHeadlineStripsTagsAndDecodesEntities(t *testing.T) {
+	// A real HTML document must escape </script> inside the blob; browsers
+	// and golang.org/x/net/html both end the enclosing <script> at </script>
+	// regardless of JSON context.
+	const h = `<script type="application/ld+json">{
+		"@type": "Article",
+		"headline": "Smith &amp; Jones: <i>an unlikely<\/i> story",
+		"description": "<script>alert(1)<\/script>plain",
+		"author": {"@type": "Person", "name": "John O&#39;Brien"}
+	}</script>`
+
+	d := extract(t, h)
+	if got, _ := d.Metadata["jsonld_headline"].(string); got != "Smith & Jones: an unlikely story" {
+		t.Errorf("jsonld_headline = %q", got)
+	}
+	if got, _ := d.Metadata["jsonld_description"].(string); got != "plain" {
+		t.Errorf("jsonld_description = %q", got)
+	}
+	if got, _ := d.Metadata["jsonld_author"].(string); got != "John O'Brien" {
+		t.Errorf("jsonld_author = %q", got)
+	}
+}
+
+func TestSanitizeImageRejectsNonHTTP(t *testing.T) {
+	cases := []struct {
+		name, raw, want string
+	}{
+		{"http", `"http://ex.com/a.jpg"`, "http://ex.com/a.jpg"},
+		{"https", `"https://ex.com/a.jpg"`, "https://ex.com/a.jpg"},
+		{"data-uri", `"data:image/png;base64,AAAA"`, ""},
+		{"javascript", `"javascript:alert(1)"`, ""},
+		{"relative", `"/images/a.jpg"`, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			d := extract(t, `<script type="application/ld+json">{"@type":"Article","image":`+tc.raw+`}</script>`)
+			got, _ := d.Metadata["jsonld_image"].(string)
+			if got != tc.want {
+				t.Errorf("jsonld_image = %q, want %q", got, tc.want)
+			}
+		})
 	}
 }

--- a/server/extractor/extractors/jsonld/jsonld_test.go
+++ b/server/extractor/extractors/jsonld/jsonld_test.go
@@ -201,6 +201,37 @@ func TestSanitizeHeadlineStripsTagsAndDecodesEntities(t *testing.T) {
 	}
 }
 
+func TestRawJSONLDDumpIsDeepSanitized(t *testing.T) {
+	const h = `<script type="application/ld+json">{
+		"@type": "Article",
+		"headline": "Smith &amp; Jones",
+		"author": {"@type": "Person", "name": "<b>Jane<\/b>"},
+		"keywords": ["<i>go<\/i>", "hister"]
+	}</script>`
+
+	d := extract(t, h)
+	nodes, _ := d.Metadata["jsonld"].([]map[string]any)
+	if len(nodes) != 1 {
+		t.Fatalf("expected 1 node, got %d", len(nodes))
+	}
+	n := nodes[0]
+	if got, _ := n["headline"].(string); got != "Smith & Jones" {
+		t.Errorf("nodes[0].headline = %q", got)
+	}
+	author, _ := n["author"].(map[string]any)
+	if got, _ := author["name"].(string); got != "Jane" {
+		t.Errorf("nodes[0].author.name = %q", got)
+	}
+	keywords, _ := n["keywords"].([]any)
+	if len(keywords) != 2 || keywords[0] != "go" || keywords[1] != "hister" {
+		t.Errorf("nodes[0].keywords = %v", keywords)
+	}
+	// @-prefixed structural keys are preserved verbatim.
+	if got, _ := n["@type"].(string); got != "Article" {
+		t.Errorf("nodes[0].@type = %q", got)
+	}
+}
+
 func TestSanitizeImageRejectsNonHTTP(t *testing.T) {
 	cases := []struct {
 		name, raw, want string

--- a/server/extractor/extractors/jsonld/jsonld_test.go
+++ b/server/extractor/extractors/jsonld/jsonld_test.go
@@ -1,0 +1,176 @@
+package jsonld
+
+import (
+	"testing"
+
+	"github.com/asciimoo/hister/server/document"
+	"github.com/asciimoo/hister/server/types"
+)
+
+func extract(t *testing.T, html string) *document.Document {
+	t.Helper()
+	d := &document.Document{URL: "https://example.com/", HTML: html}
+	e := &JSONLDExtractor{}
+	state, err := e.Extract(d)
+	if err != nil {
+		t.Fatalf("Extract returned error: %v", err)
+	}
+	if state != types.ExtractorContinue {
+		t.Fatalf("Extract state = %v, want Continue", state)
+	}
+	return d
+}
+
+func TestWikipediaArticle(t *testing.T) {
+	const h = `<html><head><script type="application/ld+json">{
+		"@context": "https://schema.org",
+		"@type": "Article",
+		"name": "Kristi Noem",
+		"headline": "Kristi Noem",
+		"author": {"@type": "Organization", "name": "Contributors to Wikimedia projects"},
+		"datePublished": "2010-01-01T00:00:00Z",
+		"dateModified": "2026-04-01T00:00:00Z",
+		"image": "https://upload.wikimedia.org/noem.jpg"
+	}</script></head><body></body></html>`
+
+	d := extract(t, h)
+	checks := map[string]string{
+		"jsonld_type":      "Article",
+		"jsonld_headline":  "Kristi Noem",
+		"jsonld_author":    "Contributors to Wikimedia projects",
+		"jsonld_published": "2010-01-01T00:00:00Z",
+		"jsonld_modified":  "2026-04-01T00:00:00Z",
+		"jsonld_image":     "https://upload.wikimedia.org/noem.jpg",
+	}
+	for k, want := range checks {
+		if got, _ := d.Metadata[k].(string); got != want {
+			t.Errorf("Metadata[%q] = %q, want %q", k, got, want)
+		}
+	}
+	if nodes, _ := d.Metadata["jsonld"].([]map[string]any); len(nodes) != 1 {
+		t.Errorf("expected 1 flattened node, got %d", len(nodes))
+	}
+}
+
+func TestYoastGraph(t *testing.T) {
+	const h = `<html><head><script type="application/ld+json">{
+		"@context": "https://schema.org",
+		"@graph": [
+			{"@type": "WebPage", "name": "About Us", "description": "The about page"},
+			{"@type": "BreadcrumbList", "itemListElement": []},
+			{"@type": "Organization", "name": "ACME"}
+		]
+	}</script></head></html>`
+
+	d := extract(t, h)
+	nodes, _ := d.Metadata["jsonld"].([]map[string]any)
+	if len(nodes) != 3 {
+		t.Fatalf("expected 3 nodes, got %d", len(nodes))
+	}
+	if got, _ := d.Metadata["jsonld_type"].(string); got != "WebPage" {
+		t.Errorf("jsonld_type = %q, want WebPage", got)
+	}
+	if got, _ := d.Metadata["jsonld_headline"].(string); got != "About Us" {
+		t.Errorf("jsonld_headline = %q, want About Us", got)
+	}
+	if got, _ := d.Metadata["jsonld_description"].(string); got != "The about page" {
+		t.Errorf("jsonld_description = %q", got)
+	}
+}
+
+func TestMultipleScriptTags(t *testing.T) {
+	const h = `<html><head>
+		<script type="application/ld+json">{"@type": "Organization", "name": "ACME"}</script>
+		<script type="application/ld+json">{"@type": "Article", "headline": "Hello"}</script>
+	</head></html>`
+
+	d := extract(t, h)
+	nodes, _ := d.Metadata["jsonld"].([]map[string]any)
+	if len(nodes) != 2 {
+		t.Fatalf("expected 2 nodes, got %d", len(nodes))
+	}
+	// Article is preferred over Organization.
+	if got, _ := d.Metadata["jsonld_type"].(string); got != "Article" {
+		t.Errorf("jsonld_type = %q, want Article", got)
+	}
+}
+
+func TestArrayForm(t *testing.T) {
+	const h = `<html><head><script type="application/ld+json">[
+		{"@type": "Person", "name": "Alice"},
+		{"@type": "Person", "name": "Bob"}
+	]</script></head></html>`
+
+	d := extract(t, h)
+	nodes, _ := d.Metadata["jsonld"].([]map[string]any)
+	if len(nodes) != 2 {
+		t.Fatalf("expected 2 nodes, got %d", len(nodes))
+	}
+}
+
+func TestMalformedJSONContinues(t *testing.T) {
+	const h = `<html><head>
+		<script type="application/ld+json">{not valid json</script>
+		<script type="application/ld+json">{"@type": "Article", "headline": "Survives"}</script>
+	</head></html>`
+
+	d := extract(t, h)
+	if got, _ := d.Metadata["jsonld_headline"].(string); got != "Survives" {
+		t.Errorf("jsonld_headline = %q, want Survives", got)
+	}
+	nodes, _ := d.Metadata["jsonld"].([]map[string]any)
+	if len(nodes) != 1 {
+		t.Errorf("expected 1 node (malformed skipped), got %d", len(nodes))
+	}
+}
+
+func TestAuthorShapes(t *testing.T) {
+	cases := []struct {
+		name, blob, want string
+	}{
+		{"string", `{"@type":"Article","author":"Jane Doe"}`, "Jane Doe"},
+		{"object", `{"@type":"Article","author":{"@type":"Person","name":"Jane Doe"}}`, "Jane Doe"},
+		{"array", `{"@type":"Article","author":[{"@type":"Person","name":"Jane Doe"},{"@type":"Person","name":"John"}]}`, "Jane Doe"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			d := extract(t, `<script type="application/ld+json">`+tc.blob+`</script>`)
+			if got, _ := d.Metadata["jsonld_author"].(string); got != tc.want {
+				t.Errorf("jsonld_author = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestImageObjectShape(t *testing.T) {
+	const h = `<script type="application/ld+json">{"@type":"Article","image":{"@type":"ImageObject","url":"https://ex.com/a.jpg"}}</script>`
+	d := extract(t, h)
+	if got, _ := d.Metadata["jsonld_image"].(string); got != "https://ex.com/a.jpg" {
+		t.Errorf("jsonld_image = %q", got)
+	}
+}
+
+func TestNoJSONLD(t *testing.T) {
+	d := &document.Document{URL: "https://example.com/", HTML: "<html><body><p>hi</p></body></html>"}
+	e := &JSONLDExtractor{}
+	state, err := e.Extract(d)
+	if err != nil {
+		t.Fatalf("Extract returned error: %v", err)
+	}
+	if state != types.ExtractorContinue {
+		t.Fatalf("state = %v, want Continue", state)
+	}
+	if _, ok := d.Metadata["jsonld"]; ok {
+		t.Errorf("Metadata[jsonld] should not be set, got %v", d.Metadata)
+	}
+}
+
+func TestEmptyHTMLDoesNotMatch(t *testing.T) {
+	e := &JSONLDExtractor{}
+	if e.Match(&document.Document{HTML: ""}) {
+		t.Error("Match should be false for empty HTML")
+	}
+	if !e.Match(&document.Document{HTML: "<html></html>"}) {
+		t.Error("Match should be true for non-empty HTML")
+	}
+}

--- a/server/sanitizer/sanitizer.go
+++ b/server/sanitizer/sanitizer.go
@@ -1,10 +1,16 @@
 package sanitizer
 
 import (
+	stdhtml "html"
+	"strings"
+
 	"github.com/microcosm-cc/bluemonday"
 )
 
-var htmlSanitizerPolicy *bluemonday.Policy
+var (
+	htmlSanitizerPolicy *bluemonday.Policy
+	textSanitizerPolicy = bluemonday.StrictPolicy()
+)
 
 func init() {
 	p := bluemonday.NewPolicy()
@@ -93,4 +99,17 @@ func init() {
 
 func SanitizeHTML(h string) string {
 	return htmlSanitizerPolicy.Sanitize(h)
+}
+
+// SanitizeText strips every HTML tag, decodes entities and trims
+// surrounding whitespace, producing safe plain text suitable for
+// storing in metadata or displaying verbatim.
+func SanitizeText(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ""
+	}
+	s = textSanitizerPolicy.Sanitize(s)
+	s = stdhtml.UnescapeString(s)
+	return strings.TrimSpace(s)
 }


### PR DESCRIPTION
Parses `<script type="application/ld+json">` tags in fetched HTML and writes normalized schema.org fields (type, headline, description, author, published, modified, image) to `d.Metadata`

Runs first in the chain and always returns Continue so Readability still populates body text. No extra HTTP requests