### PR TITLE
[enh] add multi-language subtitle support to yt-dlp extractor

### DIFF
--- a/server/extractor/extractors/ytdlp/types.go
+++ b/server/extractor/extractors/ytdlp/types.go
@@ -33,6 +33,7 @@ type videoInfo struct {
 	Chapters          []chapter                  `json:"chapters"`
 	Subtitles         map[string][]subtitleTrack `json:"subtitles"`
 	AutomaticCaptions map[string][]subtitleTrack `json:"automatic_captions"`
+	Language          string                     `json:"language"`
 	PlaylistTitle     string                     `json:"playlist_title"`
 	PlaylistIndex     *int                       `json:"playlist_index"`
 	PlaylistCount     *int                       `json:"playlist_count"`

--- a/server/extractor/extractors/ytdlp/vtt.go
+++ b/server/extractor/extractors/ytdlp/vtt.go
@@ -5,15 +5,46 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 	"unicode"
 )
 
-// fetchSubtitleText uses yt-dlp to download subtitles and strips timing/formatting
-// to return plain transcript text. It prefers manual subtitles over auto-captions.
+// fetchSubtitleText dispatches subtitle downloading based on the sub_language config:
+//   - "auto": use the video's original language reported by yt-dlp
+//   - single value (e.g. "de"): download subtitles in that language if available
+//   - comma-separated list (e.g. "de,fr"): download subtitles only if the video's
+//     original language matches one of the listed languages
 func (e *YtdlpExtractor) fetchSubtitleText(info *videoInfo) string {
-	lang := e.subLanguage()
+	langSpec := e.subLanguage()
 
+	if langSpec == "auto" {
+		if info.Language == "" {
+			return ""
+		}
+		return downloadSubtitleForLang(e, info, info.Language)
+	}
+
+	langs := strings.Split(langSpec, ",")
+	for i := range langs {
+		langs[i] = strings.TrimSpace(langs[i])
+	}
+
+	if len(langs) > 1 {
+		// Multiple languages: download only if the video's original language is in the list.
+		if info.Language == "" || !slices.Contains(langs, info.Language) {
+			return ""
+		}
+		return downloadSubtitleForLang(e, info, info.Language)
+	}
+
+	// Single language: download in the specified language regardless of video's language.
+	return downloadSubtitleForLang(e, info, langs[0])
+}
+
+// downloadSubtitleForLang downloads subtitles for a single language code and returns
+// the plain transcript text. It prefers manual subtitles over auto-captions.
+func downloadSubtitleForLang(e *YtdlpExtractor, info *videoInfo, lang string) string {
 	// Check whether any subtitles are available at all.
 	hasManual := len(info.Subtitles[lang]) > 0
 	hasAuto := len(info.AutomaticCaptions[lang]) > 0

--- a/server/extractor/extractors/ytdlp/ytdlp.go
+++ b/server/extractor/extractors/ytdlp/ytdlp.go
@@ -50,7 +50,7 @@ func (e *YtdlpExtractor) GetConfig() *config.Extractor {
 				"binary":          "yt-dlp",
 				"timeout":         15,
 				"fetch_subtitles": false,
-				"sub_language":    "en",
+				"sub_language":    "auto",
 			},
 		}
 	}

--- a/server/extractor/extractors/ytdlp/ytdlp_test.go
+++ b/server/extractor/extractors/ytdlp/ytdlp_test.go
@@ -42,10 +42,59 @@ const sampleJSONTemplate = `{
       {"ext": "vtt", "url": "%s/subs.vtt", "name": "English"}
     ]
   },
+  "language": "en",
   "automatic_captions": {},
   "playlist_title": "First Videos",
   "playlist_index": 1,
   "playlist_count": 10
+}`
+
+// sampleJSONTemplateFr is like sampleJSONTemplate but for a French-language video.
+// The "language" field is set to "fr" and automatic_captions include a French track
+// so that downloadSubtitleForLang can find available subtitles.
+// %s placeholders: 1=thumbnail URL.
+const sampleJSONTemplateFr = `{
+  "id": "testFrVideo",
+  "title": "French Video",
+  "description": "A video in French.",
+  "uploader": "testuser",
+  "channel": "testuser",
+  "duration": 60,
+  "view_count": 1000,
+  "like_count": 50,
+  "upload_date": "20240101",
+  "thumbnail": "%s/thumb.jpg",
+  "webpage_url": "https://www.youtube.com/watch?v=testFrVideo",
+  "categories": [],
+  "tags": [],
+  "chapters": [],
+  "language": "fr",
+  "subtitles": {},
+  "automatic_captions": {
+    "fr": [{"ext": "json3", "url": "https://example.com/subs?lang=fr", "name": "French"}]
+  }
+}`
+
+// sampleJSONTemplateNoLang is like sampleJSONTemplateFr but without a "language" field,
+// simulating videos where yt-dlp cannot detect the original language.
+// %s placeholder: thumbnail URL.
+const sampleJSONTemplateNoLang = `{
+  "id": "testNoLang",
+  "title": "Unknown Language Video",
+  "description": "No language metadata.",
+  "uploader": "testuser",
+  "channel": "testuser",
+  "duration": 60,
+  "view_count": 100,
+  "like_count": 5,
+  "upload_date": "20240101",
+  "thumbnail": "%s/thumb.jpg",
+  "webpage_url": "https://www.youtube.com/watch?v=testNoLang",
+  "categories": [],
+  "tags": [],
+  "chapters": [],
+  "subtitles": {},
+  "automatic_captions": {}
 }`
 
 const sampleVTT = `WEBVTT
@@ -64,13 +113,15 @@ really really long trunks
 
 // writeFakeBinary creates a shell script that handles both --dump-json and
 // --write-sub/--write-auto-sub invocations, returning its path.
+// The subtitle file is named using the --sub-lang value so that auto-mode
+// tests work correctly with any detected language.
 func writeFakeBinary(t *testing.T, jsonContent string) string {
 	t.Helper()
 	dir := t.TempDir()
 	bin := filepath.Join(dir, "fake-yt-dlp")
 	// When called with --dump-json, output JSON.
 	// When called with --write-sub or --write-auto-sub, write a .vtt file
-	// next to the -o path.
+	// next to the -o path, using the --sub-lang value as the file extension.
 	script := `#!/bin/sh
 case "$*" in
   *--dump-json*)
@@ -80,16 +131,25 @@ YTDLP_EOF
     ;;
   *--write-sub*|*--write-auto-sub*)
     out=""
+    lang="en"
     next=0
+    lang_next=0
     for arg in "$@"; do
       if [ "$next" = 1 ]; then
         out="$arg"
         next=0
       fi
-      case "$arg" in -o) next=1 ;; esac
+      if [ "$lang_next" = 1 ]; then
+        lang="$arg"
+        lang_next=0
+      fi
+      case "$arg" in
+        -o) next=1 ;;
+        --sub-lang) lang_next=1 ;;
+      esac
     done
     if [ -n "$out" ]; then
-      cat > "${out}.en.vtt" <<'VTT_EOF'
+      cat > "${out}.${lang}.vtt" <<'VTT_EOF'
 ` + sampleVTT + `
 VTT_EOF
     fi
@@ -365,6 +425,103 @@ func TestPreviewWithSubtitles(t *testing.T) {
 	}
 }
 
+// newTestExtractorFr creates an extractor configured with a French-language video
+// JSON and the given sub_language setting.
+func newTestExtractorFr(t *testing.T, subLang string) *YtdlpExtractor {
+	t.Helper()
+	srv := startTestServer(t)
+	jsonContent := fmt.Sprintf(sampleJSONTemplateFr, srv.URL)
+
+	e := &YtdlpExtractor{}
+	if err := e.SetConfig(&config.Extractor{
+		Enable: true,
+		Options: map[string]any{
+			"binary":          writeFakeBinary(t, jsonContent),
+			"timeout":         5,
+			"fetch_subtitles": true,
+			"sub_language":    subLang,
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	return e
+}
+
+// newTestExtractorNoLang creates an extractor configured with a video JSON that has
+// no "language" field and the given sub_language setting.
+func newTestExtractorNoLang(t *testing.T, subLang string) *YtdlpExtractor {
+	t.Helper()
+	srv := startTestServer(t)
+	jsonContent := fmt.Sprintf(sampleJSONTemplateNoLang, srv.URL)
+
+	e := &YtdlpExtractor{}
+	if err := e.SetConfig(&config.Extractor{
+		Enable: true,
+		Options: map[string]any{
+			"binary":          writeFakeBinary(t, jsonContent),
+			"timeout":         5,
+			"fetch_subtitles": true,
+			"sub_language":    subLang,
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	return e
+}
+
+func TestExtractWithSubtitlesAuto(t *testing.T) {
+	e := newTestExtractorFr(t, "auto")
+	d := &document.Document{URL: "https://www.youtube.com/watch?v=testFrVideo"}
+
+	if _, err := e.Extract(d); err != nil {
+		t.Fatalf("Extract returned error: %v", err)
+	}
+	if !strings.Contains(d.Text, "Transcript:") {
+		t.Error("Text missing transcript section with auto mode")
+	}
+	if !strings.Contains(d.Text, "elephants") {
+		t.Error("Text missing subtitle content with auto mode")
+	}
+}
+
+func TestExtractWithSubtitlesMultiLangMatch(t *testing.T) {
+	// "fr,en" should download subtitles because the video's original language is "fr".
+	e := newTestExtractorFr(t, "fr,en")
+	d := &document.Document{URL: "https://www.youtube.com/watch?v=testFrVideo"}
+
+	if _, err := e.Extract(d); err != nil {
+		t.Fatalf("Extract returned error: %v", err)
+	}
+	if !strings.Contains(d.Text, "elephants") {
+		t.Error("Text missing subtitle content when original language matches multi-lang list")
+	}
+}
+
+func TestExtractWithSubtitlesAutoNoLanguage(t *testing.T) {
+	// When the video has no "language" field, auto mode should skip subtitles.
+	e := newTestExtractorNoLang(t, "auto")
+	d := &document.Document{URL: "https://www.youtube.com/watch?v=testNoLang"}
+	if _, err := e.Extract(d); err != nil {
+		t.Fatalf("Extract returned error: %v", err)
+	}
+	if strings.Contains(d.Text, "Transcript:") {
+		t.Error("Text should not contain transcript when video has no language metadata")
+	}
+}
+
+func TestExtractWithSubtitlesMultiLangNoMatch(t *testing.T) {
+	// "de,es" should NOT download subtitles because the video's original language is "fr".
+	e := newTestExtractorFr(t, "de,es")
+	d := &document.Document{URL: "https://www.youtube.com/watch?v=testFrVideo"}
+
+	if _, err := e.Extract(d); err != nil {
+		t.Fatalf("Extract returned error: %v", err)
+	}
+	if strings.Contains(d.Text, "Transcript:") {
+		t.Error("Text should not contain transcript when original language is not in list")
+	}
+}
+
 func TestCaching(t *testing.T) {
 	dir := t.TempDir()
 	counterFile := filepath.Join(dir, "count")
@@ -448,7 +605,6 @@ func TestConfig(t *testing.T) {
 	if cfg.Options["binary"] != "yt-dlp" {
 		t.Errorf("default binary = %v, want yt-dlp", cfg.Options["binary"])
 	}
-
 	err := e.SetConfig(&config.Extractor{
 		Enable: true,
 		Options: map[string]any{


### PR DESCRIPTION
First of all, I really like your project; I use it actively and will follow its development with interest.

# Disclaimer

I am not a golang expert; however, I have sufficient experience in other programming languages, so I used Claude Code for AI-assisted development, not vibe-coding. This text was written by a human and verified by an LLM for mistakes.

# Problem Statement

If the `sub_language` setting in the ytdlp extractor is set to a language that does not match the video's default language, the video transcript is not saved in Hister because yt-dlp returns 201 and an empty string.

A workaround is to request an auto-translation of captions into the specified language, but in this case YouTube applies stricter checks, and cookies may be required, overwise it may return `429: Too Many Requests`. Therefore, in my experiments, the most reliable approach (without extra impersonation or cookie import) was to request captions in the language that matches the video's default language (`info.Language`).

# Core Changes

In the ytdlp extractor configuration, the `sub_language` parameter can now take the value `auto`, or contain one or more subtitle languages separated by commas. 
Logic:
- if `auto` is specified: download subtitles in the default language for this video
- if `en` is specified: download subtitles in English or nothing
- if `en`, `fr` are specified: try downloading subtitles in the listed languages in order of priority, or nothing if none of the specified languages is the video's default.

If `en` is specified as `sub_language`, the current behavior (before the change) is fully preserved.

# Changes to the default configuration

```yaml
extractors:
    ytdlp:
        fetch_subtitles: true
        sub_language: "auto"      # detect original language automatically
```

# Testing
Tested manually on videos with different languages and different values of `sub_language`.  

Added new test fixtures:
- `sampleJSONTemplateFr` for a non-English language test
- `sampleJSONTemplateNoLang` for a video without a default language (this is the real case in my experience)

Four new tests added:
  
  |       Test       | Fixture | sub_language |    Expectation     |
  |------------|--------|---------------|-----------------|
| Auto             | Fr      | `auto`        | subtitles present  |
   | MultiLangMatch   | Fr      | `fr,en`       | subtitles present  |
  | AutoNoLanguage   | NoLang  | `auto`         | no subtitles       |
  | MultiLangNoMatch | Fr      | `de,es`        | no subtitles       |
  