### PR TITLE
[fix] decode opened history responses

### DIFF
--- a/client/history.go
+++ b/client/history.go
@@ -2,11 +2,12 @@ package client
 
 import (
 	"encoding/json"
+	"net/http"
 	"strings"
 )
 
 func (c *Client) FetchHistory() (_ []HistoryItem, err error) {
-	req, err := c.newRequest("GET", "/api/history", nil)
+	req, err := c.newRequest(http.MethodGet, "/api/history?opened=true", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -18,9 +19,11 @@ func (c *Client) FetchHistory() (_ []HistoryItem, err error) {
 	if err := checkStatus(resp); err != nil {
 		return nil, err
 	}
-	var items []HistoryItem
-	err = json.NewDecoder(resp.Body).Decode(&items)
-	return items, err
+	var response struct {
+		Documents []HistoryItem `json:"documents"`
+	}
+	err = json.NewDecoder(resp.Body).Decode(&response)
+	return response.Documents, err
 }
 
 func (c *Client) PostHistory(query, urlStr, title string) (err error) {

--- a/client/history_test.go
+++ b/client/history_test.go
@@ -1,0 +1,44 @@
+package client
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestFetchHistoryRequestsAndDecodesOpenedHistory(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/api/history" {
+			t.Errorf("request = %s %s", r.Method, r.URL.Path)
+		}
+		if opened := r.URL.Query().Get("opened"); opened != "true" {
+			t.Errorf("opened query parameter = %q, want true", opened)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"documents": []map[string]any{{
+				"id":        42,
+				"query":     "history query",
+				"title":     "Opened result",
+				"url":       "https://example.com/result",
+				"added":     1_723_456_789,
+				"add_count": 3,
+			}},
+			"last_id":         42,
+			"last_updated_at": "2026-08-16T12:00:00Z",
+		})
+	}))
+	defer server.Close()
+
+	items, err := New(server.URL).FetchHistory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("history items = %#v, want one item", items)
+	}
+	item := items[0]
+	if item.Query != "history query" || item.Title != "Opened result" || item.URL != "https://example.com/result" {
+		t.Fatalf("history item = %#v", item)
+	}
+}


### PR DESCRIPTION
The history endpoint returns an envelope rather than a bare item list