### PR TITLE
[fix] update nix go package vendorHash

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -49,7 +49,7 @@ buildGoModule (finalAttrs: {
     ];
   };
 
-  vendorHash = "sha256-u6TB1tzaELd8YBCa+9YjMirSXSUu3uZVbe+QwH1dSM8=";
+  vendorHash = "sha256-L5hHd2/YMaDdl+GLGiLc03C507Akh5BXV1JTVskXaEY=";
   proxyVendor = true;
 
   nativeBuildInputs = [


### PR DESCRIPTION
Updated my flake inputs recently and got a nix build error related to the go vendor hash.

```
┏━ 1 Errors:
┃ error: hash mismatch in fixed-output derivation '/nix/store/a0hq4wmbynrlidk4f0w4xasx1izcs7gw-hister-0.14.0-go-mo…
┃            likely URL: (unknown)
┃             specified: sha256-u6TB1tzaELd8YBCa+9YjMirSXSUu3uZVbe+QwH1dSM8=
┃                   got: sha256-L5hHd2/YMaDdl+GLGiLc03C507Akh5BXV1JTVskXaEY=
┃         expected path: /nix/store/bnz5d8xbmsdmxqrmbx2qddanxk2qdf54-hister-0.14.0-go-modules
┃              got path: /nix/store/bh5favf0pb4wivcdkciyafhzddhvy95k-hister-0.14.0-go-modules
```