### PR TITLE
[enh] install yt-dlp in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ LABEL org.opencontainers.image.title="Hister" \
 
 WORKDIR /hister
 
-RUN adduser -D -u 65532 hister && mkdir -p /hister/data && chown -R 65532:65532 /hister
+RUN apk add --no-cache yt-dlp && adduser -D -u 65532 hister && mkdir -p /hister/data && chown -R 65532:65532 /hister
 COPY --chown=65532:65532 --from=builder /app/hister .
 USER 65532:65532
 
@@ -72,7 +72,7 @@ CMD ["listen"]
 FROM alpine:3.21 AS root
 WORKDIR /hister
 
-RUN mkdir -p /hister/data
+RUN apk add --no-cache yt-dlp && mkdir -p /hister/data
 COPY --from=builder /app/hister .
 
 USER root
@@ -93,7 +93,7 @@ CMD ["listen"]
 FROM alpine:3.21 AS debug
 WORKDIR /hister
 
-RUN apk add --no-cache curl bash && mkdir -p /hister/data
+RUN apk add --no-cache curl bash yt-dlp && mkdir -p /hister/data
 
 COPY --from=builder /app/hister .
 


### PR DESCRIPTION
A small change to the Dockerfile which installs the yt-dlp binary via apk.

This addresses issue #445.

Implementing the configuration UI would be a pretty big undertaking, so I've made the decision to hold off on implementing it for a few reasons:
1. The scope of the configuration UI is not defined.
2. None of the other extractors are configurable via the UI, so all the groundwork (API routes, Svelte Components, etc.) must be laid out.
3. The extractor is already configurable via the config file.

Point 2 & 3 should be worked out beforehand in the issue.

The yt-dlp extractor remains disabled by default, since other environments may not have the binary available.