### PR TITLE
Catch if path is empty we dont append a / to the requested route.

### DIFF
--- a/webui/app/src/lib/api.ts
+++ b/webui/app/src/lib/api.ts
@@ -36,6 +36,9 @@ let _config: AppConfig | null = null;
 let _csrf: string = '';
 
 function apiPath(path: string): string {
+  if (path === '') {
+    return `${base}/api`;
+  }
   return `${base}/api${path.startsWith('/') ? path : `/${path}`}`;
 }
 


### PR DESCRIPTION
I noticed the api endpoints page was empty, issue caused by appending a / to empty path string. This caused the muxServer to respond with the default / respons meaning the whole default route for SPA making the parsing fail.