### PR TITLE
Add time/tzdata import to hister.go

### DIFF
--- a/hister.go
+++ b/hister.go
@@ -20,6 +20,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	_ "time/tzdata"
 
 	"github.com/asciimoo/hister/client"
 	"github.com/asciimoo/hister/config"


### PR DESCRIPTION
If TimeZone is specified in DSN, container failed:
```
Error! unknown time zone Europe/Bucharest
```
Passing /etc/localtime as volume may work, however selinux protected systems won't allow that. There is an option to add tzdata package to every target (or add tzdata to builder stage and COPY /usr/share/zoneinfo to every target), however I found that adding a blank import of time/tzdata will also do the trick. In the end, binary will have lesser OS dependencies. 

If TimZone in DSN string is mandatory - tzdata must exist.