### PR TITLE
build(goreleaser): publish a Homebrew formula via a tap

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -46,4 +46,19 @@ builds:
           - CC=oa64-clang
 
 archives:
-  - formats: ['binary']
+  - formats: ['tar.gz', 'binary']
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+
+brews:
+  - name: hister
+    repository:
+      owner: asciimoo
+      name: homebrew-tap
+      token: "{{ .Env.GORELEASER_TOKEN }}"
+    description: "Your own search engine"
+    homepage: "https://github.com/asciimoo/hister"
+    license: "AGPL-3.0-or-later"
+    install: |
+      bin.install "hister"
+    test: |
+      system "#{bin}/hister", "--version"


### PR DESCRIPTION
## Summary

Closes #161 by wiring hister into a Homebrew tap via goreleaser. On every stable release tag, goreleaser will now push a `hister` formula to `asciimoo/homebrew-tap` in addition to producing the existing raw binaries.

## Why this matters

@SKalt opened #161 with a short, specific ask: ~10 lines of goreleaser config to publish a Homebrew formula, motivated by "MacOS refusing to run the binary from the releases page without a signature." Without a tap, macOS users have to either trust an unsigned binary from the releases page or build from source.

Investigating `.goreleaser.yml`, the existing `archives:` block emits only `formats: ['binary']`, which produces raw per-platform binaries with no tarball. `goreleaser`'s `brews:` step expects tarballs so its generated `url do` can point at the `.tar.gz` on the release page, so the archive config needs to emit `tar.gz` in addition to the current `binary` (keeping the raw binary available for anyone who wants it).

`.github/workflows/release.yml` already runs goreleaser and already passes `secrets.GORELEASER_TOKEN`. The same token is reused for the tap push; no workflow edit is needed.

## Changes

All changes live in `.goreleaser.yml`:

- `archives:` now emits `['tar.gz', 'binary']` with a `name_template` so the tap can locate each platform's tarball. Raw binaries are preserved.
- New `brews:` block pointing at `asciimoo/homebrew-tap`, with a minimal `install` / `test` stanza and metadata (description, homepage, `AGPL-3.0-or-later` SPDX license). The `test:` block invokes `hister --version`, which is already wired in `hister.go:85-89` via `cobra.Command.Version = Version`.

## Maintainer prerequisites (one-time)

Shipping this requires two things outside of this PR, both flagged in the issue body:

1. Create the `asciimoo/homebrew-tap` repository. It can start empty — goreleaser will populate the formula on the next release.
2. Ensure `secrets.GORELEASER_TOKEN` has write access to the tap repo (read-only to this repo is fine, but it needs to push to the tap).

If either of those names would be different in practice (e.g., a different tap repo naming convention), happy to adjust the `repository:` block.

## Testing

- YAML parses and still has `version`, `builds`, `archives`, `brews` at the top level.
- `goreleaser check` not available locally, so syntax is verified against goreleaser v2's documented schema at https://goreleaser.com/customization/homebrew/ (matches v2 `repository:` / `name:` / `install:` / `test:` shape).
- `hister --version` exists today, so the formula's `test:` block is exercisable.

Closes #161

_This contribution was developed with AI assistance (Claude Code)._
