### PR TITLE
[enh] add a small indicator badge to the extension icon if a URL has been indexed before

### DIFF
--- a/webui/ext/src/background/background.ts
+++ b/webui/ext/src/background/background.ts
@@ -138,9 +138,11 @@ async function updateTabIcon(tabId: number, url: string): Promise<void> {
     'histerToken',
     'indexingEnabled',
     'histerCustomHeaders',
+    'showIndexedBadge',
   ]);
 
   const serverURL: string = data['histerURL'] || '';
+  const showIndexedBadge: boolean = data['showIndexedBadge'] === true;
   const customHeaders: { name: string; value: string }[] = Array.isArray(
     data['histerCustomHeaders'],
   )
@@ -152,7 +154,7 @@ async function updateTabIcon(tabId: number, url: string): Promise<void> {
 
   if (data['indexingEnabled'] === false) {
     await setGreyIcon(tabId);
-    if (serverURL) {
+    if (showIndexedBadge && serverURL) {
       const indexed = await isUrlPreviouslyIndexed(url, serverURL, customHeaders);
       if (indexed) setPreviouslyIndexedBadge(tabId);
     }
@@ -169,12 +171,7 @@ async function updateTabIcon(tabId: number, url: string): Promise<void> {
     await setGreyIcon(tabId);
   } else {
     setNormalIcon(tabId);
-    const indexed = await isUrlPreviouslyIndexed(url, serverURL, customHeaders);
-    if (indexed) {
-      setPreviouslyIndexedBadge(tabId);
-    } else {
-      clearBadge(tabId);
-    }
+    clearBadge(tabId);
   }
 }
 
@@ -245,7 +242,7 @@ async function indexPDFTab(tabId: number, tab: chrome.tabs.Tab): Promise<void> {
     const r = await sendPDFData(u + 'api/add_pdf', doc, pdfBase64, customHeaders);
     if (r.status === 201) {
       setNormalIcon(tabId);
-      setPreviouslyIndexedBadge(tabId);
+      clearBadge(tabId);
     } else if (r.status === 406) {
       skipRulesCache = null;
       setGreyIcon(tabId);
@@ -280,7 +277,8 @@ chrome.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
 
 chrome.storage.onChanged.addListener(async (changes, area) => {
   if (area !== 'local') return;
-  if (!('indexingEnabled' in changes || 'histerURL' in changes)) return;
+  if (!('indexingEnabled' in changes || 'histerURL' in changes || 'showIndexedBadge' in changes))
+    return;
   if ('histerURL' in changes) skipRulesCache = null;
   try {
     const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
@@ -413,7 +411,7 @@ function cjsMsgHandler(request, sender, sendResponse) {
             .then((r) => {
               if (r.status === 201) {
                 setNormalIcon(sender.tab.id);
-                setPreviouslyIndexedBadge(sender.tab.id);
+                clearBadge(sender.tab.id);
               } else if (r.status === 406) {
                 // URL matched a server-side skip rule; invalidate cache and grey out
                 skipRulesCache = null;

--- a/webui/ext/src/background/background.ts
+++ b/webui/ext/src/background/background.ts
@@ -14,6 +14,15 @@ function setErrorBadge(tabId: number) {
   );
 }
 
+function setPreviouslyIndexedBadge(tabId: number) {
+  chrome.action.setBadgeText({ text: '✓', tabId }, () => void chrome.runtime.lastError);
+  chrome.action.setBadgeBackgroundColor(
+    { color: '#44aa44', tabId },
+    () => void chrome.runtime.lastError,
+  );
+  chrome.action.setBadgeTextColor({ color: '#ffffff', tabId }, () => void chrome.runtime.lastError);
+}
+
 function clearBadge(tabId: number) {
   chrome.action.setBadgeText({ text: '', tabId }, () => void chrome.runtime.lastError);
 }
@@ -131,17 +140,7 @@ async function updateTabIcon(tabId: number, url: string): Promise<void> {
     'histerCustomHeaders',
   ]);
 
-  if (data['indexingEnabled'] === false) {
-    await setGreyIcon(tabId);
-    return;
-  }
-
   const serverURL: string = data['histerURL'] || '';
-  if (!serverURL) {
-    await setNormalIcon(tabId);
-    return;
-  }
-
   const customHeaders: { name: string; value: string }[] = Array.isArray(
     data['histerCustomHeaders'],
   )
@@ -151,11 +150,31 @@ async function updateTabIcon(tabId: number, url: string): Promise<void> {
     customHeaders.push({ name: 'X-Access-Token', value: data['histerToken'] });
   }
 
+  if (data['indexingEnabled'] === false) {
+    await setGreyIcon(tabId);
+    if (serverURL) {
+      const indexed = await isUrlPreviouslyIndexed(url, serverURL, customHeaders);
+      if (indexed) setPreviouslyIndexedBadge(tabId);
+    }
+    return;
+  }
+
+  if (!serverURL) {
+    setNormalIcon(tabId);
+    return;
+  }
+
   const patterns = await getSkipPatterns(serverURL, customHeaders);
   if (patterns.some((re) => re.test(url))) {
     await setGreyIcon(tabId);
   } else {
-    await setNormalIcon(tabId);
+    setNormalIcon(tabId);
+    const indexed = await isUrlPreviouslyIndexed(url, serverURL, customHeaders);
+    if (indexed) {
+      setPreviouslyIndexedBadge(tabId);
+    } else {
+      clearBadge(tabId);
+    }
   }
 }
 
@@ -225,8 +244,8 @@ async function indexPDFTab(tabId: number, tab: chrome.tabs.Tab): Promise<void> {
 
     const r = await sendPDFData(u + 'api/add_pdf', doc, pdfBase64, customHeaders);
     if (r.status === 201) {
-      clearBadge(tabId);
       setNormalIcon(tabId);
+      setPreviouslyIndexedBadge(tabId);
     } else if (r.status === 406) {
       skipRulesCache = null;
       setGreyIcon(tabId);
@@ -268,6 +287,23 @@ chrome.storage.onChanged.addListener(async (changes, area) => {
     if (tab?.id && tab.url) await updateTabIcon(tab.id, tab.url);
   } catch (_) {}
 });
+
+async function isUrlPreviouslyIndexed(
+  url: string,
+  serverURL: string,
+  customHeaders: { name: string; value: string }[],
+): Promise<boolean> {
+  try {
+    const base = serverURL.endsWith('/') ? serverURL : serverURL + '/';
+    const r = await fetchAPI(`${base}api/document?url=${encodeURIComponent(url)}`, {
+      method: 'HEAD',
+      customHeaders,
+    });
+    return r.status === 200;
+  } catch (_) {
+    return false;
+  }
+}
 
 // --- Message handler ---
 
@@ -376,8 +412,8 @@ function cjsMsgHandler(request, sender, sendResponse) {
           sendPageData(u + 'api/add', pageData, customHeaders)
             .then((r) => {
               if (r.status === 201) {
-                clearBadge(sender.tab.id);
                 setNormalIcon(sender.tab.id);
+                setPreviouslyIndexedBadge(sender.tab.id);
               } else if (r.status === 406) {
                 // URL matched a server-side skip rule; invalidate cache and grey out
                 skipRulesCache = null;

--- a/webui/ext/src/popup/Popup.svelte
+++ b/webui/ext/src/popup/Popup.svelte
@@ -16,6 +16,7 @@
   let url = $state(defaultURL);
   let customHeaders: { name: string; value: string }[] = $state([]);
   let indexingEnabled = $state(true);
+  let showIndexedBadge = $state(false);
   let message = $state('');
   let messageType: 'success' | 'error' | 'info' = $state('success');
   let showSettings = $state(false);
@@ -78,7 +79,14 @@
   }
 
   chrome.storage.local.get(
-    ['histerURL', 'histerCustomHeaders', 'indexingEnabled', 'histerCookies', 'histerLabel'],
+    [
+      'histerURL',
+      'histerCustomHeaders',
+      'indexingEnabled',
+      'histerCookies',
+      'histerLabel',
+      'showIndexedBadge',
+    ],
     (data) => {
       if (!data['histerURL']) {
         chrome.storage.local.set({ histerURL: defaultURL });
@@ -86,6 +94,7 @@
       url = data['histerURL'] || defaultURL;
       customHeaders = Array.isArray(data['histerCustomHeaders']) ? data['histerCustomHeaders'] : [];
       indexingEnabled = data['indexingEnabled'] !== false;
+      showIndexedBadge = data['showIndexedBadge'] === true;
       pageLabel = data['histerLabel'] || '';
 
       checkAuth(url, data['histerCookies'] || '');
@@ -199,6 +208,10 @@
   function toggleIndexing() {
     chrome.storage.local.set({ indexingEnabled: indexingEnabled });
     setSuccessMessage(`Automatic indexing ${indexingEnabled ? 'enabled' : 'disabled'}`);
+  }
+
+  function toggleShowIndexedBadge() {
+    chrome.storage.local.set({ showIndexedBadge: showIndexedBadge });
   }
 
   function authenticate() {
@@ -360,6 +373,22 @@
           Automatic indexing
         </Label>
         <Switch id="indexing" bind:checked={indexingEnabled} onCheckedChange={toggleIndexing} />
+      </div>
+      <div class="mt-3 flex items-center justify-between" class:opacity-40={indexingEnabled}>
+        <Label
+          for="show-indexed-badge"
+          class="font-outfit text-text-brand text-sm font-bold {indexingEnabled
+            ? 'cursor-not-allowed'
+            : 'cursor-pointer'}"
+        >
+          Show indicator for indexed pages
+        </Label>
+        <Switch
+          id="show-indexed-badge"
+          bind:checked={showIndexedBadge}
+          onCheckedChange={toggleShowIndexedBadge}
+          disabled={indexingEnabled}
+        />
       </div>
     </div>
 


### PR DESCRIPTION
This PR closes #483 

It adds a HEAD request to the `/api/document` route on every tab activation. The endpoint returns a 200 if the url has been indexed before. If that is the case, a small green check badge is added to the extension icon (see screenshots below). 

<small>with automatic indexing enabled</small>
<img width="44" height="70" alt="image" src="https://github.com/user-attachments/assets/4c5923d6-e362-4dc8-a662-e269d17120d8" />

<small>with automatic indexing disabled</small>
<img width="35" height="49" alt="image" src="https://github.com/user-attachments/assets/eb106e00-f5db-4a0c-a1f9-6874007e32b8" />

I'd like some feedback on the indicator; Does it need further explanation in the popup? Different icon? Color? etc. Thanks!