### PR TITLE
Add option to auto-index page only once

### DIFF
--- a/webui/ext/src/background/background.ts
+++ b/webui/ext/src/background/background.ts
@@ -544,7 +544,7 @@ function cjsMsgHandler(request, sender, sendResponse) {
           let r;
           try {
             r = await sendPageData(u + 'api/add', pageData, customHeaders);
-          } catch(err) {
+          } catch (err) {
             setErrorBadge(sender.tab.id);
             sendResponse({ error: err.message });
             return;

--- a/webui/ext/src/background/background.ts
+++ b/webui/ext/src/background/background.ts
@@ -448,6 +448,7 @@ function cjsMsgHandler(request, sender, sendResponse) {
       'histerURL',
       'histerToken',
       'indexingEnabled',
+      'indexOnlyOnce',
       'histerCustomHeaders',
       'showIndexedBadge',
       'submitPublicDocuments',
@@ -455,6 +456,7 @@ function cjsMsgHandler(request, sender, sendResponse) {
     .then((data) => {
       let u = data['histerURL'] || '';
       const indexingEnabled = data['indexingEnabled'] !== false;
+      const indexOnlyOnce = data['indexOnlyOnce'] !== false;
       const showIndexedBadge = data['showIndexedBadge'] === true;
       const customHeaders = getCustomHeaders(data);
 
@@ -505,42 +507,68 @@ function cjsMsgHandler(request, sender, sendResponse) {
         u += '/';
       }
       if (request.pageData) {
-        if (!indexingEnabled && request.action != 'reindex') {
+        if (!indexingEnabled && request.action !== 'reindex') {
           sendResponse({ status: 'disabled' });
           return;
         }
-        chrome.storage.local.get(['histerLabel']).then((labelData) => {
-          const pageData = { ...request.pageData };
-          if (labelData['histerLabel']) {
-            pageData.label = labelData['histerLabel'];
+        (async () => {
+          let labelData;
+          try {
+            labelData = await chrome.storage.local.get(['histerLabel']);
+          } catch {
+            return;
           }
-          sendPageData(u + 'api/add', pageData, getDocumentSubmissionHeaders(data))
-            .then((r) => {
-              if (r.status === 201) {
+
+          const customHeaders = getDocumentSubmissionHeaders(data);
+          if (indexOnlyOnce && request.action !== 'reindex') {
+            try {
+              const indexed = await isUrlPreviouslyIndexed(request.pageData.url, u, customHeaders);
+              if (indexed) {
                 setNormalIcon(sender.tab.id);
                 if (showIndexedBadge) {
                   setPreviouslyIndexedBadge(sender.tab.id);
                 } else {
                   clearBadge(sender.tab.id);
                 }
-              } else if (r.status === 406) {
-                // URL matched a server-side skip rule; invalidate cache and grey out
-                skipRulesCache = null;
-                setGreyIcon(sender.tab.id);
-              } else if (r.status === 422) {
-                // Document rejected due to sensitive content; not an error
-                tabSensitiveState.set(sender.tab.id, sender.tab.url ?? '');
-                setGreyIcon(sender.tab.id);
-              } else {
-                setErrorBadge(sender.tab.id);
+                return;
               }
-              sendResponse({ status: 'ok', status_code: r.status });
-            })
-            .catch((err) => {
-              setErrorBadge(sender.tab.id);
-              sendResponse({ error: err.message });
-            });
-        });
+            } catch {
+              // isUrlPreviouslyIndexed must have failed, try adding the page manually
+            }
+          }
+
+          const pageData = { ...request.pageData };
+          if (labelData['histerLabel']) {
+            pageData.label = labelData['histerLabel'];
+          }
+          let r;
+          try {
+            r = await sendPageData(u + 'api/add', pageData, customHeaders);
+          } catch(err) {
+            setErrorBadge(sender.tab.id);
+            sendResponse({ error: err.message });
+            return;
+          }
+          if (r.status === 201) {
+            setNormalIcon(sender.tab.id);
+            if (showIndexedBadge) {
+              setPreviouslyIndexedBadge(sender.tab.id);
+            } else {
+              clearBadge(sender.tab.id);
+            }
+          } else if (r.status === 406) {
+            // URL matched a server-side skip rule; invalidate cache and grey out
+            skipRulesCache = null;
+            setGreyIcon(sender.tab.id);
+          } else if (r.status === 422) {
+            // Document rejected due to sensitive content; not an error
+            tabSensitiveState.set(sender.tab.id, sender.tab.url ?? '');
+            setGreyIcon(sender.tab.id);
+          } else {
+            setErrorBadge(sender.tab.id);
+          }
+          sendResponse({ status: 'ok', status_code: r.status });
+        })();
         return true;
       }
       if (request.resultData) {

--- a/webui/ext/src/background/background.ts
+++ b/webui/ext/src/background/background.ts
@@ -456,7 +456,7 @@ function cjsMsgHandler(request, sender, sendResponse) {
     .then((data) => {
       let u = data['histerURL'] || '';
       const indexingEnabled = data['indexingEnabled'] !== false;
-      const indexOnlyOnce = data['indexOnlyOnce'] !== false;
+      const indexOnlyOnce = data['indexOnlyOnce'] === true;
       const showIndexedBadge = data['showIndexedBadge'] === true;
       const customHeaders = getCustomHeaders(data);
 

--- a/webui/ext/src/popup/Popup.svelte
+++ b/webui/ext/src/popup/Popup.svelte
@@ -112,6 +112,7 @@
       'histerURL',
       'histerCustomHeaders',
       'indexingEnabled',
+      'indexOnlyOnce',
       'histerCookies',
       'histerLabel',
       'showIndexedBadge',
@@ -247,6 +248,7 @@
 
   function toggleIndexOnlyOnce() {
     chrome.storage.local.set({ indexOnlyOnce: indexOnlyOnce });
+    setSuccessMessage(`Index only once ${indexOnlyOnce ? 'enabled' : 'disabled'}`);
   }
 
   function toggleShowIndexedBadge() {

--- a/webui/ext/src/popup/Popup.svelte
+++ b/webui/ext/src/popup/Popup.svelte
@@ -361,7 +361,7 @@
         e.preventDefault();
         chrome.tabs.create({ url });
       }}
-      class="font-outfit text-lg font-black tracking-widest text-white uppercase hover:underline cursor-pointer"
+      class="font-outfit cursor-pointer text-lg font-black tracking-widest text-white uppercase hover:underline"
       >Hister</a
     >
     <div class="flex items-center gap-2">

--- a/webui/ext/src/popup/Popup.svelte
+++ b/webui/ext/src/popup/Popup.svelte
@@ -246,13 +246,12 @@
     setSuccessMessage(`Automatic indexing ${indexingEnabled ? 'enabled' : 'disabled'}`);
   }
 
-  function toggleIndexOnlyOnce() {
-    chrome.storage.local.set({ indexOnlyOnce: indexOnlyOnce });
-    setSuccessMessage(`Index only once ${indexOnlyOnce ? 'enabled' : 'disabled'}`);
-  }
-
   function toggleShowIndexedBadge() {
     chrome.storage.local.set({ showIndexedBadge: showIndexedBadge });
+  }
+
+  function toggleIndexOnlyOnce() {
+    chrome.storage.local.set({ indexOnlyOnce: indexOnlyOnce });
   }
 
   function toggleSubmitPublicDocuments() {

--- a/webui/ext/src/popup/Popup.svelte
+++ b/webui/ext/src/popup/Popup.svelte
@@ -406,6 +406,20 @@
             />
           </div>
 
+          <div class="flex items-center justify-between">
+            <Label
+              for="index-only-once"
+              class="font-outfit text-text-brand cursor-pointer text-sm font-bold"
+            >
+              Index only once
+            </Label>
+            <Switch
+              id="index-only-once"
+              bind:checked={indexOnlyOnce}
+              onCheckedChange={toggleIndexOnlyOnce}
+            />
+          </div>
+
           {#if isAuthenticated(profileUserID)}
             <div class="flex items-center justify-between">
               <Label
@@ -451,17 +465,6 @@
         </Label>
         <Switch id="indexing" bind:checked={indexingEnabled} onCheckedChange={toggleIndexing} />
       </div>
-      <label
-        class="font-inter text-text-brand-secondary mt-1 flex cursor-pointer items-center gap-2 text-xs select-none"
-      >
-        <input
-          type="checkbox"
-          bind:checked={indexOnlyOnce}
-          onchange={toggleIndexOnlyOnce}
-          class="accent-hister-rose h-3.5 w-3.5 cursor-pointer"
-        />
-        Index only once
-      </label>
     </div>
 
     <!-- Reindex section -->

--- a/webui/ext/src/popup/Popup.svelte
+++ b/webui/ext/src/popup/Popup.svelte
@@ -16,6 +16,7 @@
   let url = $state(defaultURL);
   let customHeaders: { name: string; value: string }[] = $state([]);
   let indexingEnabled = $state(true);
+  let indexOnlyOnce = $state(false);
   let showIndexedBadge = $state(false);
   let submitPublicDocuments = $state(false);
   let profileUserID = $state(0);
@@ -124,6 +125,7 @@
       url = data['histerURL'] || defaultURL;
       customHeaders = Array.isArray(data['histerCustomHeaders']) ? data['histerCustomHeaders'] : [];
       indexingEnabled = data['indexingEnabled'] !== false;
+      indexOnlyOnce = data['indexOnlyOnce'] === true;
       showIndexedBadge = data['showIndexedBadge'] === true;
       submitPublicDocuments = data['submitPublicDocuments'] === true;
       profileUserID = Number(data['histerProfileUserID'] ?? 0);
@@ -241,6 +243,10 @@
   function toggleIndexing() {
     chrome.storage.local.set({ indexingEnabled: indexingEnabled });
     setSuccessMessage(`Automatic indexing ${indexingEnabled ? 'enabled' : 'disabled'}`);
+  }
+
+  function toggleIndexOnlyOnce() {
+    chrome.storage.local.set({ indexOnlyOnce: indexOnlyOnce });
   }
 
   function toggleShowIndexedBadge() {
@@ -443,6 +449,17 @@
         </Label>
         <Switch id="indexing" bind:checked={indexingEnabled} onCheckedChange={toggleIndexing} />
       </div>
+      <label
+        class="font-inter text-text-brand-secondary mt-1 flex cursor-pointer items-center gap-2 text-xs select-none"
+      >
+        <input
+          type="checkbox"
+          bind:checked={indexOnlyOnce}
+          onchange={toggleIndexOnlyOnce}
+          class="accent-hister-rose h-3.5 w-3.5 cursor-pointer"
+        />
+        Index only once
+      </label>
     </div>
 
     <!-- Reindex section -->


### PR DESCRIPTION
This PR adds a checkbox to the web extension to skip auto indexing if the page is already indexed.

<img width="388" height="213" alt="image" src="https://github.com/user-attachments/assets/a578a29b-ccc5-41a6-adb5-136a26bfb131" />

Right now the cjsMsgHandler function nests a lot of callbacks. For clarity I refactored the relevant block into an anonymous async function. I would rather the handler be one async function but that's outside the scope of this PR.

Motivation: I use hister and the web extension primarily as an archival tool. There are a lot of sites (i.e. link aggregator sites) that I don't want archived. In contrast long form content like articles or blog posts are read once and usually do not receive updates. Adding this option allows me to skip the first set of sites while archiving the latter.

AI Disclosure: pi+deepseek was used to modify the UI and add the input checkbox. The rest was coded by hand.
