### PR TITLE
Semantic result count should = total results + semantic hits if this number is larger than total results

### DIFF
--- a/server/indexer/indexer.go
+++ b/server/indexer/indexer.go
@@ -1184,7 +1184,7 @@ func Search(cfg *config.Config, q *Query) (*Results, error) {
 			semanticOnlyCnt++
 		}
 	}
-	r.Total = max(r.Total, uint64(len(r.Documents)) + semanticOnlyCnt)
+	r.Total = max(r.Total, uint64(len(r.Documents))+semanticOnlyCnt)
 
 	return r, nil
 }

--- a/server/indexer/indexer.go
+++ b/server/indexer/indexer.go
@@ -1176,6 +1176,18 @@ func Search(cfg *config.Config, q *Query) (*Results, error) {
 		}
 	}
 
+	// Bump the total to reflect semantic matches that are not in the
+	// keyword results.
+	semanticOnlyCnt := uint64(0)
+	for _, sh := range r.SemanticHits {
+		if sh.Document != nil {
+			semanticOnlyCnt++
+		}
+	}
+	if docTotal := uint64(len(r.Documents)) + semanticOnlyCnt; docTotal > r.Total {
+		r.Total = docTotal
+	}
+
 	return r, nil
 }
 

--- a/server/indexer/indexer.go
+++ b/server/indexer/indexer.go
@@ -1184,9 +1184,7 @@ func Search(cfg *config.Config, q *Query) (*Results, error) {
 			semanticOnlyCnt++
 		}
 	}
-	if docTotal := uint64(len(r.Documents)) + semanticOnlyCnt; docTotal > r.Total {
-		r.Total = docTotal
-	}
+	r.Total = max(r.Total, uint64(len(r.Documents)) + semanticOnlyCnt)
 
 	return r, nil
 }

--- a/webui/app/src/routes/+page.svelte
+++ b/webui/app/src/routes/+page.svelte
@@ -1596,9 +1596,9 @@
                 class="results-toolbar flex min-w-0 flex-wrap items-center justify-between gap-2 px-1 py-2"
               >
                 <span class="font-outfit text-text-brand text-sm font-bold md:text-base">
-                  {semanticOn && config.semanticEnabled
-                    ? totalResults
-                    : lastResults?.total || totalResults} results{query ? ` for "${query}"` : ''}
+                  {lastResults?.total && lastResults.total > totalResults
+                    ? lastResults.total
+                    : totalResults} results{query ? ` for "${query}"` : ''}
                 </span>
                 <div class="flex min-w-0 flex-wrap items-center justify-end gap-2 overflow-hidden">
                   {#if isDesktop && !panelOpen && !disablePreviews}


### PR DESCRIPTION
Fixes a bug with the semantic results count. 

I *think* this works correctly, but I'm having trouble producing cases that *only* hit samentic search. :)