### PR TITLE
Speed up Docker builds and move publishing to Bake

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,7 @@
 .git
 .github
 .gitignore
+.jj
 .golangci.toml
 .goreleaser.yml
 manage.sh
@@ -12,6 +13,9 @@ manage.sh
 .idea/
 *.swp
 *.bak
+*.log
+.env
+.env.*
 
 # Go Build Artifacts
 hister
@@ -19,6 +23,7 @@ hister.exe
 pkg/
 bin/
 vendor/
+coverage/
 
 # Local Data & Configs
 *.db
@@ -36,10 +41,15 @@ README.md
 LICENSE
 Dockerfile*
 compose.yml
+docker-bake.hcl
 
 # Build Artifacts
 webui/app/build/
 webui/website/build/
+webui/**/.svelte-kit/
+webui/**/dist/
+webui/ext/
+webui/website/
 
 # Browser Extension & Nix
 ext/

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,12 @@ updates:
         patterns:
           - '*'
 
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+
   - package-ecosystem: github-actions
     directory: /
     schedule:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,68 +1,193 @@
 name: Publish Docker Image
 
 on:
+  pull_request:
+    paths:
+      - .dockerignore
+      - .github/workflows/docker-publish.yml
+      - .github/workflows/docker-release.yml
+      - compose.yml
+      - docker-bake.hcl
+      - Dockerfile
+      - go.mod
+      - go.sum
+      - '**/*.go'
+      - package.json
+      - package-lock.json
+      - webui/app/**
+      - webui/components/**
   push:
-    branches: ['master'] # Trigger on pushes to master branch
-    tags: ['v*.*.*'] # Trigger on semantic version tags (e.g., v1.0.0)
+    branches:
+      - master
+
+concurrency:
+  group: docker-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository_owner }}/hister # Auto-uses your GitHub username/org
+  IMAGE_NAME: ${{ github.repository_owner }}/hister
+  CACHE_IMAGE: ghcr.io/${{ github.repository_owner }}/hister:buildcache
+  CACHE_SCOPE: hister-release
 
 jobs:
-  build-and-push:
-    name: build and push (${{ matrix.target }})
+  build:
+    name: Build Docker images
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.author_association == 'OWNER' ||
+      github.event.pull_request.author_association == 'COLLABORATOR' ||
+      github.actor_id == '49699333' ||
+      github.actor_id == '41898282'
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        include:
-          - target: release
-            suffix: ''
-          - target: root
-            suffix: '-root'
-          - target: debug
-            suffix: '-debug'
+    timeout-minutes: 60
     permissions:
       contents: read
-      packages: write # Required to push to GHCR
+      packages: write
 
     steps:
-      - name: Checkout Code
-        uses: actions/checkout@v7
+      - name: Check out code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up QEMU
+        if: github.event_name != 'pull_request'
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
+        with:
+          platforms: arm64
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        id: buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Validate Compose configuration
+        run: docker compose config --quiet
+
+      - name: Restore Docker cache mounts
+        id: cache-mounts
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          driver: docker-container # Required for multi-platform
+          path: ${{ runner.temp }}/buildkit-cache
+          key: >-
+            buildkit-mounts-${{ runner.os }}-${{
+            hashFiles('Dockerfile', 'go.sum', 'package-lock.json') }}
+          restore-keys: |
+            buildkit-mounts-${{ runner.os }}-
+
+      - name: Inject Docker cache mounts
+        uses: reproducible-containers/buildkit-cache-dance@5422eac04292c961a382e0f584ea0f03ad9da723 # v3.4.0
+        with:
+          builder: ${{ steps.buildx.outputs.name }}
+          cache-dir: ${{ runner.temp }}/buildkit-cache
+          scratch-dir: ${{ runner.temp }}/buildkit-cache-scratch
+          dockerfile: Dockerfile
+          skip-extraction: ${{ steps.cache-mounts.outputs.cache-hit }}
 
       - name: Log in to GHCR
-        uses: docker/login-action@v4
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }} # Auto-generated, no setup needed
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract Metadata (tags, labels)
-        id: meta
-        uses: docker/metadata-action@v6
+      - name: Extract release metadata
+        if: github.event_name != 'pull_request'
+        id: meta-release
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          bake-target: release
           flavor: |
             latest=false
-            suffix=${{ matrix.suffix }},onlatest=true
-          # tags: branch -> :master, tag -> :v1.0.0, sha → :sha-7d4a3f2, latest on tags only
           tags: |
             type=ref,event=branch
-            type=ref,event=tag
             type=sha
-            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/') }}
 
-      - name: Build and Push
-        uses: docker/build-push-action@v7
+      - name: Extract root metadata
+        if: github.event_name != 'pull_request'
+        id: meta-root
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
-          context: .
-          platforms: linux/amd64,linux/arm64 # Build for Intel + ARM
-          target: ${{ matrix.target }}
-          push: ${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/') }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          bake-target: root
+          flavor: |
+            latest=false
+            suffix=-root,onlatest=true
+          tags: |
+            type=ref,event=branch
+            type=sha
+
+      - name: Extract debug metadata
+        if: github.event_name != 'pull_request'
+        id: meta-debug
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          bake-target: debug
+          flavor: |
+            latest=false
+            suffix=-debug,onlatest=true
+          tags: |
+            type=ref,event=branch
+            type=sha
+
+      - name: Validate Docker images
+        if: github.event_name == 'pull_request'
+        uses: docker/bake-action@d3418bd7d0e9324001bca92fa8ba175ea7e6dc9b # v7.3.0
+        with:
+          source: .
+          files: ./docker-bake.hcl
+          targets: images
+          set: |
+            *.platform=linux/amd64
+            *.cache-from=type=gha,scope=${{ env.CACHE_SCOPE }}
+            *.cache-from+=type=registry,ref=${{ env.CACHE_IMAGE }}
+            release.tags=hister:ci
+            release.output=type=docker
+            release.cache-to=type=gha,mode=max,scope=${{ env.CACHE_SCOPE }},ignore-error=true
+
+      - name: Smoke test Compose service
+        if: github.event_name == 'pull_request'
+        env:
+          HISTER_IMAGE: hister:ci
+        run: |
+          docker compose up --detach --no-build
+          for _ in {1..30}; do
+            if curl --fail --silent --max-time 2 \
+              http://127.0.0.1:4433/ >/dev/null; then
+              exit 0
+            fi
+            sleep 1
+          done
+          docker compose logs
+          exit 1
+
+      - name: Stop Compose service
+        if: always() && github.event_name == 'pull_request'
+        env:
+          HISTER_IMAGE: hister:ci
+        run: docker compose down --volumes
+
+      - name: Build and push Docker images
+        if: github.ref == 'refs/heads/master'
+        uses: docker/bake-action@d3418bd7d0e9324001bca92fa8ba175ea7e6dc9b # v7.3.0
+        with:
+          source: .
+          files: |
+            ./docker-bake.hcl
+            cwd://${{ steps.meta-release.outputs.bake-file }}
+            cwd://${{ steps.meta-root.outputs.bake-file }}
+            cwd://${{ steps.meta-debug.outputs.bake-file }}
+          targets: images
+          push: true
+          set: |
+            *.platform=linux/amd64
+            *.platform+=linux/arm64
+            *.cache-from=type=gha,scope=${{ env.CACHE_SCOPE }}
+            *.cache-from+=type=registry,ref=${{ env.CACHE_IMAGE }}
+            *.attest=type=provenance,mode=max
+            *.attest+=type=sbom
+            release.cache-to=type=gha,mode=max,scope=${{ env.CACHE_SCOPE }},ignore-error=true
+            release.cache-to+=type=registry,ref=${{ env.CACHE_IMAGE }},mode=max

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -1,0 +1,103 @@
+name: Publish Docker Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+concurrency:
+  group: docker-release-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository_owner }}/hister
+
+jobs:
+  build:
+    name: Build Docker release images
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
+        with:
+          platforms: arm64
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Log in to GHCR
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract release metadata
+        id: meta-release
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          bake-target: release
+          flavor: |
+            latest=false
+          tags: |
+            type=ref,event=tag
+            type=sha
+            type=raw,value=latest
+
+      - name: Extract root metadata
+        id: meta-root
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          bake-target: root
+          flavor: |
+            latest=false
+            suffix=-root,onlatest=true
+          tags: |
+            type=ref,event=tag
+            type=sha
+            type=raw,value=latest
+
+      - name: Extract debug metadata
+        id: meta-debug
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          bake-target: debug
+          flavor: |
+            latest=false
+            suffix=-debug,onlatest=true
+          tags: |
+            type=ref,event=tag
+            type=sha
+            type=raw,value=latest
+
+      - name: Build and push release Docker images
+        uses: docker/bake-action@d3418bd7d0e9324001bca92fa8ba175ea7e6dc9b # v7.3.0
+        with:
+          source: .
+          files: |
+            ./docker-bake.hcl
+            cwd://${{ steps.meta-release.outputs.bake-file }}
+            cwd://${{ steps.meta-root.outputs.bake-file }}
+            cwd://${{ steps.meta-debug.outputs.bake-file }}
+          targets: images
+          push: true
+          set: |
+            *.platform=linux/amd64
+            *.platform+=linux/arm64
+            *.attest=type=provenance,mode=max
+            *.attest+=type=sbom
+            *.no-cache=true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,68 +1,82 @@
 # syntax=docker/dockerfile:1
 
-# Stage 1: Build frontend
-FROM node:22-alpine AS frontend
+# Build the frontend with only the workspaces required by the embedded app.
+FROM node:22-alpine3.24@sha256:c610fcdfb1d5b4740dd70c284ed3cb16bb857e0f7166196e36a5501df7a3aa32 AS frontend
 
 WORKDIR /app
 
-# Copy workspace package files first for layer caching
 COPY package.json package-lock.json ./
 COPY webui/app/package.json webui/app/
 COPY webui/components/package.json webui/components/
-COPY webui/website/package.json webui/website/
 
-RUN npm ci --workspaces
+RUN --mount=type=cache,id=hister-npm,target=/root/.npm,sharing=locked \
+    npm ci \
+      --workspace=@hister/app \
+      --workspace=@hister/components
 
-COPY webui/ webui/
+COPY webui/app/ webui/app/
+COPY webui/components/ webui/components/
 
-RUN npm run build -w @hister/app
+RUN npm run build --workspace=@hister/app
 
-# Stage 2: Build Go binary
-FROM golang:1.26-alpine AS builder
+# Build a static Go binary. Cache downloads and compiled packages separately so
+# source changes do not force the toolchain to start cold.
+FROM golang:1.26-alpine3.24@sha256:70b46548e42db77e0966aaf3619fd068734dc6c77584d526b91126504fd95816 AS builder
 
 RUN apk add --no-cache gcc musl-dev
 
 WORKDIR /app
 
 COPY go.mod go.sum ./
-RUN go mod download
+RUN --mount=type=cache,id=hister-go-mod,target=/go/pkg/mod,sharing=locked \
+    go mod download
 
 COPY . .
-COPY --from=frontend /app/webui/app/build/ server/static/app/
+COPY --link --from=frontend /app/webui/app/build/ server/static/app/
 
-RUN set -eux; \
+RUN --mount=type=cache,id=hister-go-mod,target=/go/pkg/mod,sharing=locked \
+    --mount=type=cache,id=hister-go-build,target=/root/.cache/go-build,sharing=locked \
+    set -eux; \
     LISTEN_ADDRESS="0.0.0.0:4433"; \
     BASE_URL="http://localhost:4433"; \
     CGO_ENABLED=1 go build \
+    -trimpath \
     -tags netgo,osusergo \
     -ldflags "\
       -linkmode external -extldflags '-static' -s -w \
       -X 'github.com/asciimoo/hister/config.DefaultServerAddress=$LISTEN_ADDRESS' \
       -X 'github.com/asciimoo/hister/config.DefaultServerBaseURL=$BASE_URL'" \
-    -o hister .
+    -o /out/hister .
 
-# Stage 3: Download the latest yt-dlp release binary
-FROM alpine:3.21 AS ytdlp
+# Fetch a versioned, architecture-specific yt-dlp binary and verify it against
+# the checksums published with that release.
+FROM alpine:3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b AS ytdlp
 
 ARG TARGETARCH=amd64
+ARG YT_DLP_VERSION=2026.07.04
 
 RUN set -eux; \
-    apk add --no-cache ca-certificates wget; \
     case "$TARGETARCH" in \
-      amd64) asset="yt-dlp_musllinux" ;; \
-      arm64) asset="yt-dlp_musllinux_aarch64" ;; \
+      amd64) \
+        asset="yt-dlp_musllinux"; \
+        checksum="f7439ec2e3ffe69e06ac233f83f0d9687b89105939129bddcbf74e5de0f2b40e" \
+        ;; \
+      arm64) \
+        asset="yt-dlp_musllinux_aarch64"; \
+        checksum="9a6a4de88f35dc68c1763945fbb417e092ebd9afc5d66052ac31b68d405a12a7" \
+        ;; \
       *) echo "unsupported TARGETARCH for yt-dlp: $TARGETARCH" >&2; exit 1 ;; \
     esac; \
-    wget -O /tmp/yt-dlp "https://github.com/yt-dlp/yt-dlp/releases/latest/download/${asset}"; \
-    wget -O /tmp/SHA2-256SUMS "https://github.com/yt-dlp/yt-dlp/releases/latest/download/SHA2-256SUMS"; \
-    grep "  ${asset}$" /tmp/SHA2-256SUMS | sed "s/  ${asset}$/  \\/tmp\\/yt-dlp/" | sha256sum -c -; \
     mkdir -p /usr/local/bin; \
-    mv /tmp/yt-dlp /usr/local/bin/yt-dlp; \
+    wget -qO /usr/local/bin/yt-dlp \
+      "https://github.com/yt-dlp/yt-dlp/releases/download/${YT_DLP_VERSION}/${asset}"; \
+    echo "${checksum}  /usr/local/bin/yt-dlp" > /tmp/checksums; \
+    sha256sum -c /tmp/checksums; \
     chmod 0755 /usr/local/bin/yt-dlp
 
-# Release stage (nonroot)
-# latest & vx.x.x
-FROM alpine:3.21 AS release
+# Put shared runtime content in one stage so release, root, and debug variants
+# reuse the same immutable layers in the registry and on container hosts.
+FROM alpine:3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b AS runtime
 
 LABEL org.opencontainers.image.title="Hister" \
       org.opencontainers.image.description="Self-hosted browser history search engine" \
@@ -71,63 +85,33 @@ LABEL org.opencontainers.image.title="Hister" \
 
 WORKDIR /hister
 
-RUN adduser -D -u 65532 hister && mkdir -p /hister/data && chown -R 65532:65532 /hister
-COPY --from=ytdlp /usr/local/bin/yt-dlp /usr/local/bin/yt-dlp
-COPY --chown=65532:65532 --from=builder /app/hister .
+RUN adduser -D -u 65532 hister \
+    && mkdir -p /hister/data \
+    && chown 65532:65532 /hister/data
+
+COPY --link --from=ytdlp /usr/local/bin/yt-dlp /usr/local/bin/yt-dlp
+COPY --link --from=builder /out/hister /hister/hister
+
+ENV HISTER_DATA_DIR=/hister/data \
+    HISTER_CONFIG=/hister/data/config.yml
+
+EXPOSE 4433
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+    CMD ["wget", "-qO", "/dev/null", "http://localhost:4433/"]
+
+ENTRYPOINT ["/hister/hister"]
+CMD ["listen"]
+
+# latest and vx.x.x
+FROM runtime AS release
 USER 65532:65532
 
-ENV HISTER_DATA_DIR=/hister/data
-ENV HISTER_CONFIG=/hister/data/config.yml
-
-EXPOSE 4433
-
-HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-    CMD wget -qO /dev/null http://localhost:4433/ || exit 1
-
-ENTRYPOINT ["/hister/hister"]
-CMD ["listen"]
-
-# Release stage (root)
-# latest-root & vx.x.x-root
-FROM alpine:3.21 AS root
-WORKDIR /hister
-
-RUN mkdir -p /hister/data
-COPY --from=ytdlp /usr/local/bin/yt-dlp /usr/local/bin/yt-dlp
-COPY --from=builder /app/hister .
-
+# latest-root and vx.x.x-root
+FROM runtime AS root
 USER root
 
-ENV HISTER_DATA_DIR=/hister/data
-ENV HISTER_CONFIG=/hister/data/config.yml
-
-EXPOSE 4433
-
-HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-    CMD wget -qO /dev/null http://localhost:4433/ || exit 1
-
-ENTRYPOINT ["/hister/hister"]
-CMD ["listen"]
-
-# Release stage (debug)
-# latest-debug & vx.x.x-debug
-FROM alpine:3.21 AS debug
-WORKDIR /hister
-
-RUN apk add --no-cache curl bash && mkdir -p /hister/data
-COPY --from=ytdlp /usr/local/bin/yt-dlp /usr/local/bin/yt-dlp
-
-COPY --from=builder /app/hister .
-
+# latest-debug and vx.x.x-debug
+FROM runtime AS debug
+RUN apk add --no-cache bash curl
 USER root
-
-ENV HISTER_DATA_DIR=/hister/data
-ENV HISTER_CONFIG=/hister/data/config.yml
-
-EXPOSE 4433
-
-HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-    CMD wget -qO /dev/null http://localhost:4433/ || exit 1
-
-ENTRYPOINT ["/hister/hister"]
-CMD ["listen"]

--- a/compose.yml
+++ b/compose.yml
@@ -1,9 +1,15 @@
 services:
   hister:
+    image: ${HISTER_IMAGE:-ghcr.io/asciimoo/hister:latest}
+    # Prefer the published image for `compose up`; `compose build` still uses
+    # the source below and can reuse layers from the published image.
+    pull_policy: missing
     build:
       context: .
       target: release
-    image: ghcr.io/asciimoo/hister:latest
+      cache_from:
+        - ${HISTER_IMAGE:-ghcr.io/asciimoo/hister:latest}
+        - type=registry,ref=${HISTER_CACHE_IMAGE:-ghcr.io/asciimoo/hister:buildcache}
     container_name: hister
     init: true
     restart: unless-stopped
@@ -19,8 +25,8 @@ services:
     tmpfs:
       - /tmp:noexec,nosuid,size=64m
     environment:
-      - HISTER__SERVER__ADDRESS=0.0.0.0:4433
-      - HISTER__SERVER__BASE_URL=http://localhost:4433
+      HISTER__SERVER__ADDRESS: 0.0.0.0:4433
+      HISTER__SERVER__BASE_URL: http://localhost:4433
 
 volumes:
   hister_data:

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,0 +1,27 @@
+group "default" {
+  targets = ["release"]
+}
+
+group "images" {
+  targets = ["release", "root", "debug"]
+}
+
+target "_common" {
+  context    = "."
+  dockerfile = "Dockerfile"
+}
+
+target "release" {
+  inherits = ["_common"]
+  target   = "release"
+}
+
+target "root" {
+  inherits = ["_common"]
+  target   = "root"
+}
+
+target "debug" {
+  inherits = ["_common"]
+  target   = "debug"
+}


### PR DESCRIPTION
Docker builds were repeating a lot of work across the release, root, and debug images

This reworks the Dockerfile to cache npm and Go dependencies, share runtime layers, trim
the build context, and pin base images and yt-dlp downloads

The same targets now live in docker-bake.hcl, so local builds and CI use the same setup. Compose can also reuse the published image and registry cache instead of starting cold

On the CI side, trusted PRs get an amd64 build and Compose smoke test. Merges to master
publish multi-platform images with cache reuse, provenance, and SBOMs. Tagged releases
use a separate no-cache workflow so they always get a clean build