### PR TITLE
[enh] add a config option for the profiling endpoints

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -63,6 +63,7 @@ type App struct {
 	RedirectOnNoResults    bool   `yaml:"redirect_on_no_results" mapstructure:"redirect_on_no_results"`
 	DisplayExtractorConfig bool   `yaml:"display_extractor_config" mapstructure:"display_extractor_config"`
 	DisablePreviews        bool   `yaml:"disable_previews" mapstructure:"disable_previews"`
+	Profiler               bool   `yaml:"profiler" mapstructure:"profiler"`
 }
 
 type TUI struct {

--- a/server/debug_test.go
+++ b/server/debug_test.go
@@ -8,20 +8,20 @@ import (
 	"github.com/asciimoo/hister/server/testutil"
 )
 
-func TestDebugHeapProfileDisabledOutsideDebugLogLevel(t *testing.T) {
-	_, handler := newTokenTestServerWithLogLevel(t, false, "info")
+func TestDebugHeapProfileDisabledByDefault(t *testing.T) {
+	_, handler := newTokenTestServerWithProfiler(t, false, false)
 
 	rec := testutil.ServeHTTP(t, handler, http.MethodGet, "/debug/pprof/heap?debug=1", nil, map[string]string{
 		"X-Access-Token": "secret",
 	})
 
 	if strings.Contains(rec.Body.String(), "heap profile:") {
-		t.Fatal("heap profile was exposed outside debug log level")
+		t.Fatal("heap profile was exposed while app.profiler was off")
 	}
 }
 
 func TestDebugHeapProfileRequiresToken(t *testing.T) {
-	_, handler := newTokenTestServerWithLogLevel(t, false, "debug")
+	_, handler := newTokenTestServerWithProfiler(t, false, true)
 
 	rec := testutil.ServeHTTP(t, handler, http.MethodGet, "/debug/pprof/heap?debug=1", nil, nil)
 
@@ -31,7 +31,7 @@ func TestDebugHeapProfileRequiresToken(t *testing.T) {
 }
 
 func TestDebugHeapProfileServedWithToken(t *testing.T) {
-	_, handler := newTokenTestServerWithLogLevel(t, false, "debug")
+	_, handler := newTokenTestServerWithProfiler(t, false, true)
 
 	rec := testutil.ServeHTTP(t, handler, http.MethodGet, "/debug/pprof/heap?debug=1", nil, map[string]string{
 		"X-Access-Token": "secret",
@@ -46,7 +46,7 @@ func TestDebugHeapProfileServedWithToken(t *testing.T) {
 }
 
 func TestDebugPprofIndexServedWithToken(t *testing.T) {
-	_, handler := newTokenTestServerWithLogLevel(t, false, "debug")
+	_, handler := newTokenTestServerWithProfiler(t, false, true)
 
 	rec := testutil.ServeHTTP(t, handler, http.MethodGet, "/debug/pprof/", nil, map[string]string{
 		"X-Access-Token": "secret",
@@ -61,7 +61,7 @@ func TestDebugPprofIndexServedWithToken(t *testing.T) {
 }
 
 func TestDebugPprofAuxiliaryEndpointsServedWithToken(t *testing.T) {
-	_, handler := newTokenTestServerWithLogLevel(t, false, "debug")
+	_, handler := newTokenTestServerWithProfiler(t, false, true)
 	for _, tt := range []struct {
 		method string
 		path   string

--- a/server/endpoints.go
+++ b/server/endpoints.go
@@ -70,7 +70,7 @@ func registerEndpoints(cfg *config.Config, idx *indexer.Indexer) http.Handler {
 		}
 		mux.HandleFunc(e.Pattern(), createHandler(cfg, idx, h))
 	}
-	if cfg.App.LogLevel == "debug" {
+	if cfg.App.Profiler {
 		registerDebugEndpoints(mux, cfg, idx)
 	}
 	// SPA catch-all: serve index.html for any path not matched above

--- a/server/public_test.go
+++ b/server/public_test.go
@@ -31,15 +31,15 @@ func newServerTestIndexer(t *testing.T, cfg *config.Config) *indexer.Indexer {
 }
 
 func newTokenTestServer(t *testing.T, public bool) (*config.Config, http.Handler) {
-	return newTokenTestServerWithLogLevel(t, public, "info")
+	return newTokenTestServerWithProfiler(t, public, false)
 }
 
-func newTokenTestServerWithLogLevel(t *testing.T, public bool, logLevel string) (*config.Config, http.Handler) {
+func newTokenTestServerWithProfiler(t *testing.T, public, profiler bool) (*config.Config, http.Handler) {
 	t.Helper()
 	cfg := testutil.Config(t)
 	cfg.App.AccessToken = "secret"
 	cfg.App.Public = public
-	cfg.App.LogLevel = logLevel
+	cfg.App.Profiler = profiler
 	cfg.Server.Address = "127.0.0.1:4433"
 	if err := cfg.UpdateBaseURL("http://127.0.0.1:4433"); err != nil {
 		t.Fatal(err)

--- a/webui/website/src/content/docs/configuration.md
+++ b/webui/website/src/content/docs/configuration.md
@@ -105,6 +105,12 @@ description: 'Explore every configuration section, option, default value, enviro
       defaultValue: 'false',
       description: 'Disables the preview panel and prevents HTML storage. See the Disable Previews section below.',
     },
+    {
+      name: 'profiler',
+      type: 'bool',
+      defaultValue: 'false',
+      description: 'Serves the Go runtime profiling endpoints under /debug/pprof, behind the same authentication as the rest of the API.',
+    },
   ];
 
   const serverOptions = [


### PR DESCRIPTION
The `/debug/pprof` endpoints are only registered when `log_level` is `debug`, which is too noisy to leave on for a long running indexer. Profiling a memory issue means choosing between the profile and readable logs.

Adds `app.pprof`, defaulting to false. The endpoints keep the existing token/admin authentication wrapper, so this does not change what is exposed without authentication.

Prepared by Claude Code, reviewed by a human.
