### PR TITLE
[fix] preserve rules when prioritizing results

### DIFF
--- a/cmd/tui/handle/overlays.go
+++ b/cmd/tui/handle/overlays.go
@@ -295,8 +295,7 @@ func PrioritizeInputKeys(m *model.Model, msg tea.KeyMsg) tea.Cmd {
 		m.PrioritizeInput.Blur()
 		m.State = m.PrevState
 		if pattern != "" {
-			m.RulesData.Priority = append(m.RulesData.Priority, pattern)
-			return m.SaveRulesCmd()
+			return m.PrioritizeRuleCmd(pattern)
 		}
 		return nil
 	}

--- a/cmd/tui/model/model.go
+++ b/cmd/tui/model/model.go
@@ -458,8 +458,9 @@ func (m *Model) PostHistoryCmd(u string) tea.Cmd {
 func (m *Model) SaveRulesCmd() tea.Cmd {
 	skip := strings.Join(m.RulesData.Skip, "\n")
 	priority := strings.Join(m.RulesData.Priority, "\n")
+	versioning := strings.Join(m.RulesData.Versioning, "\n")
 	return func() tea.Msg {
-		return RulesSavedMsg{Err: m.Client.SaveRules(skip, priority)}
+		return RulesSavedMsg{Err: m.Client.SaveRules(skip, priority, versioning)}
 	}
 }
 
@@ -489,6 +490,24 @@ func (m *Model) AddPageCmd(u, title, text string) tea.Cmd {
 func (m *Model) AddAliasCmd(keyword, value string) tea.Cmd {
 	return func() tea.Msg {
 		return RulesSavedMsg{Err: m.Client.AddAlias(keyword, value)}
+	}
+}
+
+// PrioritizeRuleCmd reads the latest rules before appending a priority rule.
+// Result context menus are usable without visiting the Rules tab first, so
+// saving the model's possibly-empty cache here could erase server-side rules.
+func (m *Model) PrioritizeRuleCmd(pattern string) tea.Cmd {
+	return func() tea.Msg {
+		rules, err := m.Client.FetchRules()
+		if err != nil {
+			return RulesSavedMsg{Err: err}
+		}
+		rules.Priority = append(rules.Priority, pattern)
+		return RulesSavedMsg{Err: m.Client.SaveRules(
+			strings.Join(rules.Skip, "\n"),
+			strings.Join(rules.Priority, "\n"),
+			strings.Join(rules.Versioning, "\n"),
+		)}
 	}
 }
 

--- a/cmd/tui/model/rules_test.go
+++ b/cmd/tui/model/rules_test.go
@@ -1,0 +1,49 @@
+package model
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/asciimoo/hister/client"
+	"github.com/asciimoo/hister/config"
+)
+
+func TestPrioritizeRulePreservesRulesNotLoadedInTUI(t *testing.T) {
+	var saved url.Values
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			_ = json.NewEncoder(w).Encode(client.RulesResponse{
+				Skip:       []string{"private/*"},
+				Priority:   []string{"existing/*"},
+				Versioning: []string{"articles/*"},
+			})
+		case http.MethodPost:
+			if err := r.ParseForm(); err != nil {
+				t.Error(err)
+			}
+			saved = r.PostForm
+			w.WriteHeader(http.StatusNoContent)
+		}
+	}))
+	defer server.Close()
+
+	m := InitialModel(config.CreateDefaultConfig())
+	m.Client = client.New(server.URL)
+	msg := m.PrioritizeRuleCmd("new/*")().(RulesSavedMsg)
+	if msg.Err != nil {
+		t.Fatal(msg.Err)
+	}
+	if got := saved.Get("skip"); got != "private/*" {
+		t.Fatalf("skip = %q", got)
+	}
+	if got := saved.Get("priority"); got != "existing/*\nnew/*" {
+		t.Fatalf("priority = %q", got)
+	}
+	if got := saved.Get("versioning"); got != "articles/*" {
+		t.Fatalf("versioning = %q", got)
+	}
+}


### PR DESCRIPTION
Context-menu prioritization can run before the Rules tab has loaded

Fetch the latest server rules before appending so skip and versioning rules are not overwritten by an empty local cache