### PR TITLE
Implemented user as optional field on indexer.directories.path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ dist/
 build/
 server/static/app
 tmp/
+
+.test/
+.pre-commit-config.yaml

--- a/config/config.go
+++ b/config/config.go
@@ -90,6 +90,7 @@ type Directory struct {
 	Excludes       []string `yaml:"excludes"          mapstructure:"excludes"`
 	IncludeHidden  bool     `yaml:"include_hidden"    mapstructure:"include_hidden"`
 	DeleteOnRemove bool     `yaml:"delete_on_remove"  mapstructure:"delete_on_remove"`
+	User           string   `yaml:"user"              mapstructure:"user"`
 }
 
 type Indexer struct {

--- a/files/files.go
+++ b/files/files.go
@@ -18,6 +18,7 @@ import (
 	"github.com/rs/zerolog/log"
 
 	"github.com/asciimoo/hister/config"
+	"github.com/asciimoo/hister/server/model"
 )
 
 func ExpandHome(path string) string {
@@ -76,6 +77,23 @@ func FindMatchingDir(dirs []*config.Directory, filePath string) *config.Director
 		}
 	}
 	return nil
+}
+
+// FindDirUser finds the directory config matching a file path and resolves its user to a user ID.
+// Returns 0 for global directories (no user set). Returns an error if the username can't be resolved.
+func FindDirUser(dirs []*config.Directory, filePath string) (uint, error) {
+	dir := FindMatchingDir(dirs, filePath)
+	if dir == nil {
+		return 0, nil
+	}
+	if dir.User == "" {
+		return 0, nil
+	}
+	u, err := model.GetUser(dir.User)
+	if err != nil {
+		return 0, fmt.Errorf("user %q not found", dir.User)
+	}
+	return u.ID, nil
 }
 
 // skipDirs lists directory names that are skipped by default during watching.

--- a/files/files_test.go
+++ b/files/files_test.go
@@ -1,0 +1,155 @@
+package files
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/asciimoo/hister/config"
+	"github.com/asciimoo/hister/server/model"
+)
+
+func setupTestDB(t *testing.T) *config.Config {
+	t.Helper()
+	cfg := &config.Config{
+		Server: config.Server{
+			Database: "file::memory:",
+		},
+	}
+	err := model.Init(cfg)
+	if err != nil {
+		t.Fatalf("failed to init test DB: %v", err)
+	}
+	return cfg
+}
+
+func TestFindDirUser(t *testing.T) {
+	setupTestDB(t)
+
+	// Create test users
+	u1, err := model.CreateUser("alice", "password123", false)
+	if err != nil {
+		t.Fatalf("failed to create test user: %v", err)
+	}
+
+	dirs := []*config.Directory{
+		{Path: "/home/alice/docs", User: "alice"},
+		{Path: "/home/charlie/docs", User: "charlie"},
+		{Path: "/shared/docs", User: ""},
+		{Path: "/tmp", User: ""},
+	}
+
+	tests := []struct {
+		name    string
+		path    string
+		wantID  uint
+		wantErr bool
+	}{
+		{
+			name:    "file in alice's directory",
+			path:    "/home/alice/docs/file.txt",
+			wantID:  u1.ID,
+			wantErr: false,
+		},
+		{
+			name:    "file in nested alice directory",
+			path:    "/home/alice/docs/subdir/file.txt",
+			wantID:  u1.ID,
+			wantErr: false,
+		},
+		{
+			name:    "file in shared global directory",
+			path:    "/shared/docs/file.txt",
+			wantID:  0,
+			wantErr: false,
+		},
+		{
+			name:    "file in tmp global directory",
+			path:    "/tmp/file.txt",
+			wantID:  0,
+			wantErr: false,
+		},
+		{
+			name:    "file not in any directory",
+			path:    "/other/path/file.txt",
+			wantID:  0,
+			wantErr: false,
+		},
+		{
+			name:    "non-existent user in config",
+			path:    "/home/charlie/docs/file.txt",
+			wantID:  0,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotID, err := FindDirUser(dirs, tt.path)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("FindDirUser(%q) expected error, got nil", tt.path)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("FindDirUser(%q) unexpected error: %v", tt.path, err)
+				return
+			}
+			if gotID != tt.wantID {
+				t.Errorf("FindDirUser(%q) = %d, want %d", tt.path, gotID, tt.wantID)
+			}
+		})
+	}
+}
+
+func TestFindDirUserWithHomeExpansion(t *testing.T) {
+	setupTestDB(t)
+
+	home := ExpandHome("~/")
+	if home == "~/ " {
+		t.Skip("could not expand home directory")
+	}
+
+	// Create a test user
+	_, err := model.CreateUser("homeuser", "password123", false)
+	if err != nil {
+		t.Fatalf("failed to create test user: %v", err)
+	}
+
+	dirs := []*config.Directory{
+		{Path: "~/project", User: "homeuser"},
+	}
+
+	tests := []struct {
+		name        string
+		path        string
+		wantNonZero bool
+	}{
+		{
+			name:        "tilde path matches",
+			path:        filepath.Join(home, "project", "file.txt"),
+			wantNonZero: true,
+		},
+		{
+			name:        "tilde path does not match",
+			path:        filepath.Join(home, "other", "file.txt"),
+			wantNonZero: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotID, err := FindDirUser(dirs, tt.path)
+			if err != nil {
+				t.Errorf("FindDirUser(%q) unexpected error: %v", tt.path, err)
+				return
+			}
+			if tt.wantNonZero && gotID == 0 {
+				t.Errorf("FindDirUser(%q) = 0, expected non-zero user ID", tt.path)
+			}
+			if !tt.wantNonZero && gotID != 0 {
+				t.Errorf("FindDirUser(%q) = %d, expected 0", tt.path, gotID)
+			}
+		})
+	}
+}

--- a/hister.go
+++ b/hister.go
@@ -163,7 +163,15 @@ var listenCmd = &cobra.Command{
 			indexer.IndexAll(cfg.Indexer.Directories)
 			go func() {
 				if err := files.WatchDirectories(context.Background(), cfg.Indexer.Directories, func(path string) {
-					if err := indexer.IndexFile(path); err != nil {
+					userID, err := files.FindDirUser(cfg.Indexer.Directories, path)
+					if err != nil {
+						log.Error().Err(err).Str("path", path).Msg("Failed to resolve user for file")
+						return
+					} else if userID != 0 && !cfg.App.UserHandling {
+						log.Error().Str("path", path).Msg("user field set but user_handling is not enabled")
+						return
+					}
+					if err := indexer.IndexFile(path, userID); err != nil {
 						log.Debug().Err(err).Str("path", path).Msg("Failed to index file")
 					}
 				}, func(path string) {

--- a/server/indexer/files.go
+++ b/server/indexer/files.go
@@ -14,6 +14,7 @@ import (
 	"github.com/asciimoo/hister/config"
 	"github.com/asciimoo/hister/files"
 	"github.com/asciimoo/hister/server/document"
+	"github.com/asciimoo/hister/server/model"
 )
 
 var (
@@ -45,6 +46,16 @@ func indexDirectory(dir string, cfg *config.Directory) error {
 	indexed := 0
 	skipped := 0
 
+	var userID uint
+	if cfg.User != "" {
+		u, err := model.GetUser(cfg.User)
+		if err != nil {
+			log.Error().Err(err).Str("directory", dir).Msg("Failed to resolve user for directory")
+			return fmt.Errorf("user %q not found for directory %s: %w", cfg.User, dir, err)
+		}
+		userID = u.ID
+	}
+
 	log.Debug().Str("directory", dir).Msg("Indexing directory")
 
 	err = filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
@@ -61,7 +72,7 @@ func indexDirectory(dir string, cfg *config.Directory) error {
 		if !cfg.IsMatching(d.Name()) {
 			return nil
 		}
-		if err := IndexFile(path); err != nil {
+		if err := IndexFile(path, userID); err != nil {
 			log.Debug().Err(err).Str("path", path).Msg("Skipping file")
 			skipped++
 		} else {
@@ -74,7 +85,7 @@ func indexDirectory(dir string, cfg *config.Directory) error {
 	return err
 }
 
-func IndexFile(path string) error {
+func IndexFile(path string, userID uint) error {
 	info, err := os.Stat(path)
 	if err != nil {
 		return err
@@ -94,7 +105,7 @@ func IndexFile(path string) error {
 	fileURL := files.PathToFileURL(absPath)
 
 	// Skip if already indexed with the same modification time
-	existing := GetByURLAndUser(fileURL, 0)
+	existing := GetByURLAndUser(fileURL, userID)
 	if existing != nil && existing.Added == info.ModTime().Unix() {
 		return nil
 	}
@@ -107,8 +118,9 @@ func IndexFile(path string) error {
 	}
 
 	doc := &document.Document{
-		URL:   fileURL,
-		Added: info.ModTime().Unix(),
+		URL:    fileURL,
+		Added:  info.ModTime().Unix(),
+		UserID: userID,
 	}
 
 	if strings.EqualFold(filepath.Ext(path), ".pdf") {

--- a/server/indexer/files_test.go
+++ b/server/indexer/files_test.go
@@ -1,0 +1,177 @@
+package indexer
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/asciimoo/hister/config"
+	"github.com/asciimoo/hister/server/model"
+)
+
+func setupTestDB(t *testing.T) *config.Config {
+	t.Helper()
+	cfg := &config.Config{
+		Server: config.Server{
+			Database: "file::memory:",
+		},
+	}
+	err := model.Init(cfg)
+	if err != nil {
+		t.Fatalf("failed to init test DB: %v", err)
+	}
+	return cfg
+}
+
+func TestDirectoryUserResolution(t *testing.T) {
+	setupTestDB(t)
+
+	// Create test users
+	u1, err := model.CreateUser("alice", "password123", false)
+	if err != nil {
+		t.Fatalf("failed to create test user: %v", err)
+	}
+	u2, err := model.CreateUser("bob", "password123", false)
+	if err != nil {
+		t.Fatalf("failed to create test user: %v", err)
+	}
+
+	tests := []struct {
+		name     string
+		username string
+		wantID   uint
+		wantErr  bool
+	}{
+		{
+			name:     "empty username is global",
+			username: "",
+			wantID:   0,
+			wantErr:  false,
+		},
+		{
+			name:     "existing user alice",
+			username: "alice",
+			wantID:   u1.ID,
+			wantErr:  false,
+		},
+		{
+			name:     "existing user bob",
+			username: "bob",
+			wantID:   u2.ID,
+			wantErr:  false,
+		},
+		{
+			name:     "non-existent user",
+			username: "charlie",
+			wantID:   0,
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotID uint
+			var err error
+			if tt.username != "" {
+				u, e := model.GetUser(tt.username)
+				if e != nil {
+					err = e
+				} else {
+					gotID = u.ID
+				}
+			}
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("user resolution(%q) expected error, got nil", tt.username)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("user resolution(%q) unexpected error: %v", tt.username, err)
+				return
+			}
+			if gotID != tt.wantID {
+				t.Errorf("user resolution(%q) = %d, want %d", tt.username, gotID, tt.wantID)
+			}
+		})
+	}
+}
+
+func TestIndexFileWithUserID(t *testing.T) {
+	setupTestDB(t)
+
+	// Create a test user
+	u, err := model.CreateUser("testuser", "password123", false)
+	if err != nil {
+		t.Fatalf("failed to create test user: %v", err)
+	}
+
+	// Create temp dirs for data and test files
+	dataDir := t.TempDir()
+	testDir := t.TempDir()
+
+	// Create test files (avoid patterns that match sensitive content regex)
+	testFile := filepath.Join(testDir, "test.txt")
+	err = os.WriteFile(testFile, []byte("sample document content about indexing files for testing purposes"), 0o644)
+	if err != nil {
+		t.Fatalf("failed to create test file: %v", err)
+	}
+
+	testFile2 := filepath.Join(testDir, "test2.txt")
+	err = os.WriteFile(testFile2, []byte("sample global document content for indexing test purposes"), 0o644)
+	if err != nil {
+		t.Fatalf("failed to create test file 2: %v", err)
+	}
+
+	// Initialize the indexer with proper data and index dirs
+	idxCfg := config.CreateDefaultConfig()
+	idxCfg.App.Directory = dataDir
+	// Override the index dir
+	err = Init(idxCfg)
+	if err != nil {
+		t.Fatalf("failed to init indexer: %v", err)
+	}
+
+	// Index the file with the test user's ID
+	err = IndexFile(testFile, u.ID)
+	if err != nil {
+		t.Fatalf("IndexFile with user ID failed: %v", err)
+	}
+
+	// Index the file without user ID (global)
+	err = IndexFile(testFile2, 0)
+	if err != nil {
+		t.Fatalf("IndexFile without user ID failed: %v", err)
+	}
+}
+
+func TestDirectoryUserField(t *testing.T) {
+	tests := []struct {
+		name     string
+		user     string
+		expected string
+	}{
+		{
+			name:     "empty user",
+			user:     "",
+			expected: "",
+		},
+		{
+			name:     "user set",
+			user:     "alice",
+			expected: "alice",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := &config.Directory{
+				Path: "/some/path",
+				User: tt.user,
+			}
+			if dir.User != tt.expected {
+				t.Errorf("Directory.User = %q, want %q", dir.User, tt.expected)
+			}
+		})
+	}
+}

--- a/webui/website/src/content/docs/configuration.md
+++ b/webui/website/src/content/docs/configuration.md
@@ -244,14 +244,15 @@ TUI settings are configured in a separate `tui.yaml` file located in the same di
 
 Each entry in `directories` is an object with the following keys:
 
-| Key                | Type     | Default | Description                                                                                                                                                                                                           |
-| ------------------ | -------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `path`             | string   | ""      | **(required)** Directory path to index. Paths starting with `~/` are expanded to your home directory.                                                                                                                 |
-| `filetypes`        | string[] | (none)  | Only index files with these extensions (without the dot). e.g. `['txt', 'md']`.                                                                                                                                       |
-| `patterns`         | string[] | (none)  | Only index files whose names match at least one glob pattern. e.g. `['doc_*', 'README*']`.                                                                                                                            |
-| `excludes`         | string[] | (none)  | Skip files whose names match any of these glob patterns. e.g. `['*secret*', '*.tmp']`.                                                                                                                                |
-| `include_hidden`   | bool     | `false` | When `true`, index hidden files/directories (starting with `.`) and well-known dependency/cache directories (`node_modules`, `__pycache__`, etc.) that are skipped by default. User-specified `excludes` still apply. |
-| `delete_on_remove` | bool     | `false` | When `true`, automatically remove a file from the index when it is deleted or renamed on the filesystem.                                                                                                              |
+| Key                | Type     | Default | Description                                                                                                                                                                                                                                                                                                  |
+| ------------------ | -------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `path`             | string   | ""      | **(required)** Directory path to index. Paths starting with `~/` are expanded to your home directory.                                                                                                                                                                                                        |
+| `filetypes`        | string[] | (none)  | Only index files with these extensions (without the dot). e.g. `['txt', 'md']`.                                                                                                                                                                                                                              |
+| `patterns`         | string[] | (none)  | Only index files whose names match at least one glob pattern. e.g. `['doc_*', 'README*']`.                                                                                                                                                                                                                   |
+| `excludes`         | string[] | (none)  | Skip files whose names match any of these glob patterns. e.g. `['*secret*', '*.tmp']`.                                                                                                                                                                                                                       |
+| `include_hidden`   | bool     | `false` | When `true`, index hidden files/directories (starting with `.`) and well-known dependency/cache directories (`node_modules`, `__pycache__`, etc.) that are skipped by default. User-specified `excludes` still apply.                                                                                        |
+| `delete_on_remove` | bool     | `false` | When `true`, automatically remove a file from the index when it is deleted or renamed on the filesystem.                                                                                                                                                                                                     |
+| `user`             | string   | `""`    | Username that owns files in this directory. Files are only visible to this user in search results (plus global files). Omit or leave empty for global access. A non-existing username, or a configured username when `user_handling` is not enabled, causes an error log entry and the directory is skipped. |
 
 When multiple filters are specified, they are applied in order: excludes first, then filetypes, then patterns. A file must pass all specified filters to be indexed. When a filter is omitted, it is not applied (all files pass).
 
@@ -270,6 +271,30 @@ indexer:
     - path: '/path/to/project'
       filetypes: ['go', 'py', 'js']
 ```
+
+### User-scoped directories
+
+When `user_handling` is enabled, you can scope indexed files to specific users using the `user` field. Files in a user-scoped directory are only visible to that user in search results. Global directories (no `user` set) are visible to all users.
+
+```yaml
+indexer:
+  directories:
+    - path: '/nextcloud/notes/alice'
+      user: 'alice'
+      filetypes: ['txt', 'md']
+    - path: '/nextcloud/notes/bob'
+      user: 'bob'
+      filetypes: ['txt', 'md']
+    - path: '/shared/docs'
+      # no user = global, visible to all
+      filetypes: ['pdf', 'doc']
+```
+
+Visibility rules:
+
+- A user sees files from directories where `user == username` plus global directories (`user` empty or unset) plus their own web documents
+- Admins have the same visibility as regular users (no special access to other users' files)
+- Unauthenticated users see global directories only
 
 Files are indexed recursively, with the following rules:
 


### PR DESCRIPTION
This PR solves feature suggestion #430 

New field `user`:

```
indexer:
    detect_languages: true
    directories:
      - path: '/notes/troed'
        user: troed
        filetypes: ['md']
        delete_on_remove: true
```

If configured, indexed files under that path are only visible to the corresponding Hister user. Hister will refuse to start if a username is configured that doesn't exist, or if a username is configured but user_handling is not set to true. This to avoid unintented privacy leaks from misconfiguration.

Test suites added for all the new code, all tests pass. Linting run and passes. Docker container with the code has been built and tested successfully in my own Hister installation with user visibility verified for the configured user and non-visibility for an unconfigured user.

# AI DISCLOSURE #

This PR has been made assisted by an LLM: Qwen 3.6 35B A3B in an Opencode+DCP+Superpowers harness locally hosted. All architectual decisions have been made by me (the human Troed writing this), and several iterations to clean up what code to break out into helper functions for better test coverage were made instead of just accepting the LLM's initial output. 

The tests are verbose, but due to the privacy leak risk I wanted to be sure the codepaths have extensive regression tests. 