### PR TITLE
[fix] allow config to override Docker base URL defaults

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,9 +30,15 @@ RUN go mod download
 COPY . .
 COPY --from=frontend /app/webui/app/build/ server/static/app/
 
-RUN CGO_ENABLED=1 go build \
+RUN set -eux; \
+    LISTEN_ADDRESS="0.0.0.0:4433"; \
+    BASE_URL="http://localhost:4433"; \
+    CGO_ENABLED=1 go build \
     -tags netgo,osusergo \
-    -ldflags "-linkmode external -extldflags '-static' -s -w" \
+    -ldflags "\
+      -linkmode external -extldflags '-static' -s -w \
+      -X 'github.com/asciimoo/hister/config.DefaultServerAddress=$LISTEN_ADDRESS' \
+      -X 'github.com/asciimoo/hister/config.DefaultServerBaseURL=$BASE_URL'" \
     -o hister .
 
 # Release stage (nonroot)
@@ -52,8 +58,6 @@ USER 65532:65532
 
 ENV HISTER_DATA_DIR=/hister/data
 ENV HISTER_CONFIG=/hister/data/config.yml
-ENV HISTER__SERVER__ADDRESS=0.0.0.0:4433
-ENV HISTER__SERVER__BASE_URL=http://localhost:4433
 
 EXPOSE 4433
 
@@ -75,8 +79,6 @@ USER root
 
 ENV HISTER_DATA_DIR=/hister/data
 ENV HISTER_CONFIG=/hister/data/config.yml
-ENV HISTER__SERVER__ADDRESS=0.0.0.0:4433
-ENV HISTER__SERVER__BASE_URL=http://localhost:4433
 
 EXPOSE 4433
 
@@ -99,8 +101,6 @@ USER root
 
 ENV HISTER_DATA_DIR=/hister/data
 ENV HISTER_CONFIG=/hister/data/config.yml
-ENV HISTER__SERVER__ADDRESS=0.0.0.0:4433
-ENV HISTER__SERVER__BASE_URL=http://localhost:4433
 
 EXPOSE 4433
 

--- a/config/config.go
+++ b/config/config.go
@@ -65,6 +65,11 @@ type TUI struct {
 	ThemesDir   string `yaml:"themes_dir" mapstructure:"themes_dir"`
 }
 
+var (
+	DefaultServerAddress = "127.0.0.1:4433"
+	DefaultServerBaseURL = ""
+)
+
 type Server struct {
 	Address   string                 `yaml:"address"     mapstructure:"address"`
 	BaseURL   string                 `yaml:"base_url"    mapstructure:"base_url"`
@@ -439,7 +444,8 @@ func CreateDefaultConfig() *Config {
 			DisplayExtractorConfig: false,
 		},
 		Server: Server{
-			Address:  "127.0.0.1:4433",
+			Address:  DefaultServerAddress,
+			BaseURL:  DefaultServerBaseURL,
 			Database: "db.sqlite3",
 		},
 		Indexer: Indexer{

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,9 +1,86 @@
 package config
 
 import (
+	"os"
 	"regexp"
 	"testing"
 )
+
+func TestServerDefaults(t *testing.T) {
+	oldAddress := DefaultServerAddress
+	oldBaseURL := DefaultServerBaseURL
+	t.Cleanup(func() {
+		DefaultServerAddress = oldAddress
+		DefaultServerBaseURL = oldBaseURL
+	})
+
+	DefaultServerAddress = "127.0.0.1:4433"
+	DefaultServerBaseURL = ""
+
+	cfg := CreateDefaultConfig()
+	if cfg.Server.Address != "127.0.0.1:4433" {
+		t.Fatalf("default server address=%q, want %q", cfg.Server.Address, "127.0.0.1:4433")
+	}
+	if cfg.Server.BaseURL != "" {
+		t.Fatalf("default server base_url=%q, want empty", cfg.Server.BaseURL)
+	}
+}
+
+func TestConfigFileOverridesBuildDefaults(t *testing.T) {
+	oldAddress := DefaultServerAddress
+	oldBaseURL := DefaultServerBaseURL
+	oldEnvAddress, hadEnvAddress := os.LookupEnv("HISTER__SERVER__ADDRESS")
+	oldEnvBaseURL, hadEnvBaseURL := os.LookupEnv("HISTER__SERVER__BASE_URL")
+	t.Cleanup(func() {
+		DefaultServerAddress = oldAddress
+		DefaultServerBaseURL = oldBaseURL
+		restoreEnv("HISTER__SERVER__ADDRESS", oldEnvAddress, hadEnvAddress)
+		restoreEnv("HISTER__SERVER__BASE_URL", oldEnvBaseURL, hadEnvBaseURL)
+	})
+
+	DefaultServerAddress = "0.0.0.0:4433"
+	DefaultServerBaseURL = "http://localhost:4433"
+	_ = os.Unsetenv("HISTER__SERVER__ADDRESS")
+	_ = os.Unsetenv("HISTER__SERVER__BASE_URL")
+
+	cfg, err := parseConfig([]byte("server:\n  base_url: https://hister.example.com\n"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Server.Address != "0.0.0.0:4433" {
+		t.Fatalf("server address=%q, want build default", cfg.Server.Address)
+	}
+	if cfg.Server.BaseURL != "https://hister.example.com" {
+		t.Fatalf("server base_url=%q, want config file value", cfg.Server.BaseURL)
+	}
+}
+
+func TestEnvironmentOverridesConfigFile(t *testing.T) {
+	oldEnvBaseURL, hadEnvBaseURL := os.LookupEnv("HISTER__SERVER__BASE_URL")
+	t.Cleanup(func() {
+		restoreEnv("HISTER__SERVER__BASE_URL", oldEnvBaseURL, hadEnvBaseURL)
+	})
+
+	if err := os.Setenv("HISTER__SERVER__BASE_URL", "https://env.example.com"); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := parseConfig([]byte("server:\n  base_url: https://config.example.com\n"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Server.BaseURL != "https://env.example.com" {
+		t.Fatalf("server base_url=%q, want environment value", cfg.Server.BaseURL)
+	}
+}
+
+func restoreEnv(key, value string, existed bool) {
+	if existed {
+		_ = os.Setenv(key, value)
+		return
+	}
+	_ = os.Unsetenv(key)
+}
 
 func TestBasePathPrefix(t *testing.T) {
 	tests := []struct {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -6,6 +6,14 @@ import (
 	"testing"
 )
 
+func restoreEnv(key, value string, existed bool) {
+	if existed {
+		_ = os.Setenv(key, value)
+		return
+	}
+	_ = os.Unsetenv(key)
+}
+
 func TestServerDefaults(t *testing.T) {
 	oldAddress := DefaultServerAddress
 	oldBaseURL := DefaultServerBaseURL
@@ -14,19 +22,19 @@ func TestServerDefaults(t *testing.T) {
 		DefaultServerBaseURL = oldBaseURL
 	})
 
-	DefaultServerAddress = "127.0.0.1:4433"
-	DefaultServerBaseURL = ""
+	DefaultServerAddress = "127.0.0.1:5544"
+	DefaultServerBaseURL = "https://defaults.example.com"
 
 	cfg := CreateDefaultConfig()
-	if cfg.Server.Address != "127.0.0.1:4433" {
-		t.Fatalf("default server address=%q, want %q", cfg.Server.Address, "127.0.0.1:4433")
+	if cfg.Server.Address != DefaultServerAddress {
+		t.Fatalf("default server address=%q, want %q", cfg.Server.Address, DefaultServerAddress)
 	}
-	if cfg.Server.BaseURL != "" {
-		t.Fatalf("default server base_url=%q, want empty", cfg.Server.BaseURL)
+	if cfg.Server.BaseURL != DefaultServerBaseURL {
+		t.Fatalf("default server base_url=%q, want %q", cfg.Server.BaseURL, DefaultServerBaseURL)
 	}
 }
 
-func TestConfigFileOverridesBuildDefaults(t *testing.T) {
+func TestConfigFileOverridesServerDefaults(t *testing.T) {
 	oldAddress := DefaultServerAddress
 	oldBaseURL := DefaultServerBaseURL
 	oldEnvAddress, hadEnvAddress := os.LookupEnv("HISTER__SERVER__ADDRESS")
@@ -38,48 +46,89 @@ func TestConfigFileOverridesBuildDefaults(t *testing.T) {
 		restoreEnv("HISTER__SERVER__BASE_URL", oldEnvBaseURL, hadEnvBaseURL)
 	})
 
-	DefaultServerAddress = "0.0.0.0:4433"
-	DefaultServerBaseURL = "http://localhost:4433"
+	DefaultServerAddress = "127.0.0.1:4433"
+	DefaultServerBaseURL = "http://defaults.example.com"
 	_ = os.Unsetenv("HISTER__SERVER__ADDRESS")
 	_ = os.Unsetenv("HISTER__SERVER__BASE_URL")
 
-	cfg, err := parseConfig([]byte("server:\n  base_url: https://hister.example.com\n"))
+	cfg, err := parseConfig([]byte("server:\n  address: 0.0.0.0:9999\n  base_url: https://config.example.com\n"))
 	if err != nil {
 		t.Fatal(err)
 	}
-	if cfg.Server.Address != "0.0.0.0:4433" {
-		t.Fatalf("server address=%q, want build default", cfg.Server.Address)
+	if cfg.Server.Address != "0.0.0.0:9999" {
+		t.Fatalf("server address=%q, want config file value %q", cfg.Server.Address, "0.0.0.0:9999")
 	}
-	if cfg.Server.BaseURL != "https://hister.example.com" {
-		t.Fatalf("server base_url=%q, want config file value", cfg.Server.BaseURL)
+	if cfg.Server.BaseURL != "https://config.example.com" {
+		t.Fatalf("server base_url=%q, want config file value %q", cfg.Server.BaseURL, "https://config.example.com")
 	}
 }
 
 func TestEnvironmentOverridesConfigFile(t *testing.T) {
+	oldEnvAddress, hadEnvAddress := os.LookupEnv("HISTER__SERVER__ADDRESS")
 	oldEnvBaseURL, hadEnvBaseURL := os.LookupEnv("HISTER__SERVER__BASE_URL")
 	t.Cleanup(func() {
+		restoreEnv("HISTER__SERVER__ADDRESS", oldEnvAddress, hadEnvAddress)
 		restoreEnv("HISTER__SERVER__BASE_URL", oldEnvBaseURL, hadEnvBaseURL)
 	})
 
+	if err := os.Setenv("HISTER__SERVER__ADDRESS", "0.0.0.0:9999"); err != nil {
+		t.Fatal(err)
+	}
 	if err := os.Setenv("HISTER__SERVER__BASE_URL", "https://env.example.com"); err != nil {
 		t.Fatal(err)
 	}
 
-	cfg, err := parseConfig([]byte("server:\n  base_url: https://config.example.com\n"))
+	cfg, err := parseConfig([]byte("server:\n  address: 127.0.0.1:4433\n  base_url: https://config.example.com\n"))
 	if err != nil {
 		t.Fatal(err)
 	}
+	if cfg.Server.Address != "0.0.0.0:9999" {
+		t.Fatalf("server address=%q, want environment value %q", cfg.Server.Address, "0.0.0.0:9999")
+	}
 	if cfg.Server.BaseURL != "https://env.example.com" {
-		t.Fatalf("server base_url=%q, want environment value", cfg.Server.BaseURL)
+		t.Fatalf("server base_url=%q, want environment value %q", cfg.Server.BaseURL, "https://env.example.com")
 	}
 }
 
-func restoreEnv(key, value string, existed bool) {
-	if existed {
-		_ = os.Setenv(key, value)
-		return
+func TestCLIFlagsOverrideEnvironment(t *testing.T) {
+	oldEnvAddress, hadEnvAddress := os.LookupEnv("HISTER__SERVER__ADDRESS")
+	oldEnvBaseURL, hadEnvBaseURL := os.LookupEnv("HISTER__SERVER__BASE_URL")
+	t.Cleanup(func() {
+		restoreEnv("HISTER__SERVER__ADDRESS", oldEnvAddress, hadEnvAddress)
+		restoreEnv("HISTER__SERVER__BASE_URL", oldEnvBaseURL, hadEnvBaseURL)
+	})
+
+	if err := os.Setenv("HISTER__SERVER__ADDRESS", "0.0.0.0:9999"); err != nil {
+		t.Fatal(err)
 	}
-	_ = os.Unsetenv(key)
+	if err := os.Setenv("HISTER__SERVER__BASE_URL", "https://env.example.com"); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := parseConfig([]byte("server:\n  address: 127.0.0.1:4433\n  base_url: https://config.example.com\n"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Server.Address != "0.0.0.0:9999" {
+		t.Fatalf("precondition: server address=%q, want environment value %q", cfg.Server.Address, "0.0.0.0:9999")
+	}
+	if cfg.Server.BaseURL != "https://env.example.com" {
+		t.Fatalf("precondition: server base_url=%q, want environment value %q", cfg.Server.BaseURL, "https://env.example.com")
+	}
+
+	if err := cfg.UpdateBaseURL("https://cli.example.com"); err != nil {
+		t.Fatal(err)
+	}
+	if err := cfg.UpdateListenAddress("127.0.0.1:7777"); err != nil {
+		t.Fatal(err)
+	}
+
+	if cfg.Server.Address != "127.0.0.1:7777" {
+		t.Fatalf("server address=%q, want CLI flag value %q", cfg.Server.Address, "127.0.0.1:7777")
+	}
+	if cfg.Server.BaseURL != "https://cli.example.com" {
+		t.Fatalf("server base_url=%q, want CLI flag value %q", cfg.Server.BaseURL, "https://cli.example.com")
+	}
 }
 
 func TestBasePathPrefix(t *testing.T) {


### PR DESCRIPTION
## Summary
- move Docker image server address/base URL defaults into build-time variables
- remove runtime env defaults so config files can override server.base_url
- add tests for build defaults, config-file overrides, and env precedence

## Verification
- npm ci --workspaces
- npm run build -w @hister/app
- go test ./...
