### PR TITLE
[enh] Processing file checks field already set in JSON

### DIFF
--- a/server/document/document.go
+++ b/server/document/document.go
@@ -138,10 +138,12 @@ func (d *Document) Process(ld LanguageDetector, extractFn func(*Document) error)
 		return errors.New("invalid URL: missing scheme/host")
 	}
 	d.normalizeWebURL(pu)
-	d.Added = time.Now().Unix()
+	if d.Added == 0 {
+		d.Added = time.Now().Unix()
+	}
 	d.Type = types.Web
 	d.Domain = pu.Hostname()
-	if d.HTML != "" {
+	if d.HTML != "" && d.Text == "" {
 		if err := extractFn(d); err != nil {
 			return err
 		}
@@ -207,7 +209,9 @@ func (d *Document) processFile(ld LanguageDetector) error {
 
 // finalizeDocument sets the document language and marks it as processed.
 func (d *Document) finalizeDocument(ld LanguageDetector) {
-	d.Language = ld.DetectLanguage(d.Text)
+	if d.Language == "" || d.Language == UnknownLanguage {
+		d.Language = ld.DetectLanguage(d.Text)
+	}
 	d.processed = true
 }
 

--- a/server/document/document_test.go
+++ b/server/document/document_test.go
@@ -1,0 +1,168 @@
+package document
+
+import (
+	"errors"
+	"testing"
+)
+
+// fakeDetector records the text it was asked to detect and returns a fixed
+// language, so tests can assert whether detection ran.
+type fakeDetector struct {
+	called   bool
+	gotText  string
+	language string
+}
+
+func (f *fakeDetector) DetectLanguage(s string) string {
+	f.called = true
+	f.gotText = s
+	return f.language
+}
+
+const sampleHTML = `<html><head><title>Raw Title</title></head><body><p>raw body</p></body></html>`
+
+func TestProcessSkipsExtractionWhenTextPresent(t *testing.T) {
+	d := &Document{
+		URL:   "https://example.com/a",
+		HTML:  sampleHTML,
+		Text:  "pre-extracted text",
+		Title: "Imported Title",
+	}
+	ld := &fakeDetector{language: "fr"}
+
+	extractCalled := false
+	extractFn := func(*Document) error {
+		extractCalled = true
+		return nil
+	}
+	if err := d.Process(ld, extractFn); err != nil {
+		t.Fatalf("Process() unexpected error: %v", err)
+	}
+	if extractCalled {
+		t.Fatalf("extraction should be skipped when Text is already set")
+	}
+	if d.Text != "pre-extracted text" {
+		t.Errorf("Text = %q, want %q", d.Text, "pre-extracted text")
+	}
+	if d.Title != "Imported Title" {
+		t.Errorf("Title = %q, want %q", d.Title, "Imported Title")
+	}
+}
+
+func TestProcessRunsExtractionWhenTextAbsent(t *testing.T) {
+	d := &Document{
+		URL:  "https://example.com/a",
+		HTML: sampleHTML,
+	}
+	ld := &fakeDetector{language: "en"}
+
+	extractCalled := false
+	extractFn := func(doc *Document) error {
+		extractCalled = true
+		doc.Text = "extracted text"
+		doc.Title = "Extracted Title"
+		return nil
+	}
+	if err := d.Process(ld, extractFn); err != nil {
+		t.Fatalf("Process() unexpected error: %v", err)
+	}
+	if !extractCalled {
+		t.Fatalf("extraction should run when Text is empty")
+	}
+	if d.Text != "extracted text" {
+		t.Errorf("Text = %q, want %q", d.Text, "extracted text")
+	}
+}
+
+func TestProcessExtractionErrorPropagated(t *testing.T) {
+	d := &Document{
+		URL:  "https://example.com/a",
+		HTML: sampleHTML,
+	}
+	sentinel := errors.New("boom")
+	extractFn := func(*Document) error { return sentinel }
+	if err := d.Process(&fakeDetector{language: "en"}, extractFn); err != sentinel {
+		t.Fatalf("Process() error = %v, want %v", err, sentinel)
+	}
+}
+
+func TestProcessPreservesPresetLanguage(t *testing.T) {
+	d := &Document{
+		URL:      "https://example.com/a",
+		Text:     "some content",
+		Language: "de",
+	}
+	ld := &fakeDetector{language: "en"}
+	if err := d.Process(ld, func(*Document) error { return nil }); err != nil {
+		t.Fatalf("Process() unexpected error: %v", err)
+	}
+	if ld.called {
+		t.Fatalf("language detection should be skipped when Language is set")
+	}
+	if d.Language != "de" {
+		t.Errorf("Language = %q, want %q", d.Language, "de")
+	}
+}
+
+func TestProcessDetectsLanguageWhenAbsent(t *testing.T) {
+	d := &Document{
+		URL:  "https://example.com/a",
+		Text: "some content",
+	}
+	ld := &fakeDetector{language: "en"}
+	if err := d.Process(ld, func(*Document) error { return nil }); err != nil {
+		t.Fatalf("Process() unexpected error: %v", err)
+	}
+	if !ld.called {
+		t.Fatalf("language detection should run when Language is empty")
+	}
+	if d.Language != "en" {
+		t.Errorf("Language = %q, want %q", d.Language, "en")
+	}
+}
+
+func TestProcessRedetectsWhenLanguageUnknown(t *testing.T) {
+	d := &Document{
+		URL:      "https://example.com/a",
+		Text:     "some content",
+		Language: UnknownLanguage,
+	}
+	ld := &fakeDetector{language: "en"}
+	if err := d.Process(ld, func(*Document) error { return nil }); err != nil {
+		t.Fatalf("Process() unexpected error: %v", err)
+	}
+	if !ld.called {
+		t.Fatalf("language detection should run when Language is unknown")
+	}
+	if d.Language != "en" {
+		t.Errorf("Language = %q, want %q", d.Language, "en")
+	}
+}
+
+func TestProcessPreservesPresetAdded(t *testing.T) {
+	const orig = int64(1_700_000_000)
+	d := &Document{
+		URL:   "https://example.com/a",
+		Text:  "content",
+		Added: orig,
+	}
+	if err := d.Process(&fakeDetector{language: "en"}, func(*Document) error { return nil }); err != nil {
+		t.Fatalf("Process() unexpected error: %v", err)
+	}
+	if d.Added != orig {
+		t.Errorf("Added = %d, want %d", d.Added, orig)
+	}
+}
+
+func TestProcessSetsAddedWhenZero(t *testing.T) {
+	d := &Document{
+		URL:  "https://example.com/a",
+		Text: "content",
+	}
+	if err := d.Process(&fakeDetector{language: "en"}, func(*Document) error { return nil }); err != nil {
+		t.Fatalf("Process() unexpected error: %v", err)
+	}
+	if d.Added == 0 {
+		t.Fatalf("Added should be set when zero")
+	}
+}


### PR DESCRIPTION
When processing the JSONL, instead of extracting the text again and trying to detect the language again, it first checks whether the document has a text set and if it has a language set. Also instead of rewriting the time it was indexed, it will check whether this value is 0 or not. For example if a user exports to back up their data, and later decide to import it, it will keep the time it was originally indexed, while datasets or other type of JSONL created should not have an added time key, so it actually sets the current time.

I used [hyperfine](https://github.com/sharkdp/hyperfine) to benchmark these changes with the following command `hyperfine -w 0 -r 5 -p "sync; echo 3 | sudo tee /proc/sys/vm/drop_caches; rm -rf ~/.config/hister && ./hister -l error listen & sleep 2" -C "pkill hister || true && rm -rf ~/.config/hister" --parameter-list file datasets/go-stdlib.json,datasets/python-docs.json,datasets/mdn-html.json,datasets/nodejs-api.json --export-markdown benchmark-results.md "./hister import {file}"`

* No warmup
* 5 runs per dataset import
* Always starts from a clean state (deletes hister storage)
* Clears  OS cache

Before:

| Command | Mean [s] | Min [s] | Max [s] |
|:---|---:|---:|---:|
| `./hister import datasets/go-stdlib.json` | 21.741 ± 7.376 | 15.799 | 33.927 |
| `./hister import datasets/python-docs.json` | 27.931 ± 0.474 | 27.435 | 28.697 |
| `./hister import datasets/mdn-html.json` | 22.548 ± 1.360 | 20.593 | 23.841 |
| `./hister import datasets/nodejs-api.json` | 14.762 ± 2.722 | 12.715 | 18.583 |

This PR:

| Command | Mean [s] | Min [s] | Max [s] |
|:---|---:|---:|---:|
| `./hister import datasets/go-stdlib.json` | 18.752 ± 9.692 | 12.767 | 35.990 |
| `./hister import datasets/python-docs.json` | 23.677 ± 2.236 | 20.372 | 26.624 |
| `./hister import datasets/mdn-html.json` | 19.385 ± 4.954 | 15.705 | 27.549 |
| `./hister import datasets/nodejs-api.json` | 11.841 ± 3.623 | 9.091 | 17.308 |



I used GLM-5.2 to make the changes and it decided to add tests for `document.go`. I did review the changes.