### PR TITLE
[mod] model responsive TUI workspaces and navigation

### DIFF
--- a/client/rules.go
+++ b/client/rules.go
@@ -24,8 +24,12 @@ func (c *Client) FetchRules() (_ *RulesResponse, err error) {
 	return &data, err
 }
 
-func (c *Client) SaveRules(skip, priority, versioning string) (err error) {
-	formData := url.Values{"skip": {skip}, "priority": {priority}, "versioning": {versioning}}
+func (c *Client) SaveRules(skip, priority string, versioning ...string) (err error) {
+	versioningRules := ""
+	if len(versioning) > 0 {
+		versioningRules = versioning[0]
+	}
+	formData := url.Values{"skip": {skip}, "priority": {priority}, "versioning": {versioningRules}}
 	req, err := c.newRequest("POST", "/api/rules", strings.NewReader(formData.Encode()))
 	if err != nil {
 		return err

--- a/client/rules.go
+++ b/client/rules.go
@@ -24,12 +24,8 @@ func (c *Client) FetchRules() (_ *RulesResponse, err error) {
 	return &data, err
 }
 
-func (c *Client) SaveRules(skip, priority string, versioning ...string) (err error) {
-	versioningRules := ""
-	if len(versioning) > 0 {
-		versioningRules = versioning[0]
-	}
-	formData := url.Values{"skip": {skip}, "priority": {priority}, "versioning": {versioningRules}}
+func (c *Client) SaveRules(skip, priority, versioning string) (err error) {
+	formData := url.Values{"skip": {skip}, "priority": {priority}, "versioning": {versioning}}
 	req, err := c.newRequest("POST", "/api/rules", strings.NewReader(formData.Encode()))
 	if err != nil {
 		return err

--- a/client/tui_test.go
+++ b/client/tui_test.go
@@ -56,6 +56,25 @@ func TestSaveRulesIncludesVersioning(t *testing.T) {
 	}
 }
 
+func TestSaveRulesKeepsVersioningOptional(t *testing.T) {
+	var got url.Values
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Error(err)
+		}
+		got = r.PostForm
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	if err := New(server.URL).SaveRules("skip", "priority"); err != nil {
+		t.Fatal(err)
+	}
+	if got.Get("versioning") != "" {
+		t.Errorf("form[%q] = %q, want empty", "versioning", got.Get("versioning"))
+	}
+}
+
 func TestUpdateLabelPayload(t *testing.T) {
 	var got map[string]string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/cmd/tui/handle/actions.go
+++ b/cmd/tui/handle/actions.go
@@ -57,10 +57,7 @@ func DispatchCommonAction(m *model.Model, action config.Action) (tea.Cmd, bool) 
 	case config.ActionDeleteResult:
 		if u := m.GetSelectedURL(); u != "" {
 			m.OpenDeleteDialog("Delete Result", u, -1, func() tea.Cmd {
-				return tea.Batch(
-					m.DeleteURLCmd(u),
-					doSearch(m),
-				)
+				return m.DeleteURLCmd(u)
 			})
 		}
 		return m.FlashHint(config.ActionDeleteResult), true
@@ -112,6 +109,7 @@ func SwitchTab(m *model.Model, action config.Action) tea.Cmd {
 	if m.ActiveTab == prevTab {
 		return nil
 	}
+	m.Workspace.GotoTop()
 	m.TextInput.Blur()
 	m.State = model.StateResults
 	var cmd tea.Cmd
@@ -124,7 +122,7 @@ func SwitchTab(m *model.Model, action config.Action) tea.Cmd {
 		cmd = m.FetchHistoryCmd()
 	case model.TabRules:
 		m.RulesLoading = true
-		m.RulesFormFocus = model.RulesFieldList
+		m.RulesFormFocus = model.RulesFocusList
 		m.RulesEditingIdx = -1
 		m.BlurAllRulesInputs()
 		cmd = m.FetchRulesCmd()
@@ -178,7 +176,7 @@ func submitAdd(m *model.Model) tea.Cmd {
 		m.AddInputs[0].SetValue(u)
 	}
 	title := strings.TrimSpace(m.AddInputs[1].Value())
-	text := strings.TrimSpace(m.AddInputs[2].Value())
+	text := strings.TrimSpace(m.AddText.Value())
 	m.AddStatus = "Adding..."
 	return m.AddPageCmd(u, title, text)
 }

--- a/cmd/tui/handle/mouse/mouse.go
+++ b/cmd/tui/handle/mouse/mouse.go
@@ -30,9 +30,41 @@ type Handler struct{ Deps }
 
 func New(d Deps) *Handler { return &Handler{d} }
 
+type action uint8
+
+const (
+	actionClick action = iota
+	actionRelease
+	actionMotion
+	actionWheel
+)
+
+// Event normalizes mouse messages for the layout hit testing shared by tabs,
+// overlays, and the results viewport.
+type Event struct {
+	X, Y   int
+	Button tea.MouseButton
+	Action action
+}
+
+func newEvent(msg tea.MouseMsg) Event {
+	e := Event{X: msg.X, Y: msg.Y, Button: msg.Button}
+	switch {
+	case msg.Action == tea.MouseActionRelease:
+		e.Action = actionRelease
+	case msg.Action == tea.MouseActionMotion:
+		e.Action = actionMotion
+	case tea.MouseEvent(msg).IsWheel():
+		e.Action = actionWheel
+	default:
+		e.Action = actionClick
+	}
+	return e
+}
+
 type Region struct{ X, Y, W, H int }
 
-func (r Region) Contains(msg tea.MouseMsg) bool {
+func (r Region) Contains(msg Event) bool {
 	return msg.X >= r.X && msg.X < r.X+r.W && msg.Y >= r.Y && msg.Y < r.Y+r.H
 }
 
@@ -67,7 +99,7 @@ func scrollToPercent(m *model.Model, mouseY int) {
 	render.RefreshViewport(m)
 }
 
-func wheelDelta(msg tea.MouseMsg) int {
+func wheelDelta(msg Event) int {
 	switch msg.Button {
 	case tea.MouseButtonWheelUp:
 		return -1
@@ -78,8 +110,8 @@ func wheelDelta(msg tea.MouseMsg) int {
 	}
 }
 
-func isLeftClick(msg tea.MouseMsg) bool {
-	return msg.Action == tea.MouseActionPress && msg.Button == tea.MouseButtonLeft
+func isLeftClick(msg Event) bool {
+	return msg.Action == actionClick && msg.Button == tea.MouseButtonLeft
 }
 
 func isOverlayState(s model.ViewState) bool {
@@ -95,7 +127,7 @@ func isOverlayState(s model.ViewState) bool {
 // handleScroll applies a wheel event to idx (clamped to [lo, hi]) and calls
 // after when the index changes. Returns (nil, true) if a wheel event was
 // consumed, (nil, false) otherwise.
-func handleScroll(msg tea.MouseMsg, idx *int, lo, hi int, after func()) (tea.Cmd, bool) {
+func handleScroll(msg Event, idx *int, lo, hi int, after func()) (tea.Cmd, bool) {
 	delta := wheelDelta(msg)
 	if delta == 0 {
 		return nil, false
@@ -117,7 +149,7 @@ func (h *Handler) closeOverlayForState(m *model.Model) tea.Cmd {
 	return h.CloseOverlay(m)
 }
 
-func (h *Handler) hintRegions(m *model.Model, msg tea.MouseMsg) tea.Cmd {
+func (h *Handler) hintRegions(m *model.Model, msg Event) tea.Cmd {
 	regions := render.ComputeHintRegions(m)
 	for _, r := range regions {
 		if msg.X >= r.X0 && msg.X < r.X1 {
@@ -129,57 +161,57 @@ func (h *Handler) hintRegions(m *model.Model, msg tea.MouseMsg) tea.Cmd {
 
 // Handle is the main entry point for mouse events.
 func (h *Handler) Handle(m *model.Model, msg tea.MouseMsg) tea.Cmd {
+	event := newEvent(msg)
 	if m.ScrollbarDragging {
-		if msg.Action == tea.MouseActionMotion {
-			scrollToPercent(m, msg.Y)
+		if event.Action == actionMotion {
+			scrollToPercent(m, event.Y)
 			return nil
 		}
-		if msg.Action == tea.MouseActionRelease {
+		if event.Action == actionRelease {
 			m.ScrollbarDragging = false
 			return nil
 		}
 	}
 
 	if isOverlayState(m.State) {
-		return h.overlay(m, msg)
+		return h.overlay(m, event)
 	}
-
 	if m.ActiveTab != model.TabSearch {
-		return h.nonSearchTab(m, msg)
+		return h.nonSearchTab(m, event)
 	}
 
-	if cmd, ok := handleScroll(msg, &m.SelectedIdx, 0, m.GetTotalResults()-1, func() {
+	if cmd, ok := handleScroll(event, &m.SelectedIdx, 0, m.GetTotalResults()-1, func() {
 		render.RefreshAndScroll(m)
 	}); ok {
 		return cmd
 	}
 
-	if msg.Action == tea.MouseActionPress && msg.Button == tea.MouseButtonRight {
-		return rightClick(m, msg)
+	if event.Action == actionClick && event.Button == tea.MouseButtonRight {
+		return rightClick(m, event)
 	}
 
-	if !isLeftClick(msg) {
+	if !isLeftClick(event) {
 		return nil
 	}
 
-	if msg.Y == model.RowTabBar {
-		return h.tabBar(m, msg)
+	if event.Y == model.RowTabBar {
+		return h.tabBar(m, event)
 	}
-	if msg.Y == model.RowInput {
-		return inputRow(m, msg)
+	if event.Y == model.RowInput {
+		return inputRow(m, event)
 	}
-	if msg.Y == model.RowHints(m.Height) {
-		return h.hintRegions(m, msg)
+	if event.Y == model.RowHints(m.Height) {
+		return h.hintRegions(m, event)
 	}
-	if m.TotalLines > m.Viewport.Height && m.Viewport.Height > 0 && msg.X >= m.Width-model.ScrollbarWidth {
-		return scrollbarClick(m, msg)
+	if m.TotalLines > m.Viewport.Height && m.Viewport.Height > 0 && event.X >= m.Width-model.ScrollbarWidth {
+		return scrollbarClick(m, event)
 	}
-	return h.viewportClick(m, msg)
+	return h.viewportClick(m, event)
 }
 
 // --- search-tab handlers ---
 
-func rightClick(m *model.Model, msg tea.MouseMsg) tea.Cmd {
+func rightClick(m *model.Model, msg Event) tea.Cmd {
 	vp := vpRegion(m)
 	if !vp.ContainsY(msg.Y) || len(m.LineOffsets) == 0 {
 		return nil
@@ -196,7 +228,7 @@ func rightClick(m *model.Model, msg tea.MouseMsg) tea.Cmd {
 	return nil
 }
 
-func inputRow(m *model.Model, msg tea.MouseMsg) tea.Cmd {
+func inputRow(m *model.Model, msg Event) tea.Cmd {
 	m.State = model.StateInput
 	prefixW := model.InputLeadingPad + lipgloss.Width("❯") + model.InputTrailingPad
 	pos := min(max(msg.X-prefixW, 0), len([]rune(m.TextInput.Value())))
@@ -204,7 +236,7 @@ func inputRow(m *model.Model, msg tea.MouseMsg) tea.Cmd {
 	return m.TextInput.Focus()
 }
 
-func scrollbarClick(m *model.Model, msg tea.MouseMsg) tea.Cmd {
+func scrollbarClick(m *model.Model, msg Event) tea.Cmd {
 	vp := vpRegion(m)
 	if vp.ContainsY(msg.Y) {
 		m.ScrollbarDragging = true
@@ -213,7 +245,7 @@ func scrollbarClick(m *model.Model, msg tea.MouseMsg) tea.Cmd {
 	return nil
 }
 
-func (h *Handler) viewportClick(m *model.Model, msg tea.MouseMsg) tea.Cmd {
+func (h *Handler) viewportClick(m *model.Model, msg Event) tea.Cmd {
 	vp := vpRegion(m)
 	if !vp.ContainsY(msg.Y) || len(m.LineOffsets) == 0 {
 		return nil
@@ -254,14 +286,11 @@ func (h *Handler) viewportClick(m *model.Model, msg tea.MouseMsg) tea.Cmd {
 
 // --- shared ---
 
-func (h *Handler) tabBar(m *model.Model, msg tea.MouseMsg) tea.Cmd {
-	x := model.TabBarLeftPad
-	for _, tab := range model.Tabs {
-		labelW := len(tab.Name) + model.TabLabelPad
-		if msg.X >= x && msg.X < x+labelW {
-			return h.SwitchTab(m, tab.Action)
+func (h *Handler) tabBar(m *model.Model, msg Event) tea.Cmd {
+	for _, target := range m.TabTargets {
+		if msg.X >= target.X0 && msg.X < target.X1 {
+			return h.SwitchTab(m, target.Action)
 		}
-		x += labelW + model.TabGap
 	}
 	return nil
 }

--- a/cmd/tui/handle/mouse/overlays.go
+++ b/cmd/tui/handle/mouse/overlays.go
@@ -31,13 +31,13 @@ const (
 	themeListGap         = 1 // blank line between dark and light lists
 )
 
-func (h *Handler) overlay(m *model.Model, msg tea.MouseMsg) tea.Cmd {
-	if m.IsDragging && msg.Action == tea.MouseActionMotion {
+func (h *Handler) overlay(m *model.Model, msg Event) tea.Cmd {
+	if m.IsDragging && msg.Action == actionMotion {
 		m.OverlayOffX = min(m.Width/2, max(-m.Width/2, m.DragOffX0+(msg.X-m.DragStartX)))
 		m.OverlayOffY = min(m.Height/2, max(-m.Height/2, m.DragOffY0+(msg.Y-m.DragStartY)))
 		return nil
 	}
-	if m.IsDragging && msg.Action == tea.MouseActionRelease {
+	if m.IsDragging && msg.Action == actionRelease {
 		m.IsDragging = false
 		return nil
 	}
@@ -53,7 +53,7 @@ func (h *Handler) overlay(m *model.Model, msg tea.MouseMsg) tea.Cmd {
 	return nil
 }
 
-func (h *Handler) overlayClick(m *model.Model, msg tea.MouseMsg) tea.Cmd {
+func (h *Handler) overlayClick(m *model.Model, msg Event) tea.Cmd {
 	ox, oy, ow, oh := render.OverlayBounds(m)
 
 	titleBar := Region{ox, oy, ow, 1}
@@ -86,7 +86,7 @@ func (h *Handler) overlayClick(m *model.Model, msg tea.MouseMsg) tea.Cmd {
 
 // --- overlay click handlers ---
 
-func (h *Handler) overlayContextMenu(m *model.Model, msg tea.MouseMsg, oy int) tea.Cmd {
+func (h *Handler) overlayContextMenu(m *model.Model, msg Event, oy int) tea.Cmd {
 	relY := msg.Y - oy
 	optStartY := model.OverlayBorderRows + model.OverlayPaddingRows
 	optIdx := relY - optStartY
@@ -97,7 +97,7 @@ func (h *Handler) overlayContextMenu(m *model.Model, msg tea.MouseMsg, oy int) t
 	return nil
 }
 
-func overlayDialog(m *model.Model, msg tea.MouseMsg, ox, oy, ow int) tea.Cmd {
+func overlayDialog(m *model.Model, msg Event, ox, oy, ow int) tea.Cmd {
 	if msg.Y-oy != model.DialogBtnRowY() {
 		return nil
 	}
@@ -111,7 +111,7 @@ func overlayDialog(m *model.Model, msg tea.MouseMsg, ox, oy, ow int) tea.Cmd {
 	return cmd
 }
 
-func overlayPrioritize(m *model.Model, msg tea.MouseMsg, ox, oy, ow int) tea.Cmd {
+func overlayPrioritize(m *model.Model, msg Event, ox, oy, ow int) tea.Cmd {
 	if msg.Y-oy != model.PrioritizeBtnRowY() {
 		return nil
 	}
@@ -120,8 +120,7 @@ func overlayPrioritize(m *model.Model, msg tea.MouseMsg, ox, oy, ow int) tea.Cmd
 	if msg.X-ox >= ow/2 {
 		m.PrioritizeBtnIdx = 1
 		if pattern := strings.TrimSpace(m.PrioritizeInput.Value()); pattern != "" {
-			m.RulesData.Priority = append(m.RulesData.Priority, pattern)
-			return m.SaveRulesCmd()
+			return m.PrioritizeRuleCmd(pattern)
 		}
 	}
 	return nil
@@ -129,7 +128,7 @@ func overlayPrioritize(m *model.Model, msg tea.MouseMsg, ox, oy, ow int) tea.Cmd
 
 // --- theme picker / settings internals ---
 
-func themePickerInside(m *model.Model, msg tea.MouseMsg, ox, oy int) tea.Cmd {
+func themePickerInside(m *model.Model, msg Event, ox, oy int) tea.Cmd {
 	relY := msg.Y - oy
 
 	if relY == themeModeRowY {
@@ -152,22 +151,23 @@ func themePickerInside(m *model.Model, msg tea.MouseMsg, ox, oy int) tea.Cmd {
 		darkNames, lightNames := theme.ClassifyThemes()
 		darkHeaderY := themeModeRowY + themeSectionOffset
 		darkListStartY := darkHeaderY + 1
-		lightHeaderY := darkListStartY + len(darkNames) + themeListGap
+		lightHeaderY := darkListStartY + m.ThemeDarkCount + themeListGap
 		lightListStartY := lightHeaderY + 1
 
 		type themeList struct {
 			items   Region
 			names   []string
+			start   int
 			section int
 			idx     *int
 		}
 		lists := [...]themeList{
-			{Region{Y: darkListStartY, H: len(darkNames)}, darkNames, 0, &m.DarkThemeIdx},
-			{Region{Y: lightListStartY, H: len(lightNames)}, lightNames, 1, &m.LightThemeIdx},
+			{Region{Y: darkListStartY, H: m.ThemeDarkCount}, darkNames, m.ThemeDarkStart, 0, &m.DarkThemeIdx},
+			{Region{Y: lightListStartY, H: m.ThemeLightCount}, lightNames, m.ThemeLightStart, 1, &m.LightThemeIdx},
 		}
 		for _, l := range lists {
 			if l.items.ContainsY(relY) {
-				idx := relY - l.items.Y
+				idx := l.start + relY - l.items.Y
 				m.ThemePickerSection = l.section
 				*l.idx = idx
 				if p, ok := theme.GetPalette(l.names[idx]); ok {
@@ -181,7 +181,7 @@ func themePickerInside(m *model.Model, msg tea.MouseMsg, ox, oy int) tea.Cmd {
 	return nil
 }
 
-func (h *Handler) themePickerScroll(m *model.Model, msg tea.MouseMsg) tea.Cmd {
+func (h *Handler) themePickerScroll(m *model.Model, msg Event) tea.Cmd {
 	darkNames, lightNames := theme.ClassifyThemes()
 	if m.ThemePickerSection == 0 {
 		handleScroll(msg, &m.DarkThemeIdx, 0, len(darkNames)-1, func() { h.PreviewTheme(m) })
@@ -191,7 +191,7 @@ func (h *Handler) themePickerScroll(m *model.Model, msg tea.MouseMsg) tea.Cmd {
 	return nil
 }
 
-func settingsScroll(m *model.Model, msg tea.MouseMsg) tea.Cmd {
+func settingsScroll(m *model.Model, msg Event) tea.Cmd {
 	handleScroll(msg, &m.SettingsIdx, 0, len(m.Cfg.Hotkeys.TUI)-1, nil)
 	return nil
 }

--- a/cmd/tui/handle/mouse/tabs.go
+++ b/cmd/tui/handle/mouse/tabs.go
@@ -15,10 +15,14 @@ import (
 func focusAddField(m *model.Model, idx int) {
 	if m.AddFocusIdx < len(m.AddInputs) {
 		m.AddInputs[m.AddFocusIdx].Blur()
+	} else if m.AddFocusIdx == 2 {
+		m.AddText.Blur()
 	}
 	m.AddFocusIdx = idx
 	if idx < len(m.AddInputs) {
 		m.AddInputs[idx].Focus()
+	} else if idx == 2 {
+		m.AddText.Focus()
 	}
 }
 
@@ -33,28 +37,19 @@ func focusRulesInput(m *model.Model, section, field int) {
 	}
 }
 
-var addClickTargets = [...]struct{ y1, y2, idx int }{
-	{model.AddURLLabelY, model.AddURLInputY, 0},
-	{model.AddTitleLabelY, model.AddTitleInputY, 1},
-	{model.AddTextLabelY, model.AddTextInputY, 2},
-}
-
 // --- non-search tab handling ---
 
-// History tab layout
-const (
-	historyItemHeight    = 3 // rows per history item (title + URL + separator)
-	historyClickableRows = 2 // clickable rows per item (title + URL, not separator)
-)
+func workspaceTargetAt(m *model.Model, msg Event) (model.WorkspaceTarget, bool) {
+	y := msg.Y - model.RowWorkspaceStart + m.Workspace.YOffset
+	for _, target := range m.WorkspaceTargets {
+		if y >= target.Y && y < target.Y+target.Height {
+			return target, true
+		}
+	}
+	return model.WorkspaceTarget{}, false
+}
 
-// Rules tab layout (relative to content area)
-const (
-	rulesFirstInputY = 4 // Y of first section input
-	rulesItemsOffset = 1 // items list starts 1 row below input
-	rulesSectionGap  = 2 // rows between last item and next section's input
-)
-
-func (h *Handler) nonSearchTab(m *model.Model, msg tea.MouseMsg) tea.Cmd {
+func (h *Handler) nonSearchTab(m *model.Model, msg Event) tea.Cmd {
 	if isLeftClick(msg) {
 		if msg.Y == model.RowTabBar {
 			return h.tabBar(m, msg)
@@ -78,10 +73,16 @@ func (h *Handler) nonSearchTab(m *model.Model, msg tea.MouseMsg) tea.Cmd {
 			handleScroll(msg, &m.HistoryIdx, 0, len(m.HistoryItems)-1, nil)
 		}
 	case model.TabRules:
-		if !m.RulesLoading && m.RulesFormFocus == model.RulesFieldList {
+		if !m.RulesLoading && m.RulesFormFocus == model.RulesFocusList {
 			if n := m.RulesSectionLen(m.RulesSection); n > 0 {
 				handleScroll(msg, &m.RulesIdx, 0, n-1, nil)
 			}
+		}
+	case model.TabAdd:
+		if delta := wheelDelta(msg); delta < 0 {
+			m.Workspace.ScrollUp(3)
+		} else if delta > 0 {
+			m.Workspace.ScrollDown(3)
 		}
 	}
 	return nil
@@ -89,78 +90,56 @@ func (h *Handler) nonSearchTab(m *model.Model, msg tea.MouseMsg) tea.Cmd {
 
 // --- tab click handlers ---
 
-func historyClick(m *model.Model, msg tea.MouseMsg) tea.Cmd {
-	if len(m.HistoryItems) == 0 || msg.Y < model.RowVPStart {
+func historyClick(m *model.Model, msg Event) tea.Cmd {
+	target, ok := workspaceTargetAt(m, msg)
+	if !ok || target.Kind != model.WorkspaceHistoryItem || target.Index >= len(m.HistoryItems) {
 		return nil
 	}
-	idx := (msg.Y - model.RowVPStart) / historyItemHeight
-	if idx >= 0 && idx < len(m.HistoryItems) && (msg.Y-model.RowVPStart)%historyItemHeight < historyClickableRows {
-		if idx == m.HistoryIdx {
-			if err := browser.OpenURL(m.HistoryItems[idx].URL); err != nil {
-				log.Warn().Err(err).Msg("failed to open URL in browser")
-			}
-		} else {
-			m.HistoryIdx = idx
+	if target.Index == m.HistoryIdx {
+		if err := browser.OpenURL(m.HistoryItems[target.Index].URL); err != nil {
+			log.Warn().Err(err).Msg("failed to open URL in browser")
 		}
+	} else {
+		m.HistoryIdx = target.Index
 	}
 	return nil
 }
 
-func rulesClick(m *model.Model, msg tea.MouseMsg) tea.Cmd {
+func rulesClick(m *model.Model, msg Event) tea.Cmd {
 	if m.RulesLoading {
 		return nil
 	}
-	s := max(len(m.RulesData.Skip), 1)
-	p := max(len(m.RulesData.Priority), 1)
 
-	skipInputY := rulesFirstInputY
-	skipItemsY := skipInputY + rulesItemsOffset
-	prioInputY := skipItemsY + s + rulesSectionGap
-	prioItemsY := prioInputY + rulesItemsOffset
-	aliasInputY := prioItemsY + p + rulesSectionGap
-	aliasItemsY := aliasInputY + rulesItemsOffset
-
-	type section struct {
-		inputY int
-		items  Region
-		sec    int
-		field  int
+	target, ok := workspaceTargetAt(m, msg)
+	if !ok {
+		return nil
 	}
-	sections := [...]section{
-		{skipInputY, Region{Y: skipItemsY, H: len(m.RulesData.Skip)}, 0, model.RulesFieldSkip},
-		{prioInputY, Region{Y: prioItemsY, H: len(m.RulesData.Priority)}, 1, model.RulesFieldPriority},
-		{aliasInputY, Region{Y: aliasItemsY, H: len(m.RulesData.Aliases)}, 2, model.RulesFieldAliasKey},
-	}
-
-	y := msg.Y
-	for _, sec := range sections {
-		if y == sec.inputY {
-			focusRulesInput(m, sec.sec, sec.field)
-			return nil
+	switch target.Kind {
+	case model.WorkspaceRulesForm:
+		focus := model.RulesFocusPattern
+		if target.Section == model.RulesSectionAliases {
+			focus = model.RulesFocusAliasKey
 		}
-		if sec.items.ContainsY(y) {
-			idx := y - sec.items.Y
-			if sec.sec == 2 && idx >= len(m.SortedAliasKeys()) {
-				return nil
-			}
-			m.BlurAllRulesInputs()
-			m.RulesFormFocus = model.RulesFieldList
-			m.RulesSection = sec.sec
-			m.RulesIdx = idx
-			return nil
-		}
+		focusRulesInput(m, target.Section, focus)
+	case model.WorkspaceRulesItem:
+		m.BlurAllRulesInputs()
+		m.RulesFormFocus = model.RulesFocusList
+		m.RulesSection = target.Section
+		m.RulesIdx = target.Index
 	}
 	return nil
 }
 
-func (h *Handler) addClick(m *model.Model, msg tea.MouseMsg) tea.Cmd {
-	for _, t := range addClickTargets {
-		if msg.Y == t.y1 || msg.Y == t.y2 {
-			focusAddField(m, t.idx)
-			return nil
-		}
+func (h *Handler) addClick(m *model.Model, msg Event) tea.Cmd {
+	target, ok := workspaceTargetAt(m, msg)
+	if !ok {
+		return nil
 	}
-	if msg.Y == model.AddSubmitY {
+	if target.Kind == model.WorkspaceAddField {
+		focusAddField(m, target.Index)
+		return nil
+	}
+	if target.Kind == model.WorkspaceAddSubmit {
 		focusAddField(m, model.AddSubmitFieldIdx)
 		return h.SubmitAdd(m)
 	}

--- a/cmd/tui/handle/overlays.go
+++ b/cmd/tui/handle/overlays.go
@@ -241,7 +241,11 @@ func ContextMenuKeys(m *model.Model, msg tea.KeyMsg) tea.Cmd {
 
 func executeContextMenuAction(m *model.Model) tea.Cmd {
 	m.State = m.PrevState
-	switch m.MenuSelIdx {
+	option, ok := model.MenuOptionAt(m.MenuSelIdx)
+	if !ok {
+		return nil
+	}
+	switch option.ID {
 	case model.MenuOpen:
 		if u := m.GetSelectedURL(); u != "" {
 			if err := browser.OpenURL(u); err != nil {
@@ -252,10 +256,7 @@ func executeContextMenuAction(m *model.Model) tea.Cmd {
 	case model.MenuDelete:
 		if u := m.GetSelectedURL(); u != "" {
 			m.OpenDeleteDialog("Delete Result", u, -1, func() tea.Cmd {
-				return tea.Batch(
-					m.DeleteURLCmd(u),
-					doSearch(m),
-				)
+				return m.DeleteURLCmd(u)
 			})
 		}
 	case model.MenuPrioritize:

--- a/cmd/tui/handle/tabs.go
+++ b/cmd/tui/handle/tabs.go
@@ -24,7 +24,7 @@ func TabKeys(m *model.Model, msg tea.KeyMsg) tea.Cmd {
 		case model.TabAdd:
 			inputFocused = m.AddFocusIdx >= 0 && m.AddFocusIdx < 3
 		case model.TabRules:
-			inputFocused = m.RulesFormFocus < model.RulesFieldList // form inputs 0-3
+			inputFocused = m.RulesFormFocus < model.RulesFocusList
 		}
 		if inputFocused {
 			action = ""
@@ -80,12 +80,10 @@ func HistoryKeys(m *model.Model, msg tea.KeyMsg) tea.Cmd {
 }
 
 func RulesKeys(m *model.Model, msg tea.KeyMsg) tea.Cmd {
-	// If a form input is focused (0-3), handle text input
-	if m.RulesFormFocus < model.RulesFieldList {
+	if m.RulesFormFocus < model.RulesFocusList {
 		return rulesFormKeys(m, msg)
 	}
 
-	// List navigation (RulesFormFocus == 4)
 	action := m.Keys.Action(msg)
 	switch action {
 	case config.ActionScrollUp:
@@ -105,7 +103,7 @@ func RulesKeys(m *model.Model, msg tea.KeyMsg) tea.Cmd {
 		n := m.RulesSectionLen(m.RulesSection)
 		if m.RulesIdx < n-1 {
 			m.RulesIdx++
-		} else if m.RulesSection < 2 {
+		} else if m.RulesSection < len(model.RulesSections)-1 {
 			m.RulesSection++
 			m.RulesIdx = 0
 		}
@@ -115,49 +113,36 @@ func RulesKeys(m *model.Model, msg tea.KeyMsg) tea.Cmd {
 		if msg.String() == "esc" {
 			return SwitchTab(m, config.ActionTabSearch)
 		}
-		// Jump to the form input for the current section
-		switch m.RulesSection {
-		case 0:
-			m.RulesFormFocus = model.RulesFieldSkip
-			m.RulesSkipInput.Focus()
-		case 1:
-			m.RulesFormFocus = model.RulesFieldPriority
-			m.RulesPriorityInput.Focus()
-		case 2:
-			m.RulesFormFocus = model.RulesFieldAliasKey
+		if m.RulesSection == model.RulesSectionAliases {
+			m.RulesFormFocus = model.RulesFocusAliasKey
 			m.RulesAliasKeyInput.Focus()
+		} else {
+			m.RulesFormFocus = model.RulesFocusPattern
+			m.RulesPatternInputs[m.RulesSection].Focus()
 		}
 		m.RulesEditingIdx = -1
 		m.RulesEditingSection = m.RulesSection
 		return nil
 	case config.ActionOpenResult:
-		// Edit existing item: populate form input with existing value
 		if m.RulesSectionLen(m.RulesSection) > 0 {
 			m.RulesEditingIdx = m.RulesIdx
 			m.RulesEditingSection = m.RulesSection
-			switch m.RulesSection {
-			case 0:
-				if m.RulesIdx < len(m.RulesData.Skip) {
-					m.RulesSkipInput.SetValue(m.RulesData.Skip[m.RulesIdx])
-					m.RulesSkipInput.SetCursor(len([]rune(m.RulesSkipInput.Value())))
-					m.RulesSkipInput.Focus()
-					m.RulesFormFocus = model.RulesFieldSkip
+			if patterns := m.RulesPatterns(m.RulesSection); patterns != nil {
+				if m.RulesIdx < len(*patterns) {
+					input := &m.RulesPatternInputs[m.RulesSection]
+					input.SetValue((*patterns)[m.RulesIdx])
+					input.SetCursor(len([]rune(input.Value())))
+					input.Focus()
+					m.RulesFormFocus = model.RulesFocusPattern
 				}
-			case 1:
-				if m.RulesIdx < len(m.RulesData.Priority) {
-					m.RulesPriorityInput.SetValue(m.RulesData.Priority[m.RulesIdx])
-					m.RulesPriorityInput.SetCursor(len([]rune(m.RulesPriorityInput.Value())))
-					m.RulesPriorityInput.Focus()
-					m.RulesFormFocus = model.RulesFieldPriority
-				}
-			case 2:
+			} else {
 				keys := m.SortedAliasKeys()
 				if m.RulesIdx < len(keys) {
 					m.RulesAliasKeyInput.SetValue(keys[m.RulesIdx])
 					m.RulesAliasValInput.SetValue(m.RulesData.Aliases[keys[m.RulesIdx]])
 					m.RulesAliasKeyInput.SetCursor(len([]rune(m.RulesAliasKeyInput.Value())))
 					m.RulesAliasKeyInput.Focus()
-					m.RulesFormFocus = model.RulesFieldAliasKey
+					m.RulesFormFocus = model.RulesFocusAliasKey
 				}
 			}
 		}
@@ -167,16 +152,11 @@ func RulesKeys(m *model.Model, msg tea.KeyMsg) tea.Cmd {
 			section := m.RulesSection
 			idx := m.RulesIdx
 			var label string
-			switch section {
-			case 0:
-				if idx < len(m.RulesData.Skip) {
-					label = m.RulesData.Skip[idx]
+			if patterns := m.RulesPatterns(section); patterns != nil {
+				if idx < len(*patterns) {
+					label = (*patterns)[idx]
 				}
-			case 1:
-				if idx < len(m.RulesData.Priority) {
-					label = m.RulesData.Priority[idx]
-				}
-			case 2:
+			} else {
 				keys := m.SortedAliasKeys()
 				if idx < len(keys) {
 					label = keys[idx]
@@ -184,18 +164,12 @@ func RulesKeys(m *model.Model, msg tea.KeyMsg) tea.Cmd {
 			}
 			if label != "" {
 				m.OpenDeleteDialog("Delete Rule", label, model.TabRules, func() tea.Cmd {
-					switch section {
-					case 0:
-						if idx < len(m.RulesData.Skip) {
-							m.RulesData.Skip = append(m.RulesData.Skip[:idx], m.RulesData.Skip[idx+1:]...)
+					if patterns := m.RulesPatterns(section); patterns != nil {
+						if idx < len(*patterns) {
+							*patterns = append((*patterns)[:idx], (*patterns)[idx+1:]...)
 							return m.SaveRulesCmd()
 						}
-					case 1:
-						if idx < len(m.RulesData.Priority) {
-							m.RulesData.Priority = append(m.RulesData.Priority[:idx], m.RulesData.Priority[idx+1:]...)
-							return m.SaveRulesCmd()
-						}
-					case 2:
+					} else {
 						keys := m.SortedAliasKeys()
 						if idx < len(keys) {
 							return m.DeleteAliasCmd(keys[idx])
@@ -219,33 +193,24 @@ func rulesFormKeys(m *model.Model, msg tea.KeyMsg) tea.Cmd {
 	case config.ActionOpenResult:
 		var cmd tea.Cmd
 		switch m.RulesFormFocus {
-		case model.RulesFieldSkip:
-			pattern := strings.TrimSpace(m.RulesSkipInput.Value())
+		case model.RulesFocusPattern:
+			input := &m.RulesPatternInputs[m.RulesSection]
+			pattern := strings.TrimSpace(input.Value())
+			patterns := m.RulesPatterns(m.RulesSection)
 			if pattern != "" {
-				if m.RulesEditingIdx >= 0 && m.RulesEditingSection == 0 && m.RulesEditingIdx < len(m.RulesData.Skip) {
-					m.RulesData.Skip[m.RulesEditingIdx] = pattern
+				if m.RulesEditingIdx >= 0 && m.RulesEditingSection == m.RulesSection && m.RulesEditingIdx < len(*patterns) {
+					(*patterns)[m.RulesEditingIdx] = pattern
 				} else {
-					m.RulesData.Skip = append(m.RulesData.Skip, pattern)
+					*patterns = append(*patterns, pattern)
 				}
 				cmd = m.SaveRulesCmd()
 			}
-			m.RulesSkipInput.SetValue("")
-		case model.RulesFieldPriority:
-			pattern := strings.TrimSpace(m.RulesPriorityInput.Value())
-			if pattern != "" {
-				if m.RulesEditingIdx >= 0 && m.RulesEditingSection == 1 && m.RulesEditingIdx < len(m.RulesData.Priority) {
-					m.RulesData.Priority[m.RulesEditingIdx] = pattern
-				} else {
-					m.RulesData.Priority = append(m.RulesData.Priority, pattern)
-				}
-				cmd = m.SaveRulesCmd()
-			}
-			m.RulesPriorityInput.SetValue("")
-		case model.RulesFieldAliasKey, model.RulesFieldAliasVal:
+			input.SetValue("")
+		case model.RulesFocusAliasKey, model.RulesFocusAliasValue:
 			keyword := strings.TrimSpace(m.RulesAliasKeyInput.Value())
 			value := strings.TrimSpace(m.RulesAliasValInput.Value())
 			if keyword != "" && value != "" {
-				if m.RulesEditingIdx >= 0 && m.RulesEditingSection == 2 {
+				if m.RulesEditingIdx >= 0 && m.RulesEditingSection == model.RulesSectionAliases {
 					keys := m.SortedAliasKeys()
 					if m.RulesEditingIdx < len(keys) {
 						oldKey := keys[m.RulesEditingIdx]
@@ -263,41 +228,33 @@ func rulesFormKeys(m *model.Model, msg tea.KeyMsg) tea.Cmd {
 			m.RulesAliasValInput.SetValue("")
 		}
 		m.BlurAllRulesInputs()
-		m.RulesFormFocus = model.RulesFieldList
+		m.RulesFormFocus = model.RulesFocusList
 		m.RulesEditingIdx = -1
 		return cmd
 
 	case config.ActionToggleFocus:
 		if msg.String() == "esc" {
-			// Cancel editing
 			m.BlurAllRulesInputs()
-			m.RulesFormFocus = model.RulesFieldList
+			m.RulesFormFocus = model.RulesFocusList
 			m.RulesEditingIdx = -1
-			// Clear the input that was being edited
-			m.RulesSkipInput.SetValue("")
-			m.RulesPriorityInput.SetValue("")
+			for i := range m.RulesPatternInputs {
+				m.RulesPatternInputs[i].SetValue("")
+			}
 			m.RulesAliasKeyInput.SetValue("")
 			m.RulesAliasValInput.SetValue("")
 			return nil
 		}
-		// Cycle through form inputs: skip → priority → alias key → alias val → list
 		m.BlurAllRulesInputs()
-		next := m.RulesFormFocus + 1
-		if next > model.RulesFieldList {
-			next = model.RulesFieldSkip
-		}
-		m.RulesFormFocus = next
-		switch next {
-		case model.RulesFieldSkip:
-			m.RulesSkipInput.Focus()
-		case model.RulesFieldPriority:
-			m.RulesPriorityInput.Focus()
-		case model.RulesFieldAliasKey:
-			m.RulesAliasKeyInput.Focus()
-		case model.RulesFieldAliasVal:
-			m.RulesAliasValInput.Focus()
-		case model.RulesFieldList:
-			// list mode, nothing to focus
+		if m.RulesSection == model.RulesSectionAliases {
+			switch m.RulesFormFocus {
+			case model.RulesFocusAliasKey:
+				m.RulesFormFocus = model.RulesFocusAliasValue
+				m.RulesAliasValInput.Focus()
+			default:
+				m.RulesFormFocus = model.RulesFocusList
+			}
+		} else {
+			m.RulesFormFocus = model.RulesFocusList
 		}
 		return nil
 	}
@@ -305,19 +262,24 @@ func rulesFormKeys(m *model.Model, msg tea.KeyMsg) tea.Cmd {
 	// Pass key to the focused input
 	var cmd tea.Cmd
 	switch m.RulesFormFocus {
-	case model.RulesFieldSkip:
-		m.RulesSkipInput, cmd = m.RulesSkipInput.Update(msg)
-	case model.RulesFieldPriority:
-		m.RulesPriorityInput, cmd = m.RulesPriorityInput.Update(msg)
-	case model.RulesFieldAliasKey:
+	case model.RulesFocusPattern:
+		input := &m.RulesPatternInputs[m.RulesSection]
+		*input, cmd = input.Update(msg)
+	case model.RulesFocusAliasKey:
 		m.RulesAliasKeyInput, cmd = m.RulesAliasKeyInput.Update(msg)
-	case model.RulesFieldAliasVal:
+	case model.RulesFocusAliasValue:
 		m.RulesAliasValInput, cmd = m.RulesAliasValInput.Update(msg)
 	}
 	return cmd
 }
 
 func AddKeys(m *model.Model, msg tea.KeyMsg) tea.Cmd {
+	// Enter is content inside the multi-line field, not the global submit action.
+	if m.AddFocusIdx == 2 && msg.String() == "enter" {
+		var cmd tea.Cmd
+		m.AddText, cmd = m.AddText.Update(msg)
+		return cmd
+	}
 	action := m.Keys.Action(msg)
 	switch action {
 	case config.ActionToggleFocus:
@@ -326,28 +288,39 @@ func AddKeys(m *model.Model, msg tea.KeyMsg) tea.Cmd {
 		}
 		if m.AddFocusIdx < len(m.AddInputs) {
 			m.AddInputs[m.AddFocusIdx].Blur()
+		} else if m.AddFocusIdx == 2 {
+			m.AddText.Blur()
 		}
 		m.AddFocusIdx = (m.AddFocusIdx + 1) % 4
-		if m.AddFocusIdx < 3 {
+		if m.AddFocusIdx < len(m.AddInputs) {
 			m.AddInputs[m.AddFocusIdx].Focus()
+		} else if m.AddFocusIdx == 2 {
+			m.AddText.Focus()
 		}
 		return m.FlashHint(config.ActionToggleFocus)
 	case config.ActionOpenResult:
-		if m.AddFocusIdx == 3 || m.AddFocusIdx == 2 {
+		if m.AddFocusIdx == 3 {
 			return submitAdd(m)
 		}
 		if m.AddFocusIdx < len(m.AddInputs) {
 			m.AddInputs[m.AddFocusIdx].Blur()
 		}
 		m.AddFocusIdx++
-		if m.AddFocusIdx < 3 {
+		if m.AddFocusIdx < len(m.AddInputs) {
 			m.AddInputs[m.AddFocusIdx].Focus()
+		} else if m.AddFocusIdx == 2 {
+			m.AddText.Focus()
 		}
 		return nil
 	}
-	if m.AddFocusIdx < 3 {
+	if m.AddFocusIdx < len(m.AddInputs) {
 		var cmd tea.Cmd
 		m.AddInputs[m.AddFocusIdx], cmd = m.AddInputs[m.AddFocusIdx].Update(msg)
+		return cmd
+	}
+	if m.AddFocusIdx == 2 {
+		var cmd tea.Cmd
+		m.AddText, cmd = m.AddText.Update(msg)
 		return cmd
 	}
 	return nil

--- a/cmd/tui/handle/update.go
+++ b/cmd/tui/handle/update.go
@@ -36,16 +36,27 @@ func Update(m *model.Model, msg tea.Msg) tea.Cmd {
 		m.Width, m.Height = msg.Width, msg.Height
 
 		vpH := max(0, m.Height-model.FixedLayoutRows)
-		vpW := max(1, m.Width-model.ScrollbarWidth)
 		m.TextInput.Width = max(1, m.Width-6)
+		formW := max(12, min(72, m.Width-12))
+		for i := range m.AddInputs {
+			m.AddInputs[i].Width = formW
+		}
+		m.AddText.SetWidth(formW)
+		for i := range m.RulesPatternInputs {
+			m.RulesPatternInputs[i].Width = max(12, min(48, m.Width-24))
+		}
+		m.Workspace.Width = max(1, m.Width-1)
+		m.Workspace.Height = max(1, vpH+2)
+		m.Help.Width = max(1, m.Width-4)
 
 		if !m.Ready {
-			m.Viewport = viewport.New(vpW, vpH)
+			m.Viewport = viewport.New(1, vpH)
 			m.Viewport.SetContent("")
 			m.Ready = true
+			render.ResizeSearchViewports(m)
 			return tea.ClearScreen
 		}
-		m.Viewport.Width, m.Viewport.Height = vpW, vpH
+		render.ResizeSearchViewports(m)
 		render.RefreshAndScroll(m)
 		if changed {
 			return tea.ClearScreen
@@ -99,16 +110,35 @@ func Update(m *model.Model, msg tea.Msg) tea.Cmd {
 		m.HintFlash = ""
 	case model.SettingsErrClearMsg:
 		m.SettingsEditErr = ""
-
+	case model.NoticeClearMsg:
+		if msg.ID == m.NoticeID {
+			m.Notice = ""
+		}
 	case model.HistoryFetchedMsg:
 		m.HistoryLoading = false
+		if msg.Err != nil {
+			return m.Notify("Could not load history: " + msg.Err.Error())
+		}
 		m.HistoryItems = msg.Items
 		m.HistoryIdx = 0
 
 	case model.RulesFetchedMsg:
 		m.RulesLoading = false
+		if msg.Err != nil {
+			return m.Notify("Could not load rules: " + msg.Err.Error())
+		}
 		m.RulesData = msg.Data
 		m.RulesIdx = 0
+
+	case model.DeleteResultMsg:
+		if msg.Err != nil {
+			return m.Notify("Could not delete result: " + msg.Err.Error())
+		}
+		m.State = model.StateResults
+		m.PrevState = model.StateResults
+		render.ResizeSearchViewports(m)
+		render.RefreshAndScroll(m)
+		return tea.Batch(doSearch(m), m.Notify("Result deleted"))
 
 	case model.AddResultMsg:
 		if msg.Err != nil {
@@ -118,13 +148,15 @@ func Update(m *model.Model, msg tea.Msg) tea.Cmd {
 			for i := range m.AddInputs {
 				m.AddInputs[i].SetValue("")
 			}
+			m.AddText.SetValue("")
 		}
 
 	case model.RulesSavedMsg:
 		if msg.Err == nil {
 			m.RulesLoading = true
-			return m.FetchRulesCmd()
+			return tea.Batch(m.FetchRulesCmd(), m.Notify("Rules saved"))
 		}
+		return m.Notify("Could not save rules: " + msg.Err.Error())
 
 	case model.ResultsMsg:
 		m.IsSearching = false
@@ -142,6 +174,7 @@ func Update(m *model.Model, msg tea.Msg) tea.Cmd {
 		if msg.Conn != nil {
 			m.Conn = msg.Conn
 			m.WsReady = true
+			m.ConnError = nil
 		}
 		return network.ListenToWebSocket(m.WsChan, m.WsDone)
 
@@ -157,7 +190,7 @@ func Update(m *model.Model, msg tea.Msg) tea.Cmd {
 		return network.ConnectWebSocket(m.Cfg.WebSocketURL(), m.Cfg.BaseURL(""), m.Cfg.App.AccessToken, m.WsChan, m.WsDone)
 
 	case model.ErrMsg:
-		return network.ListenToWebSocket(m.WsChan, m.WsDone)
+		return tea.Batch(m.Notify(msg.Err.Error()), network.ListenToWebSocket(m.WsChan, m.WsDone))
 	}
 	return nil
 }

--- a/cmd/tui/model/model.go
+++ b/cmd/tui/model/model.go
@@ -11,18 +11,21 @@ import (
 	"slices"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/asciimoo/hister/client"
 	"github.com/asciimoo/hister/cmd/tui/component"
 	"github.com/asciimoo/hister/cmd/tui/theme"
 	"github.com/asciimoo/hister/config"
+	"github.com/asciimoo/hister/server/document"
 	"github.com/asciimoo/hister/server/indexer"
 
+	"github.com/charmbracelet/bubbles/help"
 	"github.com/charmbracelet/bubbles/spinner"
+	"github.com/charmbracelet/bubbles/textarea"
 	"github.com/charmbracelet/bubbles/textinput"
 	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
 	"github.com/gorilla/websocket"
 	"github.com/muesli/termenv"
 	"github.com/rs/zerolog/log"
@@ -33,20 +36,25 @@ type Model struct {
 	TextInput textinput.Model
 	Viewport  viewport.Model
 	Spinner   spinner.Model
+	Help      help.Model
+	Keys      component.KeyMap
+	Workspace viewport.Model
 	State     ViewState
 	PrevState ViewState
 	Cfg       *config.Config
 	Client    *client.Client
 	Results   *indexer.Results
-	Keys      component.KeyMap
 
 	// Dimensions and readiness
 	Width, Height int
 	Ready         bool
 
 	// Viewport line tracking
-	LineOffsets []int
-	TotalLines  int
+	LineOffsets         []int
+	TotalLines          int
+	TabTargets          []HintRegion
+	WorkspaceTargets    []WorkspaceTarget
+	WorkspaceSelectionY int
 
 	// WebSocket communication
 	Conn    *websocket.Conn
@@ -74,6 +82,8 @@ type Model struct {
 	// Connection state
 	ConnError error
 	HintFlash config.Action
+	Notice    string
+	NoticeID  uint64
 
 	// Scrollbar interaction
 	ScrollbarDragging bool
@@ -87,7 +97,7 @@ type Model struct {
 	DragOffX0   int
 	DragOffY0   int
 
-	// Terminal background
+	// Terminal background, queried asynchronously by Bubble Tea.
 	IsDarkBg bool
 	BgSet    bool
 
@@ -105,6 +115,10 @@ type Model struct {
 	OrigDarkTheme      string
 	OrigLightTheme     string
 	OrigColorScheme    string
+	ThemeDarkStart     int
+	ThemeDarkCount     int
+	ThemeLightStart    int
+	ThemeLightCount    int
 
 	// Context menu
 	MenuX, MenuY int
@@ -127,18 +141,18 @@ type Model struct {
 	// Rules tab (form-based UI)
 	RulesData           RulesResponse
 	RulesIdx            int
-	RulesSection        int // 0=skip, 1=priority, 2=aliases
+	RulesSection        int // skip, priority, versioning, or aliases
 	RulesLoading        bool
-	RulesSkipInput      textinput.Model
-	RulesPriorityInput  textinput.Model
+	RulesPatternInputs  [3]textinput.Model // skip, priority, versioning
 	RulesAliasKeyInput  textinput.Model
 	RulesAliasValInput  textinput.Model
-	RulesFormFocus      int // 0=skip input, 1=priority input, 2=alias key, 3=alias val, 4=list
+	RulesFormFocus      int // pattern, alias key, alias value, or list
 	RulesEditingIdx     int // -1 = adding new, >=0 = editing existing item
-	RulesEditingSection int // which section is being edited (0/1/2)
+	RulesEditingSection int // section containing the item being edited
 
 	// Add tab
-	AddInputs   [3]textinput.Model // url, title, text
+	AddInputs   [2]textinput.Model // URL and title
+	AddText     textarea.Model
 	AddFocusIdx int
 	AddStatus   string
 
@@ -161,28 +175,38 @@ func InitialModel(cfg *config.Config) *Model {
 	ti.Focus()
 
 	// Add tab text inputs
-	var addInputs [3]textinput.Model
-	for i, ph := range []string{"URL", "Title", "Text content"} {
+	var addInputs [2]textinput.Model
+	for i, ph := range []string{"URL", "Title"} {
 		addInputs[i] = newInput(ph, 500, 40, st)
 	}
+	addText := textarea.New()
+	addText.Placeholder = "Optional text content"
+	addText.Prompt = ""
+	addText.ShowLineNumbers = false
+	addText.CharLimit = 100_000
+	addText.SetWidth(60)
+	addText.SetHeight(AddTextHeight)
+	applyTextareaStyles(&addText, st)
 
 	// Spinner
-	s := spinner.New()
-	s.Spinner = spinner.Spinner{
-		Frames: []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"},
-		FPS:    80 * time.Millisecond,
-	}
-	s.Style = st.Spin
+	s := spinner.New(
+		spinner.WithSpinner(spinner.MiniDot),
+		spinner.WithStyle(st.Spin),
+	)
+	h := help.New()
+	h.ShowAll = true
+	applyHelpStyles(&h, st)
 
 	m := &Model{
 		TextInput:          ti,
 		Spinner:            s,
+		Help:               h,
+		Keys:               component.NewKeyMap(cfg.Hotkeys.TUI),
 		IsDarkBg:           isDarkBg,
 		State:              StateInput,
 		PrevState:          StateInput,
 		Cfg:                cfg,
 		Client:             client.New(cfg.BaseURL(""), client.WithAccessToken(cfg.App.AccessToken)),
-		Keys:               component.NewKeyMap(cfg.Hotkeys.TUI),
 		SelectedIdx:        -1,
 		DialogReturnTab:    -1,
 		Limit:              ResultsPageSize,
@@ -192,15 +216,21 @@ func InitialModel(cfg *config.Config) *Model {
 		ThemeName:          name,
 		ThemePickerMode:    cfg.TUI.ColorScheme,
 		AddInputs:          addInputs,
-		RulesSkipInput:     newInput("skip pattern...", 200, 40, st),
-		RulesPriorityInput: newInput("priority pattern...", 200, 40, st),
+		AddText:            addText,
 		RulesAliasKeyInput: newInput("keyword...", 200, 40, st),
 		RulesAliasValInput: newInput("value...", 200, 40, st),
-		RulesFormFocus:     RulesFieldList, // start on list
+		RulesFormFocus:     RulesFocusList, // start on list
 		RulesEditingIdx:    -1,
 		PrioritizeInput:    newInput("URL pattern...", 500, 40, st),
 		TipIdx:             rand.Intn(len(SearchTips)),
 	}
+	for _, section := range RulesSections {
+		if section.Aliases {
+			continue
+		}
+		m.RulesPatternInputs[section.ID] = newInput(section.Placeholder, 200, 40, st)
+	}
+	m.Workspace = viewport.New(80, 20)
 	if m.ThemePickerMode == "" {
 		m.ThemePickerMode = "auto"
 	}
@@ -211,9 +241,30 @@ func InitialModel(cfg *config.Config) *Model {
 func (m *Model) ApplyTheme(p theme.Palette) {
 	m.Styles = theme.BuildStyles(p)
 	m.ThemeName = p.Name
-	m.TextInput.PlaceholderStyle = m.Styles.Placeholder
+	applyInputStyles(&m.TextInput, m.Styles)
+	for i := range m.AddInputs {
+		applyInputStyles(&m.AddInputs[i], m.Styles)
+	}
+	applyTextareaStyles(&m.AddText, m.Styles)
+	for i := range m.RulesPatternInputs {
+		applyInputStyles(&m.RulesPatternInputs[i], m.Styles)
+	}
+	applyInputStyles(&m.RulesAliasKeyInput, m.Styles)
+	applyInputStyles(&m.RulesAliasValInput, m.Styles)
+	applyInputStyles(&m.PrioritizeInput, m.Styles)
 	m.Spinner.Style = m.Styles.Spin
+	applyHelpStyles(&m.Help, m.Styles)
 	m.SetTerminalBg(p.Base00)
+}
+
+func applyHelpStyles(h *help.Model, st theme.Styles) {
+	h.Styles.ShortKey = st.HintKey
+	h.Styles.ShortDesc = st.Hint
+	h.Styles.ShortSeparator = st.Hint
+	h.Styles.Ellipsis = st.Hint
+	h.Styles.FullKey = st.HintKey
+	h.Styles.FullDesc = st.HelpAction
+	h.Styles.FullSeparator = st.Div
 }
 
 func (m *Model) ScrollToSelected() {
@@ -235,7 +286,7 @@ func (m *Model) GetTotalResults() int {
 	if m.Results == nil {
 		return 0
 	}
-	c := len(m.Results.History) + len(m.Results.Documents)
+	c := len(m.Results.History) + len(m.VisibleDocuments())
 	if c > m.Limit {
 		return m.Limit + 1
 	}
@@ -249,9 +300,10 @@ func (m *Model) GetSelectedURL() string {
 	if m.SelectedIdx < len(m.Results.History) {
 		return m.Results.History[m.SelectedIdx].URL
 	}
+	documents := m.VisibleDocuments()
 	docIdx := m.SelectedIdx - len(m.Results.History)
-	if docIdx < len(m.Results.Documents) {
-		return m.Results.Documents[docIdx].URL
+	if docIdx < len(documents) {
+		return documents[docIdx].URL
 	}
 	return ""
 }
@@ -263,11 +315,31 @@ func (m *Model) GetSelectedTitle() string {
 	if m.SelectedIdx < len(m.Results.History) {
 		return m.Results.History[m.SelectedIdx].Title
 	}
+	documents := m.VisibleDocuments()
 	docIdx := m.SelectedIdx - len(m.Results.History)
-	if docIdx < len(m.Results.Documents) {
-		return m.Results.Documents[docIdx].Title
+	if docIdx < len(documents) {
+		return documents[docIdx].Title
 	}
 	return ""
+}
+
+func (m *Model) GetSelectedDocument() *document.Document {
+	if m.Results == nil || m.SelectedIdx < 0 || m.SelectedIdx < len(m.Results.History) || m.SelectedIdx == m.Limit {
+		return nil
+	}
+	documents := m.VisibleDocuments()
+	idx := m.SelectedIdx - len(m.Results.History)
+	if idx < len(documents) {
+		return documents[idx]
+	}
+	return nil
+}
+
+func (m *Model) VisibleDocuments() []*document.Document {
+	if m.Results == nil {
+		return nil
+	}
+	return slices.Clone(m.Results.Documents)
 }
 
 func (m *Model) SortedSettingsItems() []SettingsItem {
@@ -292,11 +364,13 @@ func (m *Model) SortedAliasKeys() []string {
 
 func (m *Model) RulesSectionLen(section int) int {
 	switch section {
-	case 0:
+	case RulesSectionSkip:
 		return len(m.RulesData.Skip)
-	case 1:
+	case RulesSectionPriority:
 		return len(m.RulesData.Priority)
-	case 2:
+	case RulesSectionVersioning:
+		return len(m.RulesData.Versioning)
+	case RulesSectionAliases:
 		return len(m.RulesData.Aliases)
 	}
 	return 0
@@ -374,23 +448,6 @@ func (m *Model) StartDrag(x, y int) {
 	m.DragOffX0, m.DragOffY0 = m.OverlayOffX, m.OverlayOffY
 }
 
-func (m *Model) SetTerminalBg(hex string) {
-	if hex == "" {
-		return
-	}
-	// sets the terminal background via OSC 11
-	fmt.Fprintf(os.Stderr, "\033]11;%s\a", hex)
-	m.BgSet = true
-}
-
-func (m *Model) ResetTerminalBg() {
-	if m.BgSet {
-		// restores the terminal's original background via OSC 111
-		fmt.Fprint(os.Stderr, "\033]111\a")
-		m.BgSet = false
-	}
-}
-
 func (m *Model) Close() {
 	m.ResetTerminalBg()
 	close(m.WsDone)
@@ -398,13 +455,13 @@ func (m *Model) Close() {
 
 func (m *Model) FocusedRulesInput() *textinput.Model {
 	switch m.RulesFormFocus {
-	case RulesFieldSkip:
-		return &m.RulesSkipInput
-	case RulesFieldPriority:
-		return &m.RulesPriorityInput
-	case RulesFieldAliasKey:
+	case RulesFocusPattern:
+		if m.RulesSection >= RulesSectionSkip && m.RulesSection <= RulesSectionVersioning {
+			return &m.RulesPatternInputs[m.RulesSection]
+		}
+	case RulesFocusAliasKey:
 		return &m.RulesAliasKeyInput
-	case RulesFieldAliasVal:
+	case RulesFocusAliasValue:
 		return &m.RulesAliasValInput
 	}
 	return nil
@@ -412,8 +469,9 @@ func (m *Model) FocusedRulesInput() *textinput.Model {
 
 // removes focus from all rules form inputs
 func (m *Model) BlurAllRulesInputs() {
-	m.RulesSkipInput.Blur()
-	m.RulesPriorityInput.Blur()
+	for i := range m.RulesPatternInputs {
+		m.RulesPatternInputs[i].Blur()
+	}
 	m.RulesAliasKeyInput.Blur()
 	m.RulesAliasValInput.Blur()
 }
@@ -464,16 +522,33 @@ func (m *Model) SaveRulesCmd() tea.Cmd {
 	}
 }
 
+// RulesPatterns returns the mutable collection for a non-alias rule section.
+func (m *Model) RulesPatterns(section int) *[]string {
+	switch section {
+	case RulesSectionSkip:
+		return &m.RulesData.Skip
+	case RulesSectionPriority:
+		return &m.RulesData.Priority
+	case RulesSectionVersioning:
+		return &m.RulesData.Versioning
+	default:
+		return nil
+	}
+}
+
 func (m *Model) FetchHistoryCmd() tea.Cmd {
 	return func() tea.Msg {
-		items, _ := m.Client.FetchHistory()
-		return HistoryFetchedMsg{Items: items}
+		items, err := m.Client.FetchHistory()
+		return HistoryFetchedMsg{Items: items, Err: err}
 	}
 }
 
 func (m *Model) FetchRulesCmd() tea.Cmd {
 	return func() tea.Msg {
-		data, _ := m.Client.FetchRules()
+		data, err := m.Client.FetchRules()
+		if err != nil {
+			return RulesFetchedMsg{Err: err}
+		}
 		if data == nil {
 			return RulesFetchedMsg{}
 		}
@@ -519,20 +594,17 @@ func (m *Model) DeleteAliasCmd(alias string) tea.Cmd {
 
 func (m *Model) DeleteURLCmd(u string) tea.Cmd {
 	return func() tea.Msg {
-		if err := m.Client.DeleteDocument(u); err != nil {
-			log.Warn().Err(err).Msg("failed to delete document")
-		}
-		return nil
+		return DeleteResultMsg{Err: m.Client.DeleteDocument(u)}
 	}
 }
 
 func (m *Model) DeleteHistoryEntryCmd(query, url string) tea.Cmd {
 	return func() tea.Msg {
 		if err := m.Client.DeleteHistoryEntry(query, url); err != nil {
-			log.Warn().Err(err).Msg("failed to delete history entry")
+			return HistoryFetchedMsg{Err: err}
 		}
-		items, _ := m.Client.FetchHistory()
-		return HistoryFetchedMsg{Items: items}
+		items, err := m.Client.FetchHistory()
+		return HistoryFetchedMsg{Items: items, Err: err}
 	}
 }
 
@@ -544,4 +616,33 @@ func newInput(placeholder string, charLimit int, width int, st theme.Styles) tex
 	inp.Prompt = ""
 	inp.PlaceholderStyle = st.Placeholder
 	return inp
+}
+
+func applyInputStyles(inp *textinput.Model, st theme.Styles) {
+	inp.PlaceholderStyle = st.Placeholder
+	inp.CompletionStyle = st.Placeholder
+	inp.Cursor.Style = lipgloss.NewStyle().Foreground(st.PromptActive.GetForeground())
+}
+
+func applyTextareaStyles(input *textarea.Model, st theme.Styles) {
+	input.FocusedStyle.Placeholder = st.Placeholder
+	input.BlurredStyle.Placeholder = st.Placeholder
+	input.FocusedStyle.CursorLine = lipgloss.NewStyle()
+	input.BlurredStyle.CursorLine = lipgloss.NewStyle()
+	input.Cursor.Style = lipgloss.NewStyle().Foreground(st.PromptActive.GetForeground())
+}
+
+func (m *Model) SetTerminalBg(hex string) {
+	if hex == "" {
+		return
+	}
+	fmt.Fprintf(os.Stderr, "\033]11;%s\a", hex)
+	m.BgSet = true
+}
+
+func (m *Model) ResetTerminalBg() {
+	if m.BgSet {
+		fmt.Fprint(os.Stderr, "\033]111\a")
+		m.BgSet = false
+	}
 }

--- a/cmd/tui/model/types.go
+++ b/cmd/tui/model/types.go
@@ -51,10 +51,18 @@ type (
 	ReconnectMsg        struct{}
 	HintClearMsg        struct{}
 	SettingsErrClearMsg struct{}
-	HistoryFetchedMsg   struct{ Items []HistoryItem }
-	RulesFetchedMsg     struct{ Data RulesResponse }
-	AddResultMsg        struct{ Err error }
-	RulesSavedMsg       struct{ Err error }
+	NoticeClearMsg      struct{ ID uint64 }
+	HistoryFetchedMsg   struct {
+		Items []HistoryItem
+		Err   error
+	}
+	RulesFetchedMsg struct {
+		Data RulesResponse
+		Err  error
+	}
+	AddResultMsg    struct{ Err error }
+	RulesSavedMsg   struct{ Err error }
+	DeleteResultMsg struct{ Err error }
 )
 
 type HistoryItem = client.HistoryItem
@@ -64,6 +72,26 @@ type RulesResponse = client.RulesResponse
 type HintRegion struct {
 	X0, X1 int
 	Action config.Action
+}
+
+type WorkspaceTargetKind uint8
+
+const (
+	WorkspaceHistoryItem WorkspaceTargetKind = iota
+	WorkspaceRulesForm
+	WorkspaceRulesItem
+	WorkspaceAddField
+	WorkspaceAddSubmit
+)
+
+// WorkspaceTarget describes one interactive block in a scrollable tab. Mouse
+// hit testing consumes the same geometry the renderer produced, so layout
+// changes do not require a second set of magic coordinates.
+type WorkspaceTarget struct {
+	Y, Height int
+	Kind      WorkspaceTargetKind
+	Section   int
+	Index     int
 }
 
 // holds one key → action row for the settings panel
@@ -79,14 +107,9 @@ const (
 	TabAdd     = 3
 )
 
-const (
-	RulesFieldSkip     = 0
-	RulesFieldPriority = 1
-	RulesFieldAliasKey = 2
-	RulesFieldAliasVal = 3
-	RulesFieldList     = 4
-)
-
+// TabDefinition is the single source of truth for tab identity, presentation,
+// and navigation. Renderers and handlers consume the same ordered slice so a
+// tab cannot acquire mismatched labels, hit targets, or shortcuts.
 type TabDefinition struct {
 	ID     int
 	Name   string
@@ -109,6 +132,34 @@ func TabForAction(action config.Action) (int, bool) {
 	return 0, false
 }
 
+const (
+	RulesSectionSkip = iota
+	RulesSectionPriority
+	RulesSectionVersioning
+	RulesSectionAliases
+)
+
+type RulesSectionDefinition struct {
+	ID          int
+	Title       string
+	Placeholder string
+	Aliases     bool
+}
+
+var RulesSections = []RulesSectionDefinition{
+	{ID: RulesSectionSkip, Title: "Skip Patterns", Placeholder: "skip pattern..."},
+	{ID: RulesSectionPriority, Title: "Priority Patterns", Placeholder: "priority pattern..."},
+	{ID: RulesSectionVersioning, Title: "Versioning Patterns", Placeholder: "versioning pattern..."},
+	{ID: RulesSectionAliases, Title: "Aliases", Aliases: true},
+}
+
+const (
+	RulesFocusPattern = iota
+	RulesFocusAliasKey
+	RulesFocusAliasValue
+	RulesFocusList
+)
+
 // Layout constants shared across packages (mouse handlers, render, model init).
 const (
 	ResultsPageSize   = 10 // results per page
@@ -122,9 +173,10 @@ const (
 )
 
 const (
-	RowTabBar  = 0 // tab bar header
-	RowInput   = 2 // search input line
-	RowVPStart = 4 // first viewport row
+	RowTabBar         = 0 // tab bar header
+	RowInput          = 2 // search input line
+	RowVPStart        = 4 // first viewport row
+	RowWorkspaceStart = 2
 )
 
 // returns the hints row Y position for the given terminal height.
@@ -138,8 +190,8 @@ const FixedLayoutRows = 6
 
 const (
 	MenuOpen int = iota
-	MenuDelete
 	MenuPrioritize
+	MenuDelete
 )
 
 type MenuOptionDefinition struct {
@@ -149,8 +201,15 @@ type MenuOptionDefinition struct {
 
 var MenuOptions = []MenuOptionDefinition{
 	{ID: MenuOpen, Label: "Open"},
-	{ID: MenuDelete, Label: "Delete"},
 	{ID: MenuPrioritize, Label: "Prioritize"},
+	{ID: MenuDelete, Label: "Delete"},
+}
+
+func MenuOptionAt(index int) (MenuOptionDefinition, bool) {
+	if index < 0 || index >= len(MenuOptions) {
+		return MenuOptionDefinition{}, false
+	}
+	return MenuOptions[index], true
 }
 
 // Dialog/overlay layout: border(1) + padding(1) + content rows
@@ -167,16 +226,7 @@ func DialogBtnRowY() int { return 7 }
 // Layout: border(1) + padding(1) + title(1) + blank(1) + label(1) + input(1) + blank(1) + buttons(1)
 func PrioritizeBtnRowY() int { return 7 }
 
-// Add tab row positions (relative to content area, after tab bar + dividers)
-const (
-	AddURLLabelY   = 5
-	AddURLInputY   = 6
-	AddTitleLabelY = 8
-	AddTitleInputY = 9
-	AddTextLabelY  = 11
-	AddTextInputY  = 12
-	AddSubmitY     = 14
-)
+const AddTextHeight = 5
 
 var SearchTips = []string{
 	"Type to search...",
@@ -199,5 +249,14 @@ func (m *Model) FlashHint(action config.Action) tea.Cmd {
 func ClearHintAfter() tea.Cmd {
 	return tea.Tick(350*time.Millisecond, func(_ time.Time) tea.Msg {
 		return HintClearMsg{}
+	})
+}
+
+func (m *Model) Notify(message string) tea.Cmd {
+	m.Notice = message
+	m.NoticeID++
+	id := m.NoticeID
+	return tea.Tick(2500*time.Millisecond, func(_ time.Time) tea.Msg {
+		return NoticeClearMsg{ID: id}
 	})
 }

--- a/cmd/tui/render/layout.go
+++ b/cmd/tui/render/layout.go
@@ -7,12 +7,10 @@ package render
 import (
 	"fmt"
 	"os"
-	"slices"
 	"strings"
 
 	"github.com/asciimoo/hister/cmd/tui/component"
 	"github.com/asciimoo/hister/cmd/tui/model"
-	"github.com/asciimoo/hister/config"
 
 	"github.com/charmbracelet/lipgloss"
 )
@@ -24,7 +22,7 @@ type overlayDef struct {
 }
 
 var overlayDefs = map[model.ViewState]overlayDef{
-	model.StateHelp:            {func(m *model.Model) string { return m.Styles.Help.Render(GenerateHelpText(m)) }, func(m *model.Model) lipgloss.Color { return m.Styles.HelpBorder }, nil},
+	model.StateHelp:            {HelpOverlay, func(m *model.Model) lipgloss.Color { return m.Styles.HelpBorder }, nil},
 	model.StateDialog:          {func(m *model.Model) string { return DeleteDialog(m) }, func(m *model.Model) lipgloss.Color { return m.Styles.DialogBorder }, nil},
 	model.StateThemePicker:     {func(m *model.Model) string { return ThemePicker(m) }, func(m *model.Model) lipgloss.Color { return m.Styles.ThemeBorder }, nil},
 	model.StateSettings:        {func(m *model.Model) string { return Settings(m) }, func(m *model.Model) lipgloss.Color { return m.Styles.HelpBorder }, nil},
@@ -36,7 +34,7 @@ func View(m *model.Model) string {
 	if !m.Ready {
 		return "Loading..."
 	}
-	if m.Width < 20 || m.Height < 10 {
+	if m.Width < 20 || m.Height < 14 {
 		return "Terminal too small"
 	}
 
@@ -68,17 +66,15 @@ func MainView(m *model.Model) string {
 
 	if renderer, ok := tabRenderers[m.ActiveTab]; ok {
 		content := renderer(m)
-		contentH := m.Viewport.Height + 2
-		contentLines := strings.Split(content, "\n")
-		for len(contentLines) < contentH {
-			contentLines = append(contentLines, "")
+		m.Workspace.SetContent(content)
+		target := m.WorkspaceSelectionY
+		if target < m.Workspace.YOffset {
+			m.Workspace.SetYOffset(target)
+		} else if target >= m.Workspace.YOffset+m.Workspace.Height {
+			m.Workspace.SetYOffset(max(0, target-m.Workspace.Height+2))
 		}
-		if len(contentLines) > contentH {
-			contentLines = contentLines[:contentH]
-		}
-		content = strings.Join(contentLines, "\n")
 		hints := Hints(m)
-		return strings.Join([]string{header, div, content, div, hints}, "\n")
+		return strings.Join([]string{header, div, m.Workspace.View(), div, hints}, "\n")
 	}
 
 	pStyle := m.Styles.PromptActive
@@ -86,38 +82,87 @@ func MainView(m *model.Model) string {
 		pStyle = m.Styles.PromptBlur
 	}
 	inputLine := "  " + pStyle.Render("❯") + " " + m.TextInput.View()
-
-	vp := m.Viewport.View()
-	vpLines := strings.Split(vp, "\n")
-	if len(vpLines) > m.Viewport.Height {
-		vpLines = vpLines[:m.Viewport.Height]
-	}
-	for len(vpLines) < m.Viewport.Height {
-		vpLines = append(vpLines, "")
-	}
-	vp = strings.Join(vpLines, "\n")
-
-	if m.TotalLines > m.Viewport.Height && m.Viewport.Height > 0 {
-		vp = lipgloss.JoinHorizontal(lipgloss.Top, vp, " ", Scrollbar(m))
-	}
+	ResizeSearchViewports(m)
+	body := SearchBody(m)
 
 	hints := Hints(m)
 
-	return strings.Join([]string{header, div, inputLine, div, vp, div, hints}, "\n")
+	return strings.Join([]string{header, div, inputLine, div, body, div, hints}, "\n")
+}
+
+func ResizeSearchViewports(m *model.Model) {
+	w := max(1, m.Width-1)
+	bodyH := max(1, m.Height-model.FixedLayoutRows)
+	m.Viewport.Width = max(1, w-2)
+	m.Viewport.Height = bodyH
+}
+
+func SearchBody(m *model.Model) string {
+	w := max(1, m.Width-1)
+	bodyH := max(1, m.Height-model.FixedLayoutRows)
+	return resultsViewport(m, w, bodyH)
+}
+
+func resultsViewport(m *model.Model, width, height int) string {
+	content := normalizeBlock(m.Viewport.View(), max(1, m.Viewport.Width), height)
+	if m.TotalLines > m.Viewport.Height && m.Viewport.Height > 0 {
+		content = lipgloss.JoinHorizontal(lipgloss.Top, content, " ", Scrollbar(m))
+	}
+	return normalizeBlock(content, width, height)
+}
+
+func normalizeBlock(content string, width, height int) string {
+	lines := strings.Split(content, "\n")
+	if len(lines) > height {
+		lines = lines[:height]
+	}
+	for len(lines) < height {
+		lines = append(lines, "")
+	}
+	for i, line := range lines {
+		line = truncateAnsi(line, width)
+		lines[i] = rightPad(line, width)
+	}
+	return strings.Join(lines, "\n")
 }
 
 func Header(m *model.Model) string {
+	w := max(1, m.Width-1)
+	compact := w < 56
 	var tabs []string
-	for _, tab := range model.Tabs {
-		if tab.ID == m.ActiveTab {
-			tabs = append(tabs, m.Styles.TabActive.Render("["+tab.Name+"]"))
-		} else {
-			tabs = append(tabs, m.Styles.TabInactive.Render(" "+tab.Name+" "))
+	m.TabTargets = nil
+	x := model.TabBarLeftPad
+	for _, definition := range model.Tabs {
+		label := definition.Name
+		if compact {
+			label = definition.Name[:1]
 		}
+		var tab string
+		if definition.ID == m.ActiveTab {
+			tab = m.Styles.TabActive.Render("[" + label + "]")
+		} else {
+			tab = m.Styles.TabInactive.Render(" " + label + " ")
+		}
+		tabs = append(tabs, tab)
+		tabWidth := lipgloss.Width(tab)
+		m.TabTargets = append(m.TabTargets, model.HintRegion{
+			X0: x, X1: x + tabWidth, Action: definition.Action,
+		})
+		x += tabWidth + model.TabGap
 	}
 	tabBar := " " + strings.Join(tabs, " ")
+	appendMode := func(full, short string) {
+		label := full
+		if compact {
+			label = short
+		}
+		badge := "  " + m.Styles.Conn.Render(label)
+		if lipgloss.Width(tabBar)+lipgloss.Width(badge) < w {
+			tabBar += badge
+		}
+	}
 	if m.SortMode == "domain" {
-		tabBar += "  " + m.Styles.Conn.Render("[domain]")
+		appendMode("[domain]", "D")
 	}
 
 	cs := m.Styles.Disc.Render("● disconnected")
@@ -126,14 +171,17 @@ func Header(m *model.Model) string {
 	}
 
 	var right string
-	if m.ConnError != nil && !m.WsReady {
+	if m.Notice != "" {
+		right = m.Styles.Conn.Render("◆ " + m.Notice)
+	} else if m.ConnError != nil && !m.WsReady {
 		right = m.Styles.Disc.Render(m.ConnError.Error())
 	} else if m.IsSearching {
 		right = cs + "  " + m.Styles.Spin.Render(m.Spinner.View()+" searching…")
 	} else {
 		countStr := "0 results"
 		if m.Results != nil {
-			countStr = fmt.Sprintf("%d results", int(m.Results.Total))
+			visibleCount := len(m.Results.History) + len(m.VisibleDocuments())
+			countStr = fmt.Sprintf("%d results", max(int(m.Results.Total)+len(m.Results.History), visibleCount))
 			if m.Results.SearchDuration != "" {
 				countStr += "  " + m.Results.SearchDuration
 			}
@@ -141,116 +189,48 @@ func Header(m *model.Model) string {
 		right = cs + "  " + m.Styles.Status.Render(countStr)
 	}
 
-	w := max(1, m.Width-1)
 	leftW := lipgloss.Width(tabBar)
 	rightW := lipgloss.Width(right)
+	if available := max(0, w-leftW); rightW > available {
+		right = truncateAnsi(right, available)
+		rightW = lipgloss.Width(right)
+	}
 	pad := max(0, w-leftW-rightW)
 	return tabBar + strings.Repeat(" ", pad) + right
 }
 
-type hintEntry struct {
-	act config.Action // action name (or "" for fixed keys)
-	key string        // pre-resolved key symbol (for fixed entries)
-	lbl string
-}
-
-func hintEntries(m *model.Model) []hintEntry {
-	bestKey := func(action config.Action) string {
-		return m.Keys.BestKey(action)
-	}
+func keyContext(m *model.Model) component.KeyContext {
 	switch m.ActiveTab {
 	case model.TabHistory:
-		var entries []hintEntry
-		if bestKey(config.ActionScrollDown) != "" {
-			entries = append(entries, hintEntry{act: config.ActionScrollDown, lbl: "navigate"})
-		}
-		if bestKey(config.ActionOpenResult) != "" {
-			entries = append(entries, hintEntry{act: config.ActionOpenResult, lbl: "open"})
-		}
-		if bestKey(config.ActionDeleteResult) != "" {
-			entries = append(entries, hintEntry{act: config.ActionDeleteResult, lbl: "delete"})
-		}
-		return append(entries, hintEntry{key: "⎋", lbl: "back"})
+		return component.ContextHistory
 	case model.TabRules:
-		entries := []hintEntry{{key: "⇥", lbl: "next"}}
-		if bestKey(config.ActionOpenResult) != "" {
-			entries = append(entries, hintEntry{act: config.ActionOpenResult, lbl: "add/save"})
-		}
-		if bestKey(config.ActionScrollDown) != "" {
-			entries = append(entries, hintEntry{act: config.ActionScrollDown, lbl: "navigate"})
-		}
-		if bestKey(config.ActionDeleteResult) != "" {
-			entries = append(entries, hintEntry{act: config.ActionDeleteResult, lbl: "delete"})
-		}
-		return append(entries, hintEntry{key: "⎋", lbl: "back"})
+		return component.ContextRules
 	case model.TabAdd:
-		return []hintEntry{
-			{key: "⇥", lbl: "next"},
-			{key: "↵", lbl: "submit"},
-			{key: "⎋", lbl: "back"},
-		}
-	default: // Search
-		isNoColor := m.ThemeName == "no-color"
-		var entries []hintEntry
-		for _, a := range []struct {
-			act config.Action
-			lbl string
-		}{
-			{config.ActionScrollUp, "up"},
-			{config.ActionScrollDown, "down"},
-			{config.ActionOpenResult, "open"},
-			{config.ActionDeleteResult, "delete"},
-			{config.ActionToggleSort, "sort"},
-			{config.ActionToggleTheme, "theme"},
-			{config.ActionToggleSettings, "settings"},
-			{config.ActionToggleHelp, "help"},
-			{config.ActionQuit, "quit"},
-		} {
-			if isNoColor && a.act == config.ActionToggleTheme {
-				continue
-			}
-			if bestKey(a.act) != "" {
-				entries = append(entries, hintEntry{act: a.act, lbl: a.lbl})
-			}
-		}
-		return entries
+		return component.ContextAdd
+	default:
+		return component.ContextSearch
 	}
 }
 
 func Hints(m *model.Model) string {
-	entries := hintEntries(m)
-	isNoColor := m.ThemeName == "no-color"
-	sep := m.Styles.Hint.Render("  ·  ")
-	if isNoColor {
-		sep = "  |  "
+	h := m.Help
+	h.ShowAll = false
+	h.Width = max(1, m.Width-4)
+	if m.ThemeName == "no-color" {
+		h.ShortSeparator = " | "
+	} else {
+		h.ShortSeparator = " · "
 	}
-	var parts []string
-	for _, e := range entries {
-		k := e.key
-		if k == "" {
-			k = m.Keys.BestKey(e.act)
-		}
-		if k == "" {
-			continue
-		}
-		isFlash := e.act != "" && m.HintFlash == e.act
-		if isNoColor {
-			if isFlash {
-				parts = append(parts, "["+k+"] "+strings.ToUpper(e.lbl))
-			} else {
-				parts = append(parts, k+" "+e.lbl)
-			}
-		} else {
-			keyRender := m.Styles.HintKey
-			lblRender := m.Styles.Hint
-			if isFlash {
-				keyRender = m.Styles.HintKeyFlash
-				lblRender = m.Styles.HintFlash
-			}
-			parts = append(parts, keyRender.Render(k)+lblRender.Render(" "+e.lbl))
-		}
-	}
-	return "  " + strings.Join(parts, sep)
+	return "  " + h.View(m.Keys.For(keyContext(m)))
+}
+
+func HelpOverlay(m *model.Model) string {
+	h := m.Help
+	h.ShowAll = true
+	h.Width = max(20, overlayMaxWidth(m)-8)
+	content := m.Styles.HelpHeader.Render("Keyboard shortcuts") + "\n\n" +
+		h.View(m.Keys.For(keyContext(m)))
+	return m.Styles.Help.Render(content)
 }
 
 func overlayMaxWidth(m *model.Model) int {
@@ -293,7 +273,10 @@ func renderOverlayBox(content string, borderColor lipgloss.Color, maxWidth int) 
 	for _, l := range lines {
 		sb.WriteByte('\n')
 		pad := max(0, maxW-lipgloss.Width(l))
-		sb.WriteString(bc.Render("│") + l + strings.Repeat(" ", pad) + bc.Render("│"))
+		sb.WriteString(bc.Render("│"))
+		sb.WriteString(l)
+		sb.WriteString(strings.Repeat(" ", pad))
+		sb.WriteString(bc.Render("│"))
 	}
 	sb.WriteByte('\n')
 	sb.WriteString(bottomBar)
@@ -319,18 +302,9 @@ func renderOverlay(bg, fg string, bgW, bgH, offX, offY int) string {
 	}
 
 	fgLines := strings.Split(fg, "\n")
-	fgH := len(fgLines)
-	fgW := 0
-	for _, l := range fgLines {
-		if w := lipgloss.Width(l); w > fgW {
-			fgW = w
-		}
-	}
-
+	fgW, fgH := lipgloss.Width(fg), lipgloss.Height(fg)
 	startY := max(0, min(bgH-fgH, (bgH-fgH)/2+offY))
 	startX := max(0, min(bgW-fgW, (bgW-fgW)/2+offX))
-
-	// Available width for overlay content
 	availW := bgW - startX
 
 	var sb strings.Builder
@@ -342,16 +316,13 @@ func renderOverlay(bg, fg string, bgW, bgH, offX, offY int) string {
 		if i < len(bgLines) {
 			bgLine = bgLines[i]
 		}
-
 		fgIdx := i - startY
 		if fgIdx >= 0 && fgIdx < fgH {
 			fgLine := fgLines[fgIdx]
 			fgLineW := lipgloss.Width(fgLine)
-			// Pad to full overlay width so right edge aligns consistently
 			if fgLineW < fgW {
 				fgLine += strings.Repeat(" ", fgW-fgLineW)
 			}
-			// Truncate if overlay exceeds available terminal width
 			if fgW > availW {
 				fgLine = truncateAnsi(fgLine, availW)
 			}
@@ -404,109 +375,27 @@ func OverlayBounds(m *model.Model) (x, y, w, h int) {
 	return
 }
 
-func GenerateHelpText(m *model.Model) string {
-	bindings := make(map[string][]string)
-	for k, v := range m.Cfg.Hotkeys.TUI {
-		bindings[v] = append(bindings[v], k)
-	}
-	const helpKeyColW = 20
-	fmtAct := func(action, label string) string {
-		keys := bindings[action]
-		if len(keys) == 0 {
-			return ""
-		}
-		slices.Sort(keys)
-		var formatted []string
-		for _, k := range keys {
-			formatted = append(formatted, component.FormatKey(k))
-		}
-		keyPart := m.Styles.HintKey.Render(strings.Join(formatted, ", "))
-		lblPart := m.Styles.HelpAction.Render(label)
-		padW := max(0, helpKeyColW-lipgloss.Width(keyPart))
-		return "  " + keyPart + strings.Repeat(" ", padW) + " " + lblPart
-	}
-	lines := []string{m.Styles.HelpHeader.Render("Shortcuts:"), ""}
-	sections := []struct {
-		title string
-		items []struct{ act, lbl string }
-	}{
-		{"General:", []struct{ act, lbl string }{
-			{"quit", "Quit"},
-			{"toggle_help", "Toggle help"},
-			{"toggle_theme", "Toggle theme picker"},
-			{"toggle_settings", "Toggle settings"},
-			{"toggle_sort", "Toggle sort mode"},
-			{"tab_search", "Search tab"},
-			{"tab_history", "History tab"},
-			{"tab_rules", "Rules tab"},
-			{"tab_add", "Add tab"},
-		}},
-		{"Search input:", []struct{ act, lbl string }{
-			{"toggle_focus", "Focus results list"},
-			{"scroll_up", "Previous result"},
-			{"scroll_down", "Next result"},
-			{"open_result", "Open result"},
-			{"delete_result", "Delete result"},
-		}},
-		{"Results list:", []struct{ act, lbl string }{
-			{"toggle_focus", "Back to input"},
-			{"scroll_up", "Navigate up"},
-			{"scroll_down", "Navigate down"},
-			{"open_result", "Open selected"},
-			{"delete_result", "Delete selected"},
-		}},
-	}
-	for i, sec := range sections {
-		if i > 0 {
-			lines = append(lines, "")
-		}
-		lines = append(lines, m.Styles.HelpHeader.Render(sec.title))
-		for _, a := range sec.items {
-			if s := fmtAct(a.act, a.lbl); s != "" {
-				lines = append(lines, s)
-			}
-		}
-	}
-	return strings.Join(lines, "\n")
-}
-
 func ComputeHintRegions(m *model.Model) []model.HintRegion {
-	entries := hintEntries(m)
-	isNoColor := m.ThemeName == "no-color"
-	sep := m.Styles.Hint.Render("  ·  ")
-	if isNoColor {
-		sep = "  |  "
+	keyMap := m.Keys.For(keyContext(m))
+	hints := keyMap.ShortHints()
+	var separator string
+	if m.ThemeName == "no-color" {
+		separator = " | "
+	} else {
+		separator = " · "
 	}
-	sepW := lipgloss.Width(sep)
+	sepW := lipgloss.Width(m.Help.Styles.ShortSeparator.Render(separator))
 
 	var regions []model.HintRegion
 	x := 2
-	first := true
-	for _, e := range entries {
-		k := e.key
-		if k == "" {
-			k = m.Keys.BestKey(e.act)
-		}
-		if k == "" {
-			continue
-		}
-		if !first {
+	for i, hint := range hints {
+		if i > 0 {
 			x += sepW
 		}
-		first = false
-		var hintW int
-		if isNoColor {
-			hintW = lipgloss.Width(k + " " + e.lbl)
-		} else {
-			keyRender := m.Styles.HintKey.Render(k)
-			lblRender := m.Styles.Hint.Render(" " + e.lbl)
-			hintW = lipgloss.Width(keyRender) + lipgloss.Width(lblRender)
-		}
-		action := e.act
-		if action == "" {
-			action = config.Action(e.lbl) // use label as action id for fixed keys
-		}
-		regions = append(regions, model.HintRegion{X0: x, X1: x + hintW, Action: action})
+		help := hint.Binding.Help()
+		hintW := lipgloss.Width(m.Help.Styles.ShortKey.Render(help.Key)) + 1 +
+			lipgloss.Width(m.Help.Styles.ShortDesc.Render(help.Desc))
+		regions = append(regions, model.HintRegion{X0: x, X1: x + hintW, Action: hint.Action})
 		x += hintW
 	}
 	return regions

--- a/cmd/tui/render/overlays.go
+++ b/cmd/tui/render/overlays.go
@@ -5,9 +5,9 @@
 package render
 
 import (
+	"fmt"
 	"strings"
 
-	"github.com/asciimoo/hister/cmd/tui/component"
 	"github.com/asciimoo/hister/cmd/tui/model"
 	"github.com/asciimoo/hister/cmd/tui/theme"
 	"github.com/asciimoo/hister/config"
@@ -17,6 +17,13 @@ import (
 
 func ThemePicker(m *model.Model) string {
 	darkNames, lightNames := theme.ClassifyThemes()
+	listBudget := max(2, m.Height-12)
+	darkBudget := (listBudget + 1) / 2
+	lightBudget := listBudget - darkBudget
+	darkStart, darkEnd := windowRange(len(darkNames), m.DarkThemeIdx, darkBudget)
+	lightStart, lightEnd := windowRange(len(lightNames), m.LightThemeIdx, lightBudget)
+	m.ThemeDarkStart, m.ThemeDarkCount = darkStart, darkEnd-darkStart
+	m.ThemeLightStart, m.ThemeLightCount = lightStart, lightEnd-lightStart
 
 	maxNameW := 0
 	for _, name := range append(darkNames, lightNames...) {
@@ -36,9 +43,10 @@ func ThemePicker(m *model.Model) string {
 	}
 	modeRow := "Mode: " + strings.Join(modeParts, " ")
 
-	renderSection := func(names []string, cursorIdx int, configuredName string, focused bool) []string {
+	renderSection := func(names []string, start, end, cursorIdx int, configuredName string, focused bool) []string {
 		var slines []string
-		for i, name := range names {
+		for i, name := range names[start:end] {
+			absoluteIdx := start + i
 			marker := "  "
 			if name == configuredName {
 				marker = "● "
@@ -49,7 +57,7 @@ func ThemePicker(m *model.Model) string {
 				swatch = renderSwatch(p)
 			}
 			content := marker + paddedName + "  " + swatch
-			if focused && i == cursorIdx {
+			if focused && absoluteIdx == cursorIdx {
 				slines = append(slines, m.Styles.ThemePickerSelected.Render(content))
 			} else {
 				slines = append(slines, m.Styles.ThemePickerItem.Render(content))
@@ -66,8 +74,8 @@ func ThemePicker(m *model.Model) string {
 	if darkFocused {
 		headerStyle = m.Styles.SelTitle
 	}
-	lines = append(lines, headerStyle.Render("Dark Themes"))
-	lines = append(lines, renderSection(darkNames, m.DarkThemeIdx, m.Cfg.TUI.DarkTheme, darkFocused)...)
+	lines = append(lines, headerStyle.Render(rangeHeader("Dark Themes", darkStart, darkEnd, len(darkNames))))
+	lines = append(lines, renderSection(darkNames, darkStart, darkEnd, m.DarkThemeIdx, m.Cfg.TUI.DarkTheme, darkFocused)...)
 	lines = append(lines, "")
 
 	lightFocused := m.ThemePickerSection == 1
@@ -75,8 +83,8 @@ func ThemePicker(m *model.Model) string {
 	if lightFocused {
 		headerStyle = m.Styles.SelTitle
 	}
-	lines = append(lines, headerStyle.Render("Light Themes"))
-	lines = append(lines, renderSection(lightNames, m.LightThemeIdx, m.Cfg.TUI.LightTheme, lightFocused)...)
+	lines = append(lines, headerStyle.Render(rangeHeader("Light Themes", lightStart, lightEnd, len(lightNames))))
+	lines = append(lines, renderSection(lightNames, lightStart, lightEnd, m.LightThemeIdx, m.Cfg.TUI.LightTheme, lightFocused)...)
 
 	lines = append(lines, "")
 	nav := m.Keys.BestKey(config.ActionScrollDown)
@@ -91,11 +99,10 @@ func ThemePicker(m *model.Model) string {
 func ContextMenu(m *model.Model) string {
 	var lines []string
 	for i, option := range model.MenuOptions {
-		opt := option.Label
 		if i == m.MenuSelIdx {
-			lines = append(lines, m.Styles.ThemePickerSelected.Render("▸ "+opt))
+			lines = append(lines, m.Styles.ThemePickerSelected.Render("▸ "+option.Label))
 		} else {
-			lines = append(lines, m.Styles.ThemePickerItem.Render("  "+opt))
+			lines = append(lines, m.Styles.ThemePickerItem.Render("  "+option.Label))
 		}
 	}
 	return m.Styles.Dialog.Render(strings.Join(lines, "\n"))
@@ -105,10 +112,7 @@ func DeleteDialog(m *model.Model) string {
 	var lines []string
 	lines = append(lines, m.Styles.Title.Render(m.DialogMsg))
 	lines = append(lines, "")
-	urlDisplay := m.DialogURL
-	if len([]rune(urlDisplay)) > 35 {
-		urlDisplay = string([]rune(urlDisplay)[:34]) + "…"
-	}
+	urlDisplay := truncateLine(m.DialogURL, 35)
 	lines = append(lines, m.Styles.URL.Render(urlDisplay))
 	lines = append(lines, "")
 	cancelLabel := " Cancel "
@@ -132,26 +136,32 @@ func DeleteDialog(m *model.Model) string {
 
 func Settings(m *model.Model) string {
 	items := m.SortedSettingsItems()
+	errorRows := 0
+	if m.SettingsEditErr != "" {
+		errorRows = 2
+	}
+	start, end := windowRange(len(items), m.SettingsIdx, max(1, m.Height-8-errorRows))
 
 	maxKeyW := 0
 	for _, it := range items {
-		fk := component.FormatKey(it.Key)
+		fk := FormatKey(it.Key)
 		if len([]rune(fk)) > maxKeyW {
 			maxKeyW = len([]rune(fk))
 		}
 	}
 
 	var lines []string
-	lines = append(lines, m.Styles.Title.Render("Keybindings"))
+	lines = append(lines, m.Styles.Title.Render(rangeHeader("Keybindings", start, end, len(items))))
 	lines = append(lines, "")
-	for i, it := range items {
-		if i == m.SettingsIdx && m.SettingsEditMode {
+	for i, it := range items[start:end] {
+		absoluteIdx := start + i
+		if absoluteIdx == m.SettingsIdx && m.SettingsEditMode {
 			lines = append(lines, m.Styles.ThemePickerSelected.Render("  Press a key...  →  "+string(it.Action)))
 		} else {
-			fk := component.FormatKey(it.Key)
+			fk := FormatKey(it.Key)
 			padded := fk + strings.Repeat(" ", maxKeyW-len([]rune(fk)))
 			row := "  " + padded + "  →  " + string(it.Action)
-			if i == m.SettingsIdx {
+			if absoluteIdx == m.SettingsIdx {
 				lines = append(lines, m.Styles.ThemePickerSelected.Render(row))
 			} else {
 				lines = append(lines, m.Styles.ThemePickerItem.Render(row))
@@ -160,7 +170,7 @@ func Settings(m *model.Model) string {
 	}
 	if m.SettingsEditErr != "" {
 		lines = append(lines, "")
-		lines = append(lines, lipgloss.NewStyle().Foreground(lipgloss.Color(m.Styles.DialogBorder)).Render("  "+m.SettingsEditErr))
+		lines = append(lines, lipgloss.NewStyle().Foreground(m.Styles.DialogBorder).Render("  "+m.SettingsEditErr))
 	}
 	lines = append(lines, "")
 	if m.SettingsEditMode {
@@ -171,6 +181,22 @@ func Settings(m *model.Model) string {
 		lines = append(lines, m.Styles.Hint.Render(sNav+" navigate  "+sEdit+" edit  ⎋ close"))
 	}
 	return m.Styles.Help.Render(strings.Join(lines, "\n"))
+}
+
+func windowRange(length, cursor, budget int) (int, int) {
+	if length <= 0 || budget <= 0 {
+		return 0, 0
+	}
+	budget = min(length, budget)
+	start := max(0, min(cursor-budget/2, length-budget))
+	return start, start + budget
+}
+
+func rangeHeader(label string, start, end, total int) string {
+	if start == 0 && end == total {
+		return label
+	}
+	return fmt.Sprintf("%s (%d–%d/%d)", label, start+1, end, total)
 }
 
 func PrioritizeInput(m *model.Model) string {

--- a/cmd/tui/render/results.go
+++ b/cmd/tui/render/results.go
@@ -16,7 +16,8 @@ import (
 )
 
 func Results(m *model.Model) string {
-	if m.Results == nil || (len(m.Results.Documents) == 0 && len(m.Results.History) == 0) {
+	documents := m.VisibleDocuments()
+	if m.Results == nil || (len(documents) == 0 && len(m.Results.History) == 0) {
 		m.LineOffsets, m.TotalLines = nil, 0
 		if m.IsSearching {
 			return m.Styles.Gray.Render("  " + m.Spinner.View() + " searching…")
@@ -47,14 +48,14 @@ func Results(m *model.Model) string {
 		histCount++
 	}
 
-	if histCount > 0 && len(m.Results.Documents) > 0 && currentIdx < m.Limit {
+	if histCount > 0 && len(documents) > 0 && currentIdx < m.Limit {
 		div := sectionDivider(m.Styles, w)
 		items = append(items, div)
 		currentLine += lipgloss.Height(div) + 1
 	}
 
 	lastDomain := ""
-	for _, d := range m.Results.Documents {
+	for _, d := range documents {
 		if currentIdx >= m.Limit {
 			break
 		}
@@ -87,10 +88,11 @@ func Results(m *model.Model) string {
 		currentLine += lipgloss.Height(closingDiv) + 1
 	}
 
-	totalItems := len(m.Results.History) + len(m.Results.Documents)
+	totalItems := len(m.Results.History) + len(documents)
 	if totalItems > m.Limit {
 		lineOffsets = append(lineOffsets, currentLine)
-		rem := max(0, int(m.Results.Total)+len(m.Results.History)-m.Limit)
+		totalAvailable := max(int(m.Results.Total)+len(m.Results.History), totalItems)
+		rem := max(0, totalAvailable-m.Limit)
 		var content string
 		if currentIdx == m.SelectedIdx {
 			content = m.Styles.LoadMoreSelected.Render(fmt.Sprintf("[ ▼ Load 10 more (%d remaining) ]", rem))
@@ -163,6 +165,12 @@ func Document(m *model.Model, d *document.Document, sel bool, contentW int) stri
 		domainBadge = m.Styles.DomainLabel.Render("["+shortDomain+"]") + " "
 		domainBadgeW = lipgloss.Width(domainBadge)
 	}
+	labelBadge := ""
+	labelBadgeW := 0
+	if d.Label != "" {
+		labelBadge = m.Styles.SuggTerm.Render("["+truncateLine(d.Label, 18)+"]") + " "
+		labelBadgeW = lipgloss.Width(labelBadge)
+	}
 
 	relTime := relativeTime(d.Updated)
 	timeRendered := m.Styles.Time.Render(relTime)
@@ -171,9 +179,9 @@ func Document(m *model.Model, d *document.Document, sel bool, contentW int) stri
 		timeW = lipgloss.Width(timeRendered) + 1
 	}
 
-	titleMaxW := max(1, contentW-timeW-domainBadgeW)
+	titleMaxW := max(1, contentW-timeW-domainBadgeW-labelBadgeW)
 	titleRendered := ts.Render(truncateLine(strings.Join(strings.Fields(d.Title), " "), titleMaxW))
-	titleLine := domainBadge + rightPad(titleRendered, contentW-timeW-domainBadgeW) +
+	titleLine := labelBadge + domainBadge + rightPad(titleRendered, contentW-timeW-domainBadgeW-labelBadgeW) +
 		strings.Repeat(" ", max(0, timeW-lipgloss.Width(timeRendered))) + timeRendered
 
 	var sb strings.Builder

--- a/cmd/tui/render/tabs.go
+++ b/cmd/tui/render/tabs.go
@@ -13,6 +13,8 @@ import (
 )
 
 func HistoryTab(m *model.Model) string {
+	m.WorkspaceTargets = nil
+	m.WorkspaceSelectionY = 0
 	if m.HistoryLoading {
 		return m.Styles.Gray.Render("  " + m.Spinner.View() + " loading…")
 	}
@@ -39,91 +41,96 @@ func HistoryTab(m *model.Model) string {
 			row = m.Styles.Title.Render(title) + queryPart
 			row = m.Styles.Item.Render(row + "\n" + renderURL(m.Styles, h.URL, "", contentW))
 		}
+		y := lipgloss.Height(strings.Join(lines, "\n\n")) + 1
+		m.WorkspaceTargets = append(m.WorkspaceTargets, model.WorkspaceTarget{
+			Y: y, Height: lipgloss.Height(row), Kind: model.WorkspaceHistoryItem, Index: i,
+		})
+		if i == m.HistoryIdx {
+			m.WorkspaceSelectionY = y
+		}
 		lines = append(lines, row)
 	}
 	return strings.Join(lines, "\n\n")
 }
 
 func RulesTab(m *model.Model) string {
+	m.WorkspaceTargets = nil
+	m.WorkspaceSelectionY = 0
 	if m.RulesLoading {
 		return m.Styles.Gray.Render("  " + m.Spinner.View() + " loading…")
 	}
-	var lines []string
-	lines = append(lines, "")
-
-	aliasKeys := m.SortedAliasKeys()
-
-	type sectionDef struct {
-		header   string
-		items    []string
-		inputIdx int // RulesFormFocus value for this section's input
-		section  int // section number (0/1/2)
+	lines := []string{""}
+	aliasItems := make([]string, 0, len(m.RulesData.Aliases))
+	for _, key := range m.SortedAliasKeys() {
+		aliasItems = append(aliasItems, key+" → "+m.RulesData.Aliases[key])
 	}
-
-	// Build alias display items
-	var aliasItems []string
-	for _, k := range aliasKeys {
-		aliasItems = append(aliasItems, k+" → "+m.RulesData.Aliases[k])
-	}
-
-	sections := []sectionDef{
-		{"Skip Patterns", m.RulesData.Skip, 0, 0},
-		{"Priority Patterns", m.RulesData.Priority, 1, 1},
-		{"Aliases", aliasItems, 2, 2},
-	}
-
-	for _, sec := range sections {
-		// Section header
+	for _, section := range model.RulesSections {
+		items := aliasItems
+		if patterns := m.RulesPatterns(section.ID); patterns != nil {
+			items = *patterns
+		}
 		headerStyle := m.Styles.Title
-		if sec.section == m.RulesSection && m.RulesFormFocus == model.RulesFieldList {
+		if section.ID == m.RulesSection && m.RulesFormFocus == model.RulesFocusList {
 			headerStyle = m.Styles.SelTitle
 		}
-		lines = append(lines, headerStyle.Render("  "+sec.header))
+		lines = append(lines, headerStyle.Render("  "+section.Title))
 
-		// Form input(s) for this section
-		if sec.section == 2 {
-			// Alias: two inputs side by side
+		var form string
+		if section.Aliases {
 			kwStyle := m.Styles.Gray
 			valStyle := m.Styles.Gray
-			if m.RulesFormFocus == model.RulesFieldAliasKey {
+			if m.RulesSection == section.ID && m.RulesFormFocus == model.RulesFocusAliasKey {
 				kwStyle = m.Styles.SelTitle
 			}
-			if m.RulesFormFocus == model.RulesFieldAliasVal {
+			if m.RulesSection == section.ID && m.RulesFormFocus == model.RulesFocusAliasValue {
 				valStyle = m.Styles.SelTitle
 			}
 			btnLabel := " + Add "
-			if m.RulesEditingIdx >= 0 && m.RulesEditingSection == 2 {
+			if m.RulesEditingIdx >= 0 && m.RulesEditingSection == section.ID {
 				btnLabel = " Save "
 			}
-			lines = append(lines, "  "+kwStyle.Render("Keyword:")+" "+m.RulesAliasKeyInput.View()+"  "+valStyle.Render("Value:")+" "+m.RulesAliasValInput.View()+"  "+m.Styles.CancelBtn.Render(btnLabel))
+			form = "  " + kwStyle.Render("Keyword:") + " " + m.RulesAliasKeyInput.View() + "  " + valStyle.Render("Value:") + " " + m.RulesAliasValInput.View() + "  " + m.Styles.CancelBtn.Render(btnLabel)
 		} else {
 			inputStyle := m.Styles.Gray
-			if m.RulesFormFocus == sec.inputIdx {
+			if m.RulesSection == section.ID && m.RulesFormFocus == model.RulesFocusPattern {
 				inputStyle = m.Styles.SelTitle
 			}
-			var inp string
-			if sec.inputIdx == 0 {
-				inp = m.RulesSkipInput.View()
-			} else {
-				inp = m.RulesPriorityInput.View()
-			}
 			btnLabel := " + Add "
-			if m.RulesEditingIdx >= 0 && m.RulesEditingSection == sec.section {
+			if m.RulesEditingIdx >= 0 && m.RulesEditingSection == section.ID {
 				btnLabel = " Save "
 			}
-			lines = append(lines, "  "+inputStyle.Render("Pattern:")+" "+inp+"  "+m.Styles.CancelBtn.Render(btnLabel))
+			form = "  " + inputStyle.Render("Pattern:") + " " + m.RulesPatternInputs[section.ID].View() + "  " + m.Styles.CancelBtn.Render(btnLabel)
 		}
+		formY := lipgloss.Height(strings.Join(lines, "\n"))
+		m.WorkspaceTargets = append(m.WorkspaceTargets, model.WorkspaceTarget{
+			Y: formY, Height: lipgloss.Height(form), Kind: model.WorkspaceRulesForm, Section: section.ID,
+		})
+		if section.ID == m.RulesSection && m.RulesFormFocus != model.RulesFocusList {
+			m.WorkspaceSelectionY = formY
+		}
+		lines = append(lines, form)
 
-		// List items
-		if len(sec.items) == 0 {
+		if len(items) == 0 {
+			if section.ID == m.RulesSection && m.RulesFormFocus == model.RulesFocusList {
+				m.WorkspaceSelectionY = formY
+			}
 			lines = append(lines, m.Styles.Gray.Render("    (none)"))
 		}
-		for i, item := range sec.items {
-			if sec.section == m.RulesSection && i == m.RulesIdx && m.RulesFormFocus == model.RulesFieldList {
-				lines = append(lines, m.Styles.SelectedItem.Render("  ▸ "+item))
+		for i, item := range items {
+			var row string
+			if section.ID == m.RulesSection && i == m.RulesIdx && m.RulesFormFocus == model.RulesFocusList {
+				row = m.Styles.SelectedItem.Render("  ▸ " + item)
 			} else {
-				lines = append(lines, m.Styles.Item.Render("    "+item))
+				row = m.Styles.Item.Render("    " + item)
 			}
+			y := lipgloss.Height(strings.Join(lines, "\n"))
+			m.WorkspaceTargets = append(m.WorkspaceTargets, model.WorkspaceTarget{
+				Y: y, Height: lipgloss.Height(row), Kind: model.WorkspaceRulesItem, Section: section.ID, Index: i,
+			})
+			if section.ID == m.RulesSection && i == m.RulesIdx && m.RulesFormFocus == model.RulesFocusList {
+				m.WorkspaceSelectionY = y
+			}
+			lines = append(lines, row)
 		}
 		lines = append(lines, "")
 	}
@@ -131,25 +138,54 @@ func RulesTab(m *model.Model) string {
 }
 
 func AddTab(m *model.Model) string {
-	var lines []string
-	lines = append(lines, "")
-	lines = append(lines, m.Styles.Title.Render("  Add Document"))
-	lines = append(lines, "")
-	labels := []string{"URL", "Title", "Text"}
-	for i, label := range labels {
+	m.WorkspaceTargets = nil
+	m.WorkspaceSelectionY = 0
+	lines := []string{"", m.Styles.Title.Render("  Add Document"), ""}
+	for i, label := range []string{"URL", "Title"} {
 		style := m.Styles.Gray
 		if i == m.AddFocusIdx {
 			style = m.Styles.SelTitle
 		}
-		lines = append(lines, "  "+style.Render(label+":"))
-		lines = append(lines, "    "+m.AddInputs[i].View())
+		y := lipgloss.Height(strings.Join(lines, "\n"))
+		labelView := "  " + style.Render(label+":")
+		inputView := "    " + m.AddInputs[i].View()
+		m.WorkspaceTargets = append(m.WorkspaceTargets, model.WorkspaceTarget{
+			Y: y, Height: lipgloss.Height(labelView) + lipgloss.Height(inputView), Kind: model.WorkspaceAddField, Index: i,
+		})
+		if i == m.AddFocusIdx {
+			m.WorkspaceSelectionY = y
+		}
+		lines = append(lines, labelView, inputView)
 		lines = append(lines, "")
 	}
+	textStyle := m.Styles.Gray
+	if m.AddFocusIdx == 2 {
+		textStyle = m.Styles.SelTitle
+	}
+	textY := lipgloss.Height(strings.Join(lines, "\n"))
+	textLabel := "  " + textStyle.Render("Text:")
+	textInput := "    " + m.AddText.View()
+	m.WorkspaceTargets = append(m.WorkspaceTargets, model.WorkspaceTarget{
+		Y: textY, Height: lipgloss.Height(textLabel) + lipgloss.Height(textInput), Kind: model.WorkspaceAddField, Index: 2,
+	})
+	if m.AddFocusIdx == 2 {
+		m.WorkspaceSelectionY = textY
+	}
+	lines = append(lines, textLabel, textInput)
+	lines = append(lines, "")
 	submitStyle := m.Styles.CancelBtn
 	if m.AddFocusIdx == 3 {
 		submitStyle = m.Styles.CancelBtnSel
 	}
-	lines = append(lines, "  "+submitStyle.Render(" Submit "))
+	submitY := lipgloss.Height(strings.Join(lines, "\n"))
+	submit := "  " + submitStyle.Render(" Submit ")
+	m.WorkspaceTargets = append(m.WorkspaceTargets, model.WorkspaceTarget{
+		Y: submitY, Height: lipgloss.Height(submit), Kind: model.WorkspaceAddSubmit, Index: model.AddSubmitFieldIdx,
+	})
+	if m.AddFocusIdx == model.AddSubmitFieldIdx {
+		m.WorkspaceSelectionY = submitY
+	}
+	lines = append(lines, submit)
 	if m.AddStatus != "" {
 		lines = append(lines, "")
 		lines = append(lines, "  "+m.Styles.Conn.Render(m.AddStatus))


### PR DESCRIPTION
Centralize workspace geometry, navigation targets, and rules metadata in the model. Rendering and input handlers now share state instead of relying on duplicated fixed-row calculations