### PR TITLE
Add required scope param to Google OAuth redirect

### DIFF
--- a/server/oauth/google.go
+++ b/server/oauth/google.go
@@ -31,6 +31,13 @@ func (g GoogleOAuth) Prepare(_ context.Context, _ *PrepareRequest) error { retur
 func (g GoogleOAuth) GetRedirectURL(req *RedirectURIRequest) string {
 	params := &url.Values{}
 
+	scopeName, scopeValue := g.GetScope()
+	if len(req.scopes) > 0 { // config-based scopes
+		params.Add(scopeName.String(), strings.Join(req.scopes, " "))
+	} else { // default scopes
+		params.Add(scopeName.String(), scopeValue.String())
+	}
+
 	params.Add("client_id", req.clientID)
 	params.Add("response_type", responseTypeCode.String())
 	params.Add("redirect_uri", req.redirectURI)


### PR DESCRIPTION
[Google OAuth 2.0 endpoint](https://developers.google.com/identity/protocols/oauth2/web-server#httprest_1:~:text=web%20server%20applications.-,scope,Required,-A%20space%2Ddelimited) expects scope param as **required**. This commit adds it using the pre-existing implementation of GetScope, making it in-line with GitHub OAuth implementation, but diverges from OIDC implementation which uses scopes provided from the request itself.

Without this param, the OAuth flow fails with [`invalid_request`](https://developers.google.com/identity/protocols/oauth2/web-server#:~:text=The%20request%20was%20missing%20required%20parameters).

Few review notes:
- I don't really write go, so review with heavy scrutiny, I'm happy to learn.
- I couldn't find a consistent approach, between GitHub, OIDC and Google auth, I'm looking for input.

Tests passed, and I'm currently running this code on my instance, so I thought I'd sned the changes back