### PR TITLE
[fix] import line size too small for nodejs

### DIFF
--- a/cmd/import_export.go
+++ b/cmd/import_export.go
@@ -282,7 +282,7 @@ func importJSONFile(c *client.Client, inputFile string, skip bool, startDate, en
 		reader = f
 	}
 
-	const maxLineSize = 16 * 1024 * 1024 // 16 MB covers large HTML+favicon lines
+	const maxLineSize = 64 * 1024 * 1024 // 64 MB covers large HTML+favicon lines
 	scanner := bufio.NewScanner(reader)
 	scanner.Buffer(make([]byte, 64*1024), maxLineSize)
 


### PR DESCRIPTION
I was running some benchmarks and I noticed really low times when importing `nodejs-api.json`. I took a look at the logs and noticed the import command was throwing this warning:

```
$ ./hister import datasets/nodejs-api.json 
2026-07-08T13:55:27-04:00 | WARN   | cmd/import_export.go:327 > Failed to read input file error="bufio.Scanner: token too long" file=datasets/nodejs-api.json
✓ Imported 0 document(s) (1 errors)
```

And when I took at the first JSONL from `nodejs-api.json` I noticed that it was 30MB in size, and in the code it only allows up to 16MB.

So I changed it to 64MB, to leave room in case a bigger JSONL appears and should fix the import of `nodejs-api.json`. (I suppose these are just edge cases, if we ever need more, then the internet might be doomed.)

---
As a side note it seems to simply stop at the first JSONL and does not continue reading the file as it seems to imply the code by this `return imported, skipped, errCount`. 