### PR TITLE
GitHub issue preview

### DIFF
--- a/server/extractor/extractors/github/github.go
+++ b/server/extractor/extractors/github/github.go
@@ -97,13 +97,14 @@ var (
 type githubPattern = struct {
 	re      *regexp.Regexp
 	handler func(*document.Document) (types.ExtractorState, error)
+	preview func(*document.Document) (types.PreviewResponse, types.ExtractorState, error)
 }
 
 var githubPatterns = []githubPattern{
-	{fullRepoRe, extractRepo},
-	{issueRe, extractIssue},
-	{issuesRe, extractIssues},
-	{prRe, extractPull},
+	{fullRepoRe, extractRepo, previewRepo},
+	{issueRe, extractIssue, previewIssue},
+	{issuesRe, extractIssues, previewIssues},
+	{prRe, extractPull, previewPull},
 }
 
 // Match returns true for known github URLs, defined in githubPatterns
@@ -144,57 +145,14 @@ func (e *GitHubExtractor) Extract(d *document.Document) (types.ExtractorState, e
 	return types.ExtractorContinue, fmt.Errorf("no extractor matched for %s", d.URL)
 }
 
-// Preview renders a summary card (description, stars, topics, languages) and
-// the sanitized README HTML suitable for the preview panel.
 func (e *GitHubExtractor) Preview(d *document.Document) (types.PreviewResponse, types.ExtractorState, error) {
-	doc, err := goquery.NewDocumentFromReader(strings.NewReader(d.HTML))
-	if err != nil {
-		return types.PreviewResponse{}, types.ExtractorContinue, err
-	}
-
-	info := parseRepoPage(doc, d.HTML)
-	if info == nil {
-		return types.PreviewResponse{}, types.ExtractorContinue, nil
-	}
-
-	var b strings.Builder
-
-	// Metadata card.
-	b.WriteString(`<div class="gh-meta">`)
-
-	if info.description != "" {
-		fmt.Fprintf(&b, `<p class="gh-description">%s</p>`, stdhtml.EscapeString(info.description))
-	}
-
-	if info.stars != "" || len(info.languages) > 0 {
-		b.WriteString(`<p class="gh-stats">`)
-		parts := make([]string, 0, 2)
-		if info.stars != "" {
-			parts = append(parts, fmt.Sprintf("&#9733; %s stars", stdhtml.EscapeString(info.stars)))
+	for _, p := range githubPatterns {
+		if p.re.MatchString(d.URL) {
+			return p.preview(d)
 		}
-		if len(info.languages) > 0 {
-			parts = append(parts, stdhtml.EscapeString(strings.Join(info.languages, " / ")))
-		}
-		b.WriteString(strings.Join(parts, " &nbsp;&middot;&nbsp; "))
-		b.WriteString("</p>")
 	}
 
-	if len(info.topics) > 0 {
-		b.WriteString(`<p class="gh-topics">`)
-		for _, t := range info.topics {
-			fmt.Fprintf(&b, `<code>%s</code> `, stdhtml.EscapeString(t))
-		}
-		b.WriteString("</p>")
-	}
-
-	b.WriteString("</div>")
-
-	if info.readmeHTML != "" {
-		b.WriteString("<hr>")
-		b.WriteString(sanitizer.SanitizeHTML(info.readmeHTML))
-	}
-
-	return types.PreviewResponse{Content: b.String()}, types.ExtractorStop, nil
+	return types.PreviewResponse{}, types.ExtractorContinue, fmt.Errorf("no previewer matched for %s", d.URL)
 }
 
 // --- Repositories --------------------------------------------------------
@@ -265,6 +223,59 @@ func extractRepo(d *document.Document) (types.ExtractorState, error) {
 		return types.ExtractorContinue, fmt.Errorf("no content found")
 	}
 	return types.ExtractorStop, nil
+}
+
+// Preview renders a summary card (description, stars, topics, languages) and
+// the sanitized README HTML suitable for the preview panel.
+func previewRepo(d *document.Document) (types.PreviewResponse, types.ExtractorState, error) {
+	doc, err := goquery.NewDocumentFromReader(strings.NewReader(d.HTML))
+	if err != nil {
+		return types.PreviewResponse{}, types.ExtractorContinue, err
+	}
+
+	info := parseRepoPage(doc, d.HTML)
+	if info == nil {
+		return types.PreviewResponse{}, types.ExtractorContinue, nil
+	}
+
+	var b strings.Builder
+
+	// Metadata card.
+	b.WriteString(`<div class="gh-meta">`)
+
+	if info.description != "" {
+		fmt.Fprintf(&b, `<p class="gh-description">%s</p>`, stdhtml.EscapeString(info.description))
+	}
+
+	if info.stars != "" || len(info.languages) > 0 {
+		b.WriteString(`<p class="gh-stats">`)
+		parts := make([]string, 0, 2)
+		if info.stars != "" {
+			parts = append(parts, fmt.Sprintf("&#9733; %s stars", stdhtml.EscapeString(info.stars)))
+		}
+		if len(info.languages) > 0 {
+			parts = append(parts, stdhtml.EscapeString(strings.Join(info.languages, " / ")))
+		}
+		b.WriteString(strings.Join(parts, " &nbsp;&middot;&nbsp; "))
+		b.WriteString("</p>")
+	}
+
+	if len(info.topics) > 0 {
+		b.WriteString(`<p class="gh-topics">`)
+		for _, t := range info.topics {
+			fmt.Fprintf(&b, `<code>%s</code> `, stdhtml.EscapeString(t))
+		}
+		b.WriteString("</p>")
+	}
+
+	b.WriteString("</div>")
+
+	if info.readmeHTML != "" {
+		b.WriteString("<hr>")
+		b.WriteString(sanitizer.SanitizeHTML(info.readmeHTML))
+	}
+
+	return types.PreviewResponse{Content: b.String()}, types.ExtractorStop, nil
 }
 
 // repoInfo holds the extracted fields from a GitHub repository page.
@@ -452,6 +463,10 @@ func extractIssue(d *document.Document) (types.ExtractorState, error) {
 	return types.ExtractorStop, nil
 }
 
+func previewIssue(d *document.Document) (types.PreviewResponse, types.ExtractorState, error) {
+	return types.PreviewResponse{}, types.ExtractorContinue, nil
+}
+
 func extractIssues(d *document.Document) (types.ExtractorState, error) {
 	doc, err := goquery.NewDocumentFromReader(strings.NewReader(d.HTML))
 	if err != nil {
@@ -491,6 +506,10 @@ func extractIssues(d *document.Document) (types.ExtractorState, error) {
 		return types.ExtractorContinue, fmt.Errorf("no content found")
 	}
 	return types.ExtractorStop, nil
+}
+
+func previewIssues(d *document.Document) (types.PreviewResponse, types.ExtractorState, error) {
+	return types.PreviewResponse{}, types.ExtractorContinue, nil
 }
 
 // --- Pull Requests -------------------------------------------------------
@@ -539,4 +558,8 @@ func extractPull(d *document.Document) (types.ExtractorState, error) {
 	}
 
 	return types.ExtractorStop, nil
+}
+
+func previewPull(d *document.Document) (types.PreviewResponse, types.ExtractorState, error) {
+	return types.PreviewResponse{}, types.ExtractorContinue, nil
 }

--- a/server/extractor/extractors/github/github.go
+++ b/server/extractor/extractors/github/github.go
@@ -465,7 +465,33 @@ func extractIssue(d *document.Document) (types.ExtractorState, error) {
 }
 
 func previewIssue(d *document.Document) (types.PreviewResponse, types.ExtractorState, error) {
-	return types.PreviewResponse{}, types.ExtractorContinue, nil
+	doc, err := goquery.NewDocumentFromReader(strings.NewReader(d.HTML))
+	if err != nil {
+		return types.PreviewResponse{}, types.ExtractorContinue, err
+	}
+
+	info := parseIssue(doc)
+	if info == nil {
+		return types.PreviewResponse{}, types.ExtractorContinue, nil
+	}
+
+	var b strings.Builder
+
+	fmt.Println(info.title)
+	fmt.Println(info.body)
+	if info.title != "" {
+		fmt.Fprintf(&b, "<h1>%s</h1>", info.title)
+	}
+
+	if info.body != "" {
+		fmt.Fprintf(&b, "<hr>%s", info.body)
+	}
+
+	if len(info.commentBodies) > 0 {
+		fmt.Fprintf(&b, "<hr>%s", strings.Join(info.commentBodies, "<br><br>"))
+	}
+
+	return types.PreviewResponse{Content: b.String()}, types.ExtractorStop, nil
 }
 
 type issueInfo struct {

--- a/server/extractor/extractors/github/github.go
+++ b/server/extractor/extractors/github/github.go
@@ -436,24 +436,25 @@ func extractIssue(d *document.Document) (types.ExtractorState, error) {
 		d.Metadata["repo"] = repo
 	}
 
-	if title := doc.Find(`bdi[data-testid="issue-title"]`).Text(); title != "" {
-		d.Metadata["title"] = title
-		fmt.Fprintf(&b, "title: %s\n\n", title)
+	info := parseIssue(doc)
+	if info == nil {
+		return types.ExtractorContinue, nil
+	}
+
+	if info.title != "" {
+		d.Metadata["title"] = info.title
+		fmt.Fprintf(&b, "title: %s\n\n", info.title)
 	}
 	if dateOpened := doc.Find(`[data-testid="issue-body"] relative-time`).AttrOr("datetime", ""); dateOpened != "" {
 		d.Metadata["date"] = dateOpened
 	}
 
-	if body := doc.Find(`#issue-body-viewer`).Text(); body != "" {
-		fmt.Fprintf(&b, "body: %s\n\n", body)
+	if info.body != "" {
+		fmt.Fprintf(&b, "body: %s\n\n", info.body)
 	}
 
-	var commentBodies []string
-	doc.Find(`[data-testid="issue-viewer-comments-container"] [data-testid="markdown-body"]`).Each(func(_ int, s *goquery.Selection) {
-		commentBodies = append(commentBodies, strings.TrimSpace(s.Text()))
-	})
-	if len(commentBodies) > 0 {
-		fmt.Fprintf(&b, "comments: %s\n", strings.Join(commentBodies, ", "))
+	if len(info.commentBodies) > 0 {
+		fmt.Fprintf(&b, "comments: %s\n", strings.Join(info.commentBodies, ", "))
 	}
 
 	d.Text = strings.TrimSpace(b.String())
@@ -465,6 +466,29 @@ func extractIssue(d *document.Document) (types.ExtractorState, error) {
 
 func previewIssue(d *document.Document) (types.PreviewResponse, types.ExtractorState, error) {
 	return types.PreviewResponse{}, types.ExtractorContinue, nil
+}
+
+type issueInfo struct {
+	title         string
+	body          string
+	commentBodies []string
+}
+
+func parseIssue(doc *goquery.Document) *issueInfo {
+	info := &issueInfo{}
+
+	if title := doc.Find(`bdi[data-testid="issue-title"]`).Text(); title != "" {
+		info.title = title
+	}
+	if body := doc.Find(`#issue-body-viewer`).Text(); body != "" {
+		info.body = body
+	}
+
+	doc.Find(`[data-testid="issue-viewer-comments-container"] [data-testid="markdown-body"]`).Each(func(_ int, s *goquery.Selection) {
+		info.commentBodies = append(info.commentBodies, strings.TrimSpace(s.Text()))
+	})
+
+	return info
 }
 
 func extractIssues(d *document.Document) (types.ExtractorState, error) {

--- a/server/extractor/extractors/github/github.go
+++ b/server/extractor/extractors/github/github.go
@@ -170,7 +170,7 @@ func extractRepo(d *document.Document) (types.ExtractorState, error) {
 		return types.ExtractorContinue, err
 	}
 
-	info := parseRepoPage(doc, d.HTML)
+	info := parseRepoPage(doc)
 	if info == nil {
 		return types.ExtractorContinue, nil
 	}
@@ -233,7 +233,7 @@ func previewRepo(d *document.Document) (types.PreviewResponse, types.ExtractorSt
 		return types.PreviewResponse{}, types.ExtractorContinue, err
 	}
 
-	info := parseRepoPage(doc, d.HTML)
+	info := parseRepoPage(doc)
 	if info == nil {
 		return types.PreviewResponse{}, types.ExtractorContinue, nil
 	}
@@ -292,7 +292,7 @@ var starsRe = regexp.MustCompile(`^([\d,]+)\s+users?\s+starred\s+this\s+reposito
 
 // parseRepoPage extracts repository metadata from the parsed goquery document.
 // Returns nil if the page does not appear to be a repository overview page.
-func parseRepoPage(doc *goquery.Document, rawHTML string) *repoInfo {
+func parseRepoPage(doc *goquery.Document) *repoInfo {
 	info := &repoInfo{}
 
 	// Description: the sidebar "about" paragraph (class varies by page version).

--- a/server/extractor/extractors/github/github_test.go
+++ b/server/extractor/extractors/github/github_test.go
@@ -272,6 +272,7 @@ const issuePage = `<html>
 		<div data-testid="markdown-body">
 		  <h1 dir="auto">This is a meta issue raising awareness to contribute to existing extractors or add new ones</h1>
 		  <p dir="auto">Extractors are modules that provide custom, content-specific document parsing or rendering functions to enhance the data quality of Hister. [...]</p>
+		  <ul><li><div><div><div><div><div data-testid="tasklist-item-0-0"><div><div></div><div id="checkbox-item-0"><input disabled="" aria-required="false" aria-invalid="false" aria-label="Video information extractor using yt-dlp (@FlameFlag) checklist item" data-component="Checkbox" type="checkbox" checked="" aria-checked="true"><div> Video information extractor using<code>yt-dlp</code> (@FlameFlag)</div></div></div><div></div></div></div></div><div><div><div data-testid="tasklist-item-0-1"><div><div></div><div id="checkbox-item-1"><input disabled="" aria-required="false" aria-invalid="false" aria-label="GitHub project information extractor checklist item" data-component="Checkbox" type="checkbox" aria-checked="false"><div> GitHub project information extractor</div></div></div><div></div></div></div></div><div><div><div data-testid="tasklist-item-0-2"><div><div></div><div id="checkbox-item-2"><input disabled="" aria-required="false" aria-invalid="false" aria-label="General StackExchange question/answer extractor checklist item" data-component="Checkbox" type="checkbox" checked="" aria-checked="true"><div> General StackExchange question/answer extractor</div></div></div><div></div></div></div></div><div><div><div data-testid="tasklist-item-0-3"><div><div></div><div id="checkbox-item-3"><input disabled="" aria-required="false" aria-invalid="false" aria-label="Reddit post extractor (@dinzz005) checklist item" data-component="Checkbox" type="checkbox" aria-checked="false"><div> Reddit post extractor (<a data-hovercard-type="user" data-hovercard-url="/users/dinzz005/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="https://github.com/dinzz005" aria-keyshortcuts="Alt+ArrowUp">@dinzz005</a>)</div></div></div><div></div></div></div></div></div></div></li></ul>
 		</div>
       </div>
 	</div>
@@ -349,8 +350,17 @@ func TestPreviewIssue(t *testing.T) {
 	if c == "" {
 		t.Fatalf("content is empty")
 	}
-	if !strings.Contains(c, `<h1>This is a meta issue raising awareness to contribute to existing extractors or add new ones</h1>`) {
-		t.Error("Preview should contain the issue title, if it exists")
+	if !strings.Contains(c, `<h1>Extractors wanted!</h1>`) {
+		t.Error("Preview should contain the issue title")
+	}
+	if !strings.Contains(c, `This is a meta issue raising awareness to contribute to existing extractors or add new ones`) {
+		t.Error("Preview should contain the issue body, if it exists")
+	}
+	if !strings.Contains(c, `General StackExchange question/answer extractor`) {
+		t.Error("Preview should contain the issue body, if it exists")
+	}
+	if !strings.Contains(c, `Thanks bro, is there any deadline for this ???`) {
+		t.Error("Preview should contain the issue comments")
 	}
 }
 

--- a/server/extractor/extractors/github/github_test.go
+++ b/server/extractor/extractors/github/github_test.go
@@ -332,6 +332,28 @@ func TestExtractIssuePage(t *testing.T) {
 	}
 }
 
+func TestPreviewIssue(t *testing.T) {
+	d := &document.Document{
+		URL:  "https://github.com/asciimoo/hister/issues/305",
+		HTML: issuePage,
+	}
+	e := &GitHubExtractor{}
+	response, state, err := e.Preview(d)
+	c := response.Content
+	if err != nil {
+		t.Fatalf("Extract error: %v", err)
+	}
+	if state != types.ExtractorStop {
+		t.Fatalf("state = %v, want Stop", state)
+	}
+	if c == "" {
+		t.Fatalf("content is empty")
+	}
+	if !strings.Contains(c, `<h1>This is a meta issue raising awareness to contribute to existing extractors or add new ones</h1>`) {
+		t.Error("Preview should contain the issue title, if it exists")
+	}
+}
+
 const issuesPage = `<html>
 <head><title>Issues · asciimoo/hister</title></head>
 <body>

--- a/server/extractor/extractors/github/github_test.go
+++ b/server/extractor/extractors/github/github_test.go
@@ -218,6 +218,37 @@ func TestExtractRepo(t *testing.T) {
 	}
 }
 
+func TestPreviewRepo(t *testing.T) {
+	d := &document.Document{
+		URL:  "https://github.com/asciimoo/hister",
+		HTML: minimalRepoPage,
+	}
+	e := &GitHubExtractor{}
+	response, state, err := e.Preview(d)
+	c := response.Content
+	if err != nil {
+		t.Fatalf("Extract error: %v", err)
+	}
+	if state != types.ExtractorStop {
+		t.Fatalf("state = %v, want Stop", state)
+	}
+	if c == "" {
+		t.Fatalf("content is empty")
+	}
+	if !strings.Contains(c, `<p class="gh-description">Your own search engine</p>`) {
+		t.Error("Preview should contain the description")
+	}
+	if !strings.Contains(c, "<h1>Hister</h1>") {
+		t.Error("Preview should contain the README, properly formatted")
+	}
+	if !strings.Contains(c, "Hister is a general purpose web search engine providing automatic full-text indexing for visited websites") {
+		t.Error("Preview should contain the README body")
+	}
+	if !strings.Contains(c, `<p class="gh-stats">`) {
+		t.Errorf("Preview should show the stats nicely")
+	}
+}
+
 // --- Issue ---------------------------------------------------------------
 const issuePage = `<html>
 <head><title>Extractors wanted! · Issue #305 · asciimoo/hister</title></head>


### PR DESCRIPTION
Hi!

Still a bit WIP, the preview is quite ugly for now, since I don't do any styling or wrapping in `<div class="gh-meta">` like the preview repo.

Question though: where did those `gh-meta` and `gh-description` classnames come from? Can any preview function create their own structure, or is there some documented/standard anywhere?