### PR TITLE
add org mode extractor

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -104,6 +104,7 @@ require (
 	github.com/mschoch/smat v0.2.0 // indirect
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
+	github.com/niklasfasching/go-org v1.9.1 // indirect
 	github.com/pelletier/go-toml/v2 v2.4.0 // indirect
 	github.com/pierrec/lz4/v4 v4.1.27 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -192,6 +192,8 @@ github.com/muesli/cancelreader v0.2.2 h1:3I4Kt4BQjOR54NavqnDogx/MIoWBFa0StPA8ELU
 github.com/muesli/cancelreader v0.2.2/go.mod h1:3XuTXfFS2VjM+HTLZY9Ak0l6eUKfijIfMUZ4EgX0QYo=
 github.com/muesli/termenv v0.16.0 h1:S5AlUN9dENB57rsbnkPyfdGuWIlkmzJjbFf0Tf5FWUc=
 github.com/muesli/termenv v0.16.0/go.mod h1:ZRfOIKPFDYQoDFF4Olj7/QJbW60Ol/kL1pU3VfY/Cnk=
+github.com/niklasfasching/go-org v1.9.1 h1:/3s4uTPOF06pImGa2Yvlp24yKXZoTYM+nsIlMzfpg/0=
+github.com/niklasfasching/go-org v1.9.1/go.mod h1:ZAGFFkWvUQcpazmi/8nHqwvARpr1xpb+Es67oUGX/48=
 github.com/orisano/pixelmatch v0.0.0-20220722002657-fb0b55479cde h1:x0TT0RDC7UhAVbbWWBzr41ElhJx5tXPWkIHA2HWPRuw=
 github.com/orisano/pixelmatch v0.0.0-20220722002657-fb0b55479cde/go.mod h1:nZgzbfBr3hhjoZnS66nKrHmduYNpc34ny7RK4z5/HM0=
 github.com/pelletier/go-toml/v2 v2.4.0 h1:Mwu0mAkUKbittDs3/ADDWXqMmq3EOK2VHiuCkV00Row=

--- a/server/extractor/extractor.go
+++ b/server/extractor/extractor.go
@@ -25,6 +25,7 @@ import (
 	"github.com/asciimoo/hister/server/extractor/extractors/markdown"
 	"github.com/asciimoo/hister/server/extractor/extractors/mastodon"
 	"github.com/asciimoo/hister/server/extractor/extractors/notion"
+	"github.com/asciimoo/hister/server/extractor/extractors/org"
 	"github.com/asciimoo/hister/server/extractor/extractors/stackexchange"
 	"github.com/asciimoo/hister/server/extractor/extractors/wikipedia"
 	"github.com/asciimoo/hister/server/extractor/extractors/ytdlp"
@@ -135,6 +136,7 @@ func List() []ExtractorInfo {
 
 var extractors = []Extractor{
 	&markdown.MarkdownExtractor{},
+	&org.OrgModeExtractor{},
 	&embeddedvideo.EmbeddedVideoExtractor{},
 	&jsonld.JSONLDExtractor{},
 	&stackexchange.StackExchangeExtractor{},

--- a/server/extractor/extractors/org/org.go
+++ b/server/extractor/extractors/org/org.go
@@ -1,0 +1,61 @@
+package org
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/asciimoo/hister/config"
+	"github.com/asciimoo/hister/server/document"
+	"github.com/asciimoo/hister/server/sanitizer"
+	"github.com/asciimoo/hister/server/types"
+)
+
+// OrgModeExtractor serves previews for locally indexed Org files.
+// During indexing, indexer.AddOrg renders the source to HTML and stores
+// it in doc.HTML, so Preview only needs to sanitize that HTML.
+type OrgModeExtractor struct {
+	cfg *config.Extractor
+}
+
+func (e *OrgModeExtractor) Name() string { return "OrgMode" }
+
+func (e *OrgModeExtractor) Description() string {
+	return "Renders locally indexed Org files (.org) as HTML for preview."
+}
+
+func (e *OrgModeExtractor) GetConfig() *config.Extractor {
+	if e.cfg == nil {
+		return &config.Extractor{Enable: true, Options: map[string]any{}}
+	}
+	return e.cfg
+}
+
+func (e *OrgModeExtractor) SetConfig(c *config.Extractor) error {
+	for k := range c.Options {
+		return fmt.Errorf("unknown option %q", k)
+	}
+	e.cfg = c
+	return nil
+}
+
+// Match returns true for file:// URLs with an  .org extension.
+func (e *OrgModeExtractor) Match(d *document.Document) bool {
+	if !strings.HasPrefix(d.URL, "file://") {
+		return false
+	}
+	lower := strings.ToLower(d.URL)
+	return strings.HasSuffix(lower, ".org")
+}
+
+// Extract is a no-op: indexing is handled by indexer.AddOrg.
+func (e *OrgModeExtractor) Extract(_ *document.Document) (types.ExtractorState, error) {
+	return types.ExtractorContinue, nil
+}
+
+// Preview sanitizes the rendered HTML stored in doc.HTML.
+func (e *OrgModeExtractor) Preview(d *document.Document) (types.PreviewResponse, types.ExtractorState, error) {
+	if d.HTML == "" {
+		return types.PreviewResponse{}, types.ExtractorContinue, nil
+	}
+	return types.PreviewResponse{Content: sanitizer.SanitizeHTML(d.HTML)}, types.ExtractorStop, nil
+}

--- a/server/extractor/extractors/org/org.go
+++ b/server/extractor/extractors/org/org.go
@@ -38,7 +38,7 @@ func (e *OrgModeExtractor) SetConfig(c *config.Extractor) error {
 	return nil
 }
 
-// Match returns true for file:// URLs with an  .org extension.
+// Match returns true for file:// URLs with an .org extension.
 func (e *OrgModeExtractor) Match(d *document.Document) bool {
 	if !strings.HasPrefix(d.URL, "file://") {
 		return false

--- a/server/indexer/files.go
+++ b/server/indexer/files.go
@@ -132,6 +132,10 @@ func IndexFile(path string, userID uint) error {
 		return AddMarkdown(doc, content)
 	}
 
+	if strings.EqualFold(filepath.Ext(path), ".org") {
+		return AddOrg(doc, content)
+	}
+
 	if !utf8.Valid(content) {
 		return ErrBinaryFile
 	}

--- a/server/indexer/org.go
+++ b/server/indexer/org.go
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package indexer
+
+import (
+	"errors"
+	"github.com/asciimoo/hister/server/document"
+)
+
+// AddOrg renders TODO to HTML, stores it in d.HTML, and stores the raw
+// source in d.Text for full-text indexing.
+func AddOrg(d *document.Document, src []byte) error {
+	return errors.New("Not implemented yet")
+}

--- a/server/indexer/org.go
+++ b/server/indexer/org.go
@@ -8,9 +8,10 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/niklasfasching/go-org/org"
+
 	"github.com/asciimoo/hister/server/document"
 	"github.com/asciimoo/hister/server/sanitizer"
-	"github.com/niklasfasching/go-org/org"
 )
 
 // AddOrg renders Org files to HTML, stores it in d.HTML, and stores the raw

--- a/server/indexer/org.go
+++ b/server/indexer/org.go
@@ -3,12 +3,41 @@
 package indexer
 
 import (
+	"bytes"
 	"errors"
+	"fmt"
+	"strings"
+
 	"github.com/asciimoo/hister/server/document"
+	"github.com/asciimoo/hister/server/sanitizer"
+	"github.com/niklasfasching/go-org/org"
 )
 
-// AddOrg renders TODO to HTML, stores it in d.HTML, and stores the raw
+// AddOrg renders Org files to HTML, stores it in d.HTML, and stores the raw
 // source in d.Text for full-text indexing.
-func AddOrg(d *document.Document, src []byte) error {
-	return errors.New("Not implemented yet")
+func AddOrg(d *document.Document, orgData []byte) error {
+	src := strings.TrimSpace(string(orgData))
+	if src == "" {
+		return errors.New("org file empty")
+	}
+	html, title, err := renderOrg(orgData)
+	if err != nil {
+		return fmt.Errorf("rendering org: %w", err)
+	}
+	d.HTML = html
+	d.Text = sanitizer.SanitizeText(d.HTML)
+	d.Title = title
+	d.AddMetadata("type", "org")
+	return Add(d)
+}
+
+func renderOrg(src []byte) (string, string, error) {
+	doc := org.New().Parse(bytes.NewReader(src), "./")
+
+	html, error := doc.Write(org.NewHTMLWriter())
+	if error != nil {
+		return "", "", error
+	}
+	title := doc.Get("TITLE")
+	return html, title, nil
 }


### PR DESCRIPTION
This PR adds a new file extractor for .org files. I tried to stay as close as possible to the existing Markdown extractor. It's worth mentioning that this PR introduces [go-org](https://github.com/niklasfasching/go-org) as a dependency to the project. go-org is also used by [Hugo](https://github.com/gohugoio/hugo/blob/master/markup/org/convert.go) to render Org files to HTML. I tested it against my personal wiki, and all files render without issues.

@asciimoo already mentioned adding an interface to handle local file types better. This is still missing. Let me know how we could introduce it, and I will also include it in this PR.

<img width="1904" height="990" alt="image" src="https://github.com/user-attachments/assets/47528301-713b-4079-adf6-bd6bec699ba2" />

Kind regards,
cashmere