### PR TITLE
Add a sample systemd unit

### DIFF
--- a/contrib/systemd/hister.service
+++ b/contrib/systemd/hister.service
@@ -1,0 +1,43 @@
+[Unit]
+Description=Hister web history service
+After=network.target
+
+[Service]
+Type=simple
+User=hister
+Group=hister
+StateDirectory=hister
+Environment=HISTER_DATA_DIR=/var/lib/hister
+EnvironmentFile=-/etc/hister/hister.env
+ExecStart=/usr/local/bin/hister listen
+Restart=on-failure
+
+# For privileged ports (< 1024), set both values to CAP_NET_BIND_SERVICE.
+AmbientCapabilities=
+CapabilityBoundingSet=
+
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+PrivateTmp=true
+PrivateDevices=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectKernelLogs=true
+ProtectControlGroups=true
+ProtectClock=true
+ProtectHostname=true
+ProtectProc=invisible
+ProcSubset=pid
+LockPersonality=true
+RestrictNamespaces=true
+RestrictRealtime=true
+RestrictSUIDSGID=true
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
+SystemCallArchitectures=native
+SystemCallFilter=@system-service ~@privileged
+MemoryDenyWriteExecute=true
+UMask=0077
+
+[Install]
+WantedBy=multi-user.target

--- a/webui/website/src/content/docs/installing.md
+++ b/webui/website/src/content/docs/installing.md
@@ -147,6 +147,7 @@ services.hister = {
 - To manage settings through the config file only, leave `port` and `dataDir` unset
 - `services.hister.config` was renamed to `services.hister.settings` to align with the nixpkgs `services.*.settings` convention. The old name still works via `mkRenamedOptionModule` but emits a deprecation warning.
 - On NixOS the systemd unit ships with a hardened `serviceConfig` (`ProtectSystem=strict`, `NoNewPrivileges`, private `/tmp` and `/dev`, an `AF_INET{,6}`/`AF_UNIX` address-family filter, `@system-service` syscall filter, `MemoryDenyWriteExecute`, etc.). Binding a privileged port (`< 1024`) automatically adds `CAP_NET_BIND_SERVICE`.
+- On other systemd-based Linux distributions, see the sample unit at [`contrib/systemd/hister.service`](https://github.com/asciimoo/hister/blob/master/contrib/systemd/hister.service).
 - On macOS (both `darwinModules` and `homeModules`) the launchd agent uses `KeepAlive = { Crashed = true; SuccessfulExit = false; }` so fatal config errors that exit 0 are not hidden, plus `ProcessType = "Background"` and `RunAtLoad = true`.
 - The home-manager module now gates the systemd user unit on Linux and the launchd agent on Darwin, so a single `homeModules.hister` import works on either host.
 


### PR DESCRIPTION
Adds a sample systemd unit for non-Nix Linux installs, matching the hardening options already used by the NixOS module as closely as a reusable example can.

This gives #459 a copyable starting point without changing the packaged service.

Checked:
- npm exec prettier -- --check webui/website/src/content/docs/installing.md
- npm -w @hister/website run build

I could not run systemd-analyze on this macOS host.

AI disclosure: I used Codex to help prepare this small docs/service-file patch and compare it against the existing NixOS unit settings.