### PR TITLE
[fix] keep title when importing if document doesn't have one

### DIFF
--- a/server/extractor/extractor.go
+++ b/server/extractor/extractor.go
@@ -291,7 +291,7 @@ func (e *basicExtractor) Match(_ *document.Document) bool {
 }
 
 func (e *basicExtractor) Extract(d *document.Document) (types.ExtractorState, error) {
-	d.Title = ""
+	var extractedTitle strings.Builder
 	r := strings.NewReader(d.HTML)
 	doc := html.NewTokenizer(r)
 	inBody := false
@@ -319,7 +319,7 @@ out:
 			}
 		case html.TextToken:
 			if currentTag == "title" {
-				d.Title += strings.TrimSpace(string(doc.Text()))
+				extractedTitle.WriteString(strings.TrimSpace(string(doc.Text())))
 			}
 			if inBody && !skip {
 				text.Write(doc.Text())
@@ -335,6 +335,9 @@ out:
 		}
 	}
 	d.Text = strings.TrimSpace(text.String())
+	if extractedTitle.String() != "" {
+		d.Title = extractedTitle.String()
+	}
 	if d.Text == "" && d.Title == "" {
 		return types.ExtractorStop, errors.New("no content found")
 	}
@@ -373,7 +376,9 @@ func (e *readabilityExtractor) Extract(d *document.Document) (types.ExtractorSta
 		return types.ExtractorContinue, err
 	}
 	d.Text = buf.String()
-	d.Title = a.Title()
+	if t := a.Title(); t != "" {
+		d.Title = t
+	}
 	d.SetFaviconURL(a.Favicon())
 	writeReadabilityMeta(d, a)
 	return types.ExtractorStop, nil


### PR DESCRIPTION
I was looking to create a dataset for hister, more specifically RFC. RFC provides a nice way to sync the RFCs files without having to crawl their website using `rsync`. The problem is that the synced HTML files they provide, they are only the `<body>` of the HTML, they don't have any metadata or header but when you sync those files, they do include `.json` files with metadata from which you can extract information such as the title of the RFC.

The problem was that I tried to create a script that would create JSON with all the RFCs using the `.json` metadata for title but when I imported the JSON I noticed that none of the imported documents had title and rendered as `*title*` on the webui.

So what I noticed is that when importing, the extractor would overwrite the `title` key from the importing json and try to extract `<title>` from the HTML document provided, but since they don't have one, they would be left empty.

**What this PR does is that it tries to respect the `title` from the imported JSON if it doesn't find `<title>` in the HTML document when importing.**

From what I can gather, Hister doesn't provide a way to modify manually the title yet, so the "use-case" for this PR would be only for someone who is creating a dataset/custom history with an HTML that doesn't have a `<title>` and want to respect the given title in the JSON file.

Here is an example of an entry (I'll shorten it as the HTML can be big and the whole document is not relevant):

```
{
    "url": "https://www.rfc-editor.org/rfc/rfc1.html",
    "domain": "www.rfc-editor.org",
    "html": "<pre>Network Working Group                                   Steve Crocker\nRequest for Comments: 1                                          UCLA\n                                                         7 April 1969\n\n\n                         <span class=\"h1\">Title:   Host Software</span>\n                        <span class=\"h1\">Author:   Steve Crocker</span>\n                          <span class=\"h1\">Installation:   UCLA</span>\n                          Date:   7 April 1969\n             Network Working Group Request for Comment:   1\n\n\nCONTENTS\n\nINTRODUCTION\n\n  I. A Summary of the IMP Software...",
    "title": "Host Software",
    "text": "\n\n\n\n\n\nNetwork Working Group                                   Steve Crocker\nRequest for Comments: 1                                          UCLA\n                                                         7 April 1969\n\n\n                         Title:   Host Software\n                        Author:   Steve Crocker\n                          Installation:   UCLA\n                          Date:   7 April 1969\n             Network Working Group Request for Comment:   1\n\n\nCONTENTS\n\nINTRODUCTION\n\n  I. A Summary of the IMP Software...",
    "language": "en",
    "label": "rfc",
    "skip_sensitive_check": true,
    "favicon": "..."
}
```

As you can see the HTML doesn't have `<title>` but the JSON itself does have one, extracted from the metadata. This PR will still look for a title in the HTML but won't overwrite it if it doesn't find one and keep the `title` key from the json.