### PR TITLE
[fix] fully qualify column names in ON CONFLICT statements

### DIFF
--- a/server/model/embedding.go
+++ b/server/model/embedding.go
@@ -59,23 +59,23 @@ func EnqueueEmbeddingJob(docID string) error {
 		Columns: []clause.Column{{Name: "doc_id"}},
 		DoUpdates: clause.Assignments(map[string]any{
 			"status": gorm.Expr(
-				"CASE WHEN status = ? THEN status ELSE ? END",
+				"CASE WHEN embedding_jobs.status = ? THEN embedding_jobs.status ELSE ? END",
 				EmbeddingJobInProgress, EmbeddingJobPending,
 			),
 			"dirty": gorm.Expr(
-				"CASE WHEN status = ? THEN ? ELSE dirty END",
+				"CASE WHEN embedding_jobs.status = ? THEN ? ELSE embedding_jobs.dirty END",
 				EmbeddingJobInProgress, true,
 			),
 			"attempts": gorm.Expr(
-				"CASE WHEN status = ? THEN attempts ELSE 0 END",
+				"CASE WHEN embedding_jobs.status = ? THEN embedding_jobs.attempts ELSE 0 END",
 				EmbeddingJobInProgress,
 			),
 			"available_at": gorm.Expr(
-				"CASE WHEN status = ? THEN available_at ELSE ? END",
+				"CASE WHEN embedding_jobs.status = ? THEN embedding_jobs.available_at ELSE ? END",
 				EmbeddingJobInProgress, now,
 			),
 			"last_error": gorm.Expr(
-				"CASE WHEN status = ? THEN last_error ELSE '' END",
+				"CASE WHEN embedding_jobs.status = ? THEN embedding_jobs.last_error ELSE '' END",
 				EmbeddingJobInProgress,
 			),
 			"updated_at": now,


### PR DESCRIPTION
SQLite accepts it, but Postgres requires ambiguous columns to be qualified, otherwise it rejects the request with SQLSTATE 42702 (see #572). I did a search across the server directory and didn't find any other occurrence of this, but I'm happy to revise if other areas need this fix as well. Given the ambiguity I could have gotten the table name wrong as well.  

Also I couldn't find any Postgres tests in here, so no tests :/ (could also expand this PR with test infra, or follow up)

Closes #572 (currently when a user has postgres enabled, embeddings don't work)

AI Usage: I used it to slurp the error messsage from my logs, nothing else.