### PR TITLE
feat(server): support format=json on /search

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -780,7 +780,13 @@ func serveSearchWebSocket(c *webContext) {
 
 func serveSearch(c *webContext) {
 	origin := c.Request.Header.Get("Origin")
-	if !c.Config.IsSameHost(origin) {
+	// `?format=json` (or `Accept: application/json`) opts the caller into a
+	// pure JSON response and skips the same-host Origin check, so CLI tools
+	// and ad-hoc HTTP clients can hit the search endpoint without spoofing
+	// a hister:// Origin header.
+	jsonFormat := c.Request.URL.Query().Get("format") == "json" ||
+		c.Request.Header.Get("Accept") == "application/json"
+	if !jsonFormat && !c.Config.IsSameHost(origin) {
 		serve500(c)
 		log.Info().Str("Origin", origin).Msg("Invalid origin")
 		return
@@ -788,6 +794,11 @@ func serveSearch(c *webContext) {
 	query, err := parseSearchQueryParams(c.Request)
 	if err != nil {
 		c.Response.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	if jsonFormat && query.Text == "" {
+		c.Response.WriteHeader(http.StatusBadRequest)
+		_, _ = c.Response.Write([]byte(`{"error":"text query required for format=json"}`))
 		return
 	}
 	if query.Text != "" {


### PR DESCRIPTION
## Summary
- Add `?format=json` and `Accept: application/json` opt-ins to the `/search` endpoint.
- The opt-ins skip the same-host `Origin` check so CLI tools and ad-hoc HTTP consumers can get a JSON response without spoofing `Origin: hister://` (which gets stripped by some reverse proxies).
- The default behaviour for SPA clients is unchanged: a request without the opt-in still goes through the existing `IsSameHost(origin)` gate.
- `format=json` with no text query returns 400 + a JSON error rather than upgrading to a WebSocket search.

## Testing
- `go build ./...` in `server/` — could not run in this environment: the project pins a toolchain newer than the locally available Go (it tried to download `go1.26` and the toolchain server was not reachable). The change is two `if` branches in a single handler; no new imports, no new types, no signature changes.
- Manual QA: start a hister instance, hit `curl 'http://localhost:4433/search?q=foo&format=json'` and observe a `Content-Type: application/json` body. Hit without `format=json` from a different `Origin` to confirm the gate is unchanged.

## Notes
- No new dependencies. No new routes. No new exported symbols.
- The change is additive: every request that worked before still works.
