### PR TITLE
[fix] submit pending page changes on tab close

### DIFF
--- a/webui/ext/src/content/content.ts
+++ b/webui/ext/src/content/content.ts
@@ -38,6 +38,25 @@ if (typeof window.navigation !== 'undefined') {
   window.navigation.addEventListener('navigatesuccess', update);
 }
 
+// Submit the latest page state when the tab is being hidden or closed.
+document.addEventListener('visibilitychange', () => {
+  if (!document.hidden || !d || !isContextValid()) return;
+  let current;
+  try {
+    current = extractPageData();
+  } catch (_) {
+    return;
+  }
+  if (current.html != d.html || current.url != d.url || current.title != d.title) {
+    d = current;
+    chrome.runtime.sendMessage({ pageData: d }, (resp) => {
+      if (resp?.status_code === 406) {
+        skippedUrl = d.url;
+      }
+    });
+  }
+});
+
 function scheduleUpdate() {
   if (updateTimer !== null) {
     clearTimeout(updateTimer);
@@ -107,7 +126,7 @@ function update() {
     console.log('failed to extract page data', e);
     return;
   }
-  if (d2.html != d.html || d2.url != d.url) {
+  if (d2.html != d.html || d2.url != d.url || d2.title != d.title) {
     sleepTime = defaultSleepTime;
     d = d2;
     if (d2.url === skippedUrl) {


### PR DESCRIPTION
After a soft navigation, the page title may update after the initial submission. The existing polling corrects this, but only if the tab stays open long enough.

This adds a `visibilitychange` handler that re-extracts the page when the tab is hidden or closed. If the content differs from the last submission, it is sent to the server. No MutationObserver, no dirty tracking, no fixed delays.

Also includes title in the polling change detection so title-only updates are not missed.

Verified with `npm run build -w @hister/ext` and Prettier.

AI disclosure: Codex assisted with implementation and review.
