### PR TITLE
[enh] restrict language detection to configured languages

### DIFF
--- a/cmd/service_import.go
+++ b/cmd/service_import.go
@@ -258,7 +258,10 @@ func newServiceImportRuntime(cmd *cobra.Command) (*serviceImportRuntime, error) 
 	clientOptions := append([]client.Option{client.WithTimeout(0)}, targetUserIDClientOptions(cmd, global)...)
 	languageDetector := document.LanguageDetector(document.NewNullLanguageDetector())
 	if cfg.Indexer.DetectLanguages {
-		languageDetector = document.NewLanguageDetector()
+		languageDetector = document.NewLanguageDetectorFor(
+			cfg.Indexer.Languages,
+			cfg.Indexer.LowAccuracyLanguageDetection(),
+		)
 	}
 	cfg.Crawler.UserAgent = UserAgent
 	applyCrawlerBackendFlags(cmd)

--- a/config/config.go
+++ b/config/config.go
@@ -545,9 +545,10 @@ func CreateDefaultConfig() *Config {
 			MaxBatchBodySize: DefaultMaxBatchBodySize,
 		},
 		Indexer: Indexer{
-			DetectLanguages: true,
-			KeepStopwords:   false,
-			MaxFileSize:     1,
+			DetectLanguages:           true,
+			KeepStopwords:             false,
+			MaxFileSize:               1,
+			LanguageDetectionAccuracy: LanguageDetectionAccuracyHigh,
 		},
 		Crawler: CrawlerConfig{
 			Backend: "http",

--- a/config/config.go
+++ b/config/config.go
@@ -119,6 +119,53 @@ type Indexer struct {
 	KeepStopwords   bool         `yaml:"keep_stopwords" mapstructure:"keep_stopwords"`
 	Directories     []*Directory `yaml:"directories" mapstructure:"directories"`
 	MaxFileSize     int64        `yaml:"max_file_size_mb" mapstructure:"max_file_size_mb"`
+	// Languages restricts detection to the given ISO 639-1 codes. An empty list
+	// detects every supported language. Each language kept here holds its
+	// detection models on the heap for the lifetime of the process.
+	Languages []string `yaml:"languages" mapstructure:"languages"`
+	// LanguageDetectionAccuracy is "high" or "low". Low restricts lingua to its
+	// trigram models, which is what it already uses on its own for text longer
+	// than 120 characters.
+	LanguageDetectionAccuracy string `yaml:"language_detection_accuracy" mapstructure:"language_detection_accuracy"`
+}
+
+const (
+	LanguageDetectionAccuracyHigh = "high"
+	LanguageDetectionAccuracyLow  = "low"
+)
+
+// LowAccuracyLanguageDetection reports whether lingua should run in its reduced
+// memory mode.
+func (i Indexer) LowAccuracyLanguageDetection() bool {
+	return i.LanguageDetectionAccuracy == LanguageDetectionAccuracyLow
+}
+
+// Validate checks what can be checked without knowing which languages the
+// detector supports. The codes themselves are validated in server/document,
+// which owns that list; config keeps no dependency on it.
+func (i Indexer) Validate() error {
+	switch i.LanguageDetectionAccuracy {
+	case "", LanguageDetectionAccuracyHigh, LanguageDetectionAccuracyLow:
+	default:
+		return fmt.Errorf(
+			"invalid indexer.language_detection_accuracy %q: must be %q or %q",
+			i.LanguageDetectionAccuracy, LanguageDetectionAccuracyHigh, LanguageDetectionAccuracyLow,
+		)
+	}
+	if len(i.Languages) == 0 {
+		return nil
+	}
+	// Count distinct codes the way the detector resolves them: a repeated entry
+	// would otherwise pass this check, resolve to a single language, and leave
+	// the detector disabled without saying so.
+	distinct := make(map[string]struct{}, len(i.Languages))
+	for _, code := range i.Languages {
+		distinct[strings.ToLower(strings.TrimSpace(code))] = struct{}{}
+	}
+	if len(distinct) < 2 {
+		return errors.New("indexer.languages needs at least two distinct languages, or none at all to detect every supported language")
+	}
+	return nil
 }
 
 type CrawlerCookie struct {
@@ -636,6 +683,9 @@ func (c *Config) init() error {
 		return err
 	}
 	if err := c.SemanticSearch.Validate(); err != nil {
+		return err
+	}
+	if err := c.Indexer.Validate(); err != nil {
 		return err
 	}
 	if err := c.validateOAuth(); err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -115,18 +115,12 @@ type Directory struct {
 }
 
 type Indexer struct {
-	DetectLanguages bool         `yaml:"detect_languages" mapstructure:"detect_languages"`
-	KeepStopwords   bool         `yaml:"keep_stopwords" mapstructure:"keep_stopwords"`
-	Directories     []*Directory `yaml:"directories" mapstructure:"directories"`
-	MaxFileSize     int64        `yaml:"max_file_size_mb" mapstructure:"max_file_size_mb"`
-	// Languages restricts detection to the given ISO 639-1 codes. An empty list
-	// detects every supported language. Each language kept here holds its
-	// detection models on the heap for the lifetime of the process.
-	Languages []string `yaml:"languages" mapstructure:"languages"`
-	// LanguageDetectionAccuracy is "high" or "low". Low restricts lingua to its
-	// trigram models, which is what it already uses on its own for text longer
-	// than 120 characters.
-	LanguageDetectionAccuracy string `yaml:"language_detection_accuracy" mapstructure:"language_detection_accuracy"`
+	DetectLanguages           bool         `yaml:"detect_languages" mapstructure:"detect_languages"`
+	KeepStopwords             bool         `yaml:"keep_stopwords" mapstructure:"keep_stopwords"`
+	Directories               []*Directory `yaml:"directories" mapstructure:"directories"`
+	MaxFileSize               int64        `yaml:"max_file_size_mb" mapstructure:"max_file_size_mb"`
+	Languages                 []string     `yaml:"languages" mapstructure:"languages"`
+	LanguageDetectionAccuracy string       `yaml:"language_detection_accuracy" mapstructure:"language_detection_accuracy"`
 }
 
 const (

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -89,6 +89,29 @@ func TestIndexerDefaults(t *testing.T) {
 	}
 }
 
+func TestIndexerValidate(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		indexer Indexer
+		wantErr bool
+	}{
+		{"no languages detects everything", Indexer{}, false},
+		{"two languages", Indexer{Languages: []string{"en", "de"}}, false},
+		{"one language", Indexer{Languages: []string{"en"}}, true},
+		// A repeated code resolves to a single language, which would leave the
+		// detector disabled rather than narrowed.
+		{"repeated language", Indexer{Languages: []string{"en", " EN "}}, true},
+		{"unknown accuracy", Indexer{LanguageDetectionAccuracy: "medium"}, true},
+		{"low accuracy", Indexer{LanguageDetectionAccuracy: "low"}, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := tc.indexer.Validate(); (err != nil) != tc.wantErr {
+				t.Fatalf("Validate() error = %v, wantErr %v", err, tc.wantErr)
+			}
+		})
+	}
+}
+
 func TestDirectoryLabelConfig(t *testing.T) {
 	cfg, err := parseConfig([]byte("indexer:\n  directories:\n    - path: /srv/docs\n      label: reference\n"))
 	if err != nil {

--- a/server/document/language.go
+++ b/server/document/language.go
@@ -74,6 +74,59 @@ var Languages = []lingua.Language{
 	// supported by bleve but not by lingua: gl, in
 }
 
+// languageCode returns the ISO 639-1 code Hister uses for a lingua language.
+func languageCode(l lingua.Language) string {
+	code := strings.ToLower(l.IsoCode639_1().String())
+	if code == "nb" {
+		// use generic "no" code for Norwegian
+		return "no"
+	}
+	return code
+}
+
+// SupportedLanguages maps every code Hister accepts in indexer.languages to its
+// lingua counterpart. It is derived from Languages so the two cannot drift.
+var SupportedLanguages = func() map[string]lingua.Language {
+	m := make(map[string]lingua.Language, len(Languages))
+	for _, l := range Languages {
+		m[languageCode(l)] = l
+	}
+	return m
+}()
+
+// UnsupportedLanguages returns the codes that ResolveLanguages would drop, so
+// callers can reject a misspelled configuration instead of silently indexing
+// the affected documents into the default index.
+func UnsupportedLanguages(codes []string) []string {
+	var unsupported []string
+	for _, code := range codes {
+		if _, ok := SupportedLanguages[strings.ToLower(strings.TrimSpace(code))]; !ok {
+			unsupported = append(unsupported, code)
+		}
+	}
+	return unsupported
+}
+
+// ResolveLanguages maps ISO 639-1 codes onto lingua languages, preserving the
+// order of Languages and dropping codes that are not supported. An empty list
+// resolves to every supported language.
+func ResolveLanguages(codes []string) []lingua.Language {
+	if len(codes) == 0 {
+		return Languages
+	}
+	wanted := make(map[string]struct{}, len(codes))
+	for _, c := range codes {
+		wanted[strings.ToLower(strings.TrimSpace(c))] = struct{}{}
+	}
+	langs := make([]lingua.Language, 0, len(wanted))
+	for _, l := range Languages {
+		if _, ok := wanted[languageCode(l)]; ok {
+			langs = append(langs, l)
+		}
+	}
+	return langs
+}
+
 // LanguageDetector detects the language of a text.
 type LanguageDetector interface {
 	DetectLanguage(string) string
@@ -86,9 +139,30 @@ type langDetector struct {
 }
 
 func NewLanguageDetector() LanguageDetector {
-	return &langDetector{
-		detector: lingua.NewLanguageDetectorBuilder().FromLanguages(Languages...).Build(),
+	return NewLanguageDetectorFor(nil, false)
+}
+
+// NewLanguageDetectorFor builds a detector limited to the given ISO 639-1
+// codes, or to every supported language when codes is empty.
+//
+// Both arguments bound memory. lingua caches decompressed n-gram models in
+// package level maps that are never evicted, so every language and every n-gram
+// order it is asked for stays on the heap for the lifetime of the process.
+// Loading is lazy, so narrowing the language set keeps the excluded models from
+// being decompressed at all, and lowAccuracy restricts lingua to trigram models
+// instead of the unigram through fivegram set.
+func NewLanguageDetectorFor(codes []string, lowAccuracy bool) LanguageDetector {
+	langs := ResolveLanguages(codes)
+	if len(langs) < 2 {
+		// lingua's builder panics with fewer than two languages, and detection
+		// between fewer than two is meaningless in any case.
+		return NewNullLanguageDetector()
 	}
+	b := lingua.NewLanguageDetectorBuilder().FromLanguages(langs...)
+	if lowAccuracy {
+		b = b.WithLowAccuracyMode()
+	}
+	return &langDetector{detector: b.Build()}
 }
 
 func NewNullLanguageDetector() LanguageDetector {
@@ -97,13 +171,7 @@ func NewNullLanguageDetector() LanguageDetector {
 
 func (d *langDetector) DetectLanguage(s string) string {
 	if language, exists := d.detector.DetectLanguageOf(s); exists {
-		code := strings.ToLower(language.IsoCode639_1().String())
-		switch code {
-		case "nb":
-			// use generic "no" code for Norwegian
-			return "no"
-		}
-		return code
+		return languageCode(language)
 	}
 	return UnknownLanguage
 }

--- a/server/document/language_test.go
+++ b/server/document/language_test.go
@@ -1,0 +1,83 @@
+package document
+
+import (
+	"slices"
+	"testing"
+)
+
+func codesOf(t *testing.T, codes []string) []string {
+	t.Helper()
+	langs := ResolveLanguages(codes)
+	out := make([]string, 0, len(langs))
+	for _, l := range langs {
+		out = append(out, languageCode(l))
+	}
+	slices.Sort(out)
+	return out
+}
+
+func TestResolveLanguages(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		codes []string
+		want  []string
+	}{
+		{"normalizes case and spacing", []string{"EN", " de ", "nl", "id"}, []string{"de", "en", "id", "nl"}},
+		{"drops unsupported", []string{"en", "de", "xx"}, []string{"de", "en"}},
+		// Norwegian Bokmal is exposed as the generic "no" code, not lingua's "nb".
+		{"uses generic norwegian code", []string{"no", "en"}, []string{"en", "no"}},
+		{"rejects lingua's nb spelling", []string{"nb", "en"}, []string{"en"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := codesOf(t, tc.codes); !slices.Equal(got, tc.want) {
+				t.Fatalf("ResolveLanguages(%v) = %v, want %v", tc.codes, got, tc.want)
+			}
+		})
+	}
+
+	for _, empty := range [][]string{nil, {}} {
+		if got, want := len(ResolveLanguages(empty)), len(Languages); got != want {
+			t.Fatalf("ResolveLanguages(%v) = %d languages, want all %d", empty, got, want)
+		}
+	}
+}
+
+func TestUnsupportedLanguages(t *testing.T) {
+	if got := UnsupportedLanguages([]string{"en", "de", "nl", "id"}); len(got) != 0 {
+		t.Fatalf("UnsupportedLanguages = %v, want none", got)
+	}
+	got := UnsupportedLanguages([]string{"en", "xx", "zz"})
+	if !slices.Equal(got, []string{"xx", "zz"}) {
+		t.Fatalf("UnsupportedLanguages = %v, want [xx zz]", got)
+	}
+	// "cs" is commented out of Languages, so it must be reported rather than
+	// silently ignored.
+	if got := UnsupportedLanguages([]string{"cs"}); !slices.Equal(got, []string{"cs"}) {
+		t.Fatalf("UnsupportedLanguages([cs]) = %v, want [cs]", got)
+	}
+}
+
+// lingua's builder panics with fewer than two languages, so the constructor has
+// to degrade to the null detector instead of passing the list through.
+func TestNewLanguageDetectorForRequiresTwoLanguages(t *testing.T) {
+	for _, codes := range [][]string{{"en"}, {"en", "en"}, {"xx"}} {
+		d := NewLanguageDetectorFor(codes, true)
+		if _, ok := d.(*nullLangDetector); !ok {
+			t.Fatalf("NewLanguageDetectorFor(%v) = %T, want the null detector", codes, d)
+		}
+	}
+}
+
+func TestDetectLanguageRespectsAllowlist(t *testing.T) {
+	const german = "Der schnelle braune Fuchs springt über den faulen Hund, während " +
+		"der Ausschuss prüft, ob die vorgeschlagene Änderung angenommen werden soll."
+
+	if got := NewLanguageDetectorFor([]string{"en", "de"}, true).DetectLanguage(german); got != "de" {
+		t.Fatalf("DetectLanguage(german) with de allowed = %q, want \"de\"", got)
+	}
+	// Outside the allowlist German can only be answered with one of the
+	// configured languages, never "de".
+	if got := NewLanguageDetectorFor([]string{"en", "id"}, true).DetectLanguage(german); got == "de" {
+		t.Fatal("DetectLanguage(german) returned \"de\" although de is not in the allowlist")
+	}
+}

--- a/server/indexer/analyzer_test.go
+++ b/server/indexer/analyzer_test.go
@@ -49,7 +49,7 @@ func TestProcessedFieldIsNotStoredOrIndexed(t *testing.T) {
 
 func TestLanguageIndexesAreReindexSourcesWhenDetectionIsDisabled(t *testing.T) {
 	dir := t.TempDir()
-	idx, err := initializeIndexer(dir, true, false)
+	idx, err := initializeIndexer(dir, indexOptions{DetectLanguages: true, KeepStopwords: false})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -67,7 +67,7 @@ func TestLanguageIndexesAreReindexSourcesWhenDetectionIsDisabled(t *testing.T) {
 	}
 	idx.Close()
 
-	idx, err = initializeIndexer(dir, false, false)
+	idx, err = initializeIndexer(dir, indexOptions{DetectLanguages: false, KeepStopwords: false})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/server/indexer/indexer.go
+++ b/server/indexer/indexer.go
@@ -65,10 +65,45 @@ type Indexer struct {
 	embeddingWorkers  int
 	disablePreviews   bool
 	keepStopwords     bool
+	languages         []string
+	lowAccuracyDetect bool
 	directories       []*config.Directory
 	maxFileSize       int64
 	sensitivePattern  *regexp.Regexp
 	semanticConfig    config.SemanticSearch
+}
+
+// indexOptions carries the settings that decide how indexes are created and
+// which languages get one of their own.
+type indexOptions struct {
+	DetectLanguages bool
+	KeepStopwords   bool
+	// Languages restricts detection to these ISO 639-1 codes. Empty means every
+	// language document.Languages supports.
+	Languages []string
+	// LowAccuracy restricts lingua to its trigram models.
+	LowAccuracy bool
+}
+
+func optionsFromConfig(cfg *config.Config) indexOptions {
+	return indexOptions{
+		DetectLanguages: cfg.Indexer.DetectLanguages,
+		KeepStopwords:   cfg.Indexer.KeepStopwords,
+		Languages:       cfg.Indexer.Languages,
+		LowAccuracy:     cfg.Indexer.LowAccuracyLanguageDetection(),
+	}
+}
+
+// optionsWith combines the receiver's language settings with a per-request
+// override of detectLanguages and keepStopwords, so a reindex keeps the
+// configured language set while still honouring the request.
+func (i *Indexer) optionsWith(detectLanguages, keepStopwords bool) indexOptions {
+	return indexOptions{
+		DetectLanguages: detectLanguages,
+		KeepStopwords:   keepStopwords,
+		Languages:       i.languages,
+		LowAccuracy:     i.lowAccuracyDetect,
+	}
 }
 
 const (
@@ -330,7 +365,7 @@ func New(cfg *config.Config) (*Indexer, error) {
 		sp = append(sp, v)
 	}
 	sensitivePattern := regexp.MustCompile(fmt.Sprintf("(%s)", strings.Join(sp, "|")))
-	idx, err := initializeIndexer(cfg.FullPath(""), cfg.Indexer.DetectLanguages, cfg.Indexer.KeepStopwords)
+	idx, err := initializeIndexer(cfg.FullPath(""), optionsFromConfig(cfg))
 	if err != nil {
 		return nil, err
 	}
@@ -389,7 +424,11 @@ func registerHighlighters() error {
 	return registerHighlightersErr
 }
 
-func initializeIndexer(basePath string, detectLanguages, keepStopwords bool) (*Indexer, error) {
+func initializeIndexer(basePath string, opts indexOptions) (*Indexer, error) {
+	if unsupported := document.UnsupportedLanguages(opts.Languages); len(unsupported) > 0 {
+		return nil, fmt.Errorf("unsupported language(s) in indexer.languages: %s", strings.Join(unsupported, ", "))
+	}
+	detectLanguages, keepStopwords := opts.DetectLanguages, opts.KeepStopwords
 	if _, err := os.Stat(basePath); errors.Is(err, os.ErrNotExist) {
 		if err := os.MkdirAll(basePath, os.ModePerm); err != nil {
 			return nil, err
@@ -416,12 +455,14 @@ func initializeIndexer(basePath string, detectLanguages, keepStopwords bool) (*I
 		indexers: map[string]bleve.Index{
 			defaultIndexerName: idx,
 		},
-		dir:           basePath,
-		keepStopwords: keepStopwords,
-		embedCtx:      embedCtx,
-		embedCancel:   embedCancel,
-		data:          newDataStore(filepath.Join(basePath, dataDirName)),
-		maxFileSize:   defaultMaxFileSize,
+		dir:               basePath,
+		keepStopwords:     keepStopwords,
+		languages:         opts.Languages,
+		lowAccuracyDetect: opts.LowAccuracy,
+		embedCtx:          embedCtx,
+		embedCancel:       embedCancel,
+		data:              newDataStore(filepath.Join(basePath, dataDirName)),
+		maxFileSize:       defaultMaxFileSize,
 	}
 	initialized := false
 	defer func() {
@@ -432,7 +473,7 @@ func initializeIndexer(basePath string, detectLanguages, keepStopwords bool) (*I
 	if !detectLanguages {
 		i.langDetector = document.NewNullLanguageDetector()
 	} else {
-		i.langDetector = document.NewLanguageDetector()
+		i.langDetector = document.NewLanguageDetectorFor(opts.Languages, opts.LowAccuracy)
 	}
 	entries, err := os.ReadDir(basePath)
 	if err != nil {
@@ -601,7 +642,7 @@ func (idx *Indexer) reindex(basePath string, rules *config.Rules, skipSensitiveC
 		return err
 	}
 	defer closeExtraSources()
-	tmpIdx, err := initializeIndexer(tmpBasePath, detectLanguages, keepStopwords)
+	tmpIdx, err := initializeIndexer(tmpBasePath, idx.optionsWith(detectLanguages, keepStopwords))
 	if err != nil {
 		return err
 	}
@@ -764,7 +805,7 @@ func (idx *Indexer) reindex(basePath string, rules *config.Rules, skipSensitiveC
 	if renameError != nil {
 		return errors.New("failed to rename tmp indexes during the reindex, resolve the issue manually")
 	}
-	replacement, err := initializeIndexer(basePath, detectLanguages, keepStopwords)
+	replacement, err := initializeIndexer(basePath, idx.optionsWith(detectLanguages, keepStopwords))
 	if err != nil {
 		return err
 	}
@@ -1367,6 +1408,8 @@ func (i *Indexer) adopt(replacement *Indexer) {
 	i.embeddingWorkers = replacement.embeddingWorkers
 	i.disablePreviews = replacement.disablePreviews
 	i.keepStopwords = replacement.keepStopwords
+	i.languages = replacement.languages
+	i.lowAccuracyDetect = replacement.lowAccuracyDetect
 	i.directories = replacement.directories
 	i.maxFileSize = replacement.maxFileSize
 	i.sensitivePattern = replacement.sensitivePattern

--- a/server/indexer/metadata_test.go
+++ b/server/indexer/metadata_test.go
@@ -30,7 +30,7 @@ func requireIndexMetadata(t *testing.T, idx bleve.Index, want indexMetadata) {
 
 func TestIndexMetadataPersistence(t *testing.T) {
 	cfg := testutil.Config(t)
-	idx, err := initializeIndexer(cfg.FullPath(""), true, true)
+	idx, err := initializeIndexer(cfg.FullPath(""), indexOptions{DetectLanguages: true, KeepStopwords: true})
 	if err != nil {
 		t.Fatalf("initialize indexer: %v", err)
 	}
@@ -51,7 +51,7 @@ func TestIndexMetadataPersistence(t *testing.T) {
 	}
 	idx.Close()
 
-	idx, err = initializeIndexer(cfg.FullPath(""), true, true)
+	idx, err = initializeIndexer(cfg.FullPath(""), indexOptions{DetectLanguages: true, KeepStopwords: true})
 	if err != nil {
 		t.Fatalf("reopen indexer: %v", err)
 	}
@@ -71,7 +71,7 @@ func TestIndexMetadataPersistence(t *testing.T) {
 
 func TestGetMetadataRejectsInvalidInternalValue(t *testing.T) {
 	cfg := testutil.Config(t)
-	idx, err := initializeIndexer(cfg.FullPath(""), false, false)
+	idx, err := initializeIndexer(cfg.FullPath(""), indexOptions{DetectLanguages: false, KeepStopwords: false})
 	if err != nil {
 		t.Fatalf("initialize indexer: %v", err)
 	}
@@ -101,7 +101,7 @@ func TestGetMetadataRejectsInvalidInternalValue(t *testing.T) {
 
 func TestGetMetadataValidatesAllSubIndexes(t *testing.T) {
 	cfg := testutil.Config(t)
-	idx, err := initializeIndexer(cfg.FullPath(""), true, false)
+	idx, err := initializeIndexer(cfg.FullPath(""), indexOptions{DetectLanguages: true, KeepStopwords: false})
 	if err != nil {
 		t.Fatalf("initialize indexer: %v", err)
 	}
@@ -158,7 +158,7 @@ func TestGetMetadataValidatesAllSubIndexes(t *testing.T) {
 
 func TestLanguageIndexMetadataIsSelfContained(t *testing.T) {
 	cfg := testutil.Config(t)
-	idx, err := initializeIndexer(cfg.FullPath(""), true, true)
+	idx, err := initializeIndexer(cfg.FullPath(""), indexOptions{DetectLanguages: true, KeepStopwords: true})
 	if err != nil {
 		t.Fatalf("initialize indexer: %v", err)
 	}
@@ -197,7 +197,7 @@ func TestLanguageIndexMetadataIsSelfContained(t *testing.T) {
 
 func TestReindexStoresReplacementIndexMetadata(t *testing.T) {
 	cfg := testutil.Config(t)
-	idx, err := initializeIndexer(cfg.FullPath(""), false, false)
+	idx, err := initializeIndexer(cfg.FullPath(""), indexOptions{DetectLanguages: false, KeepStopwords: false})
 	if err != nil {
 		t.Fatalf("initialize indexer: %v", err)
 	}

--- a/webui/website/src/content/docs/configuration.md
+++ b/webui/website/src/content/docs/configuration.md
@@ -622,6 +622,8 @@ server:
 
 indexer:
   detect_languages: true
+  language_detection_accuracy: 'high'
+  languages: ['en', 'de']
   keep_stopwords: false
   directories:
     - path: '~/notes'
@@ -998,7 +1000,7 @@ The `indexer.keep_stopwords` option defaults to `false`. When enabled together w
 
 **Performance considerations**: Language detection increases both CPU usage and memory consumption. Each document requires additional processing to analyze text and determine its language, and separate indexes are maintained for each detected language. If you're experiencing memory pressure or slow indexing performance, especially with large numbers of documents, consider disabling this feature.
 
-**Important**: Changing either analyzer setting requires a full reindex to take effect. After changing `detect_languages` or `keep_stopwords`, run:
+**Important**: Changing `detect_languages` or `keep_stopwords` requires a full reindex to take effect. Neither `languages` nor `language_detection_accuracy` does; both apply to documents indexed after the change, and existing indexes stay searchable. After changing `detect_languages` or `keep_stopwords`, run:
 
 ```bash
 hister reindex

--- a/webui/website/src/content/docs/configuration.md
+++ b/webui/website/src/content/docs/configuration.md
@@ -181,6 +181,18 @@ description: 'Explore every configuration section, option, default value, enviro
       description: 'Enables automatic language detection. Changing this setting requires reindexing.',
     },
     {
+      name: 'languages',
+      type: 'string[]',
+      defaultValue: '(none)',
+      description: 'Restricts language detection to these ISO 639-1 codes, which reduces memory use. Empty detects every supported language. Changing this setting does not require reindexing.',
+    },
+    {
+      name: 'language_detection_accuracy',
+      type: 'string',
+      defaultValue: 'high',
+      description: 'Detection accuracy, high or low. Low uses only trigram models and less memory. The two settings detect text of 120 letters or more identically, so only shorter text is affected.',
+    },
+    {
       name: 'keep_stopwords',
       type: 'bool',
       defaultValue: 'false',


### PR DESCRIPTION
`lingua` caches decompressed n-gram models in package level maps that are never evicted. Consequence: every language it is asked about, at every n-gram order it is asked for, stays on the heap for the lifetime of the process. The detector is only used when indexing, so this does not show up in an idle heap profile. Under indexing load it was 362MB of a 392MB heap on my instance.

This PR adds two settings, both defaulting to current behaviour:

```
    indexer.languages                    ISO 639-1 codes, empty means all
    indexer.language_detection_accuracy  "high" (default) or "low"
```

Loading langauges is lazy, so naming the languages keeps the excluded models from ever being decompressed.

Low accuracy restricts lingua to its trigram models. lingua already selects trigrams alone once a document has 120 or more letters, which covers essentially every real page, so detection on full pages is unaffected. Below that it also consults the unigram, bigram, quadrigram and fivegram models, and those then stay loaded for the life of the process. So the largest model tiers were being pinned by pages with very little extracted text, and then never used again. 

Implementation detail: the `initializeIndexer` being a list was getting unwieldy, so the settings are passed as an `indexOptions` struct instead. I can set it back to a list if desired?

Measured on a 2.6GB index, timing backfill plus file indexing to completion, with semantic search enabled and embedding f. The middle row isolates the two settings from each other; the lingua column is that package's share of
`inuse_space`, which does not depend on how much of the workload had finished:

                                   lingua heap   settled footprint
    30 languages, high accuracy          377MB               739MB
    [en de nl id], high accuracy          77MB               164MB
    [en de nl id], low accuracy         3.58MB               105MB

It seems naming the languages is the big win but the accuracy setting helps too — The 77MB to 3.58MB step down is using the same four languages either way, so that difference is the n-gram tiers that only short documents use. 

Naming languages narrows what detection can return, so Latin script text in an unlisted language lands in the default index instead of its own. Those documents stay searchable. Someone who wanted the wide detector could set only
`language_detection_accuracy: low` and leave `languages` empty.

No reindex is needed and nothing is orphaned by this: `initializeIndexer` still opens every `index_*.db` it finds and adds it to the alias, so an existing `index_fr.db` stays searchable after `fr` drops off the list. The setting only narrows what language newly indexed documents can be detected as.

Written with Claude Code, which produced the diagnosis, the measurements and the patch under my direction and multiple revisions. I understand the updates, I believe, but am a Go noob, so could be mistaken.
