### PR TITLE
[enh] open search results in a readable details pane

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -92,6 +92,28 @@ func New(baseURL string, opts ...Option) *Client {
 	return c
 }
 
+// FetchConfig retrieves capabilities from the server the client is connected
+// to. This avoids assuming that local configuration describes a remote server.
+func (c *Client) FetchConfig() (_ *ServerConfig, err error) {
+	req, err := c.newRequest(http.MethodGet, "/api/config", nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer closeBody(resp, &err)
+	if err = checkStatus(resp); err != nil {
+		return nil, err
+	}
+	var serverConfig ServerConfig
+	if err = json.NewDecoder(resp.Body).Decode(&serverConfig); err != nil {
+		return nil, err
+	}
+	return &serverConfig, nil
+}
+
 const legacyMaxBatchBodyBytes int64 = 5 << 20
 
 // MaxBatchBodyBytes returns the server advertised batch request limit. Servers

--- a/client/tui_test.go
+++ b/client/tui_test.go
@@ -32,6 +32,28 @@ func TestFetchPreview(t *testing.T) {
 	}
 }
 
+func TestFetchConfigReadsServerSemanticCapabilities(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/config" || r.Method != http.MethodGet {
+			t.Errorf("request = %s %s", r.Method, r.URL.Path)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"semanticEnabled":     true,
+			"semanticWeight":      0.65,
+			"similarityThreshold": 0.82,
+		})
+	}))
+	defer server.Close()
+
+	serverConfig, err := New(server.URL).FetchConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !serverConfig.SemanticEnabled || serverConfig.SemanticWeight != 0.65 || serverConfig.SimilarityThreshold != 0.82 {
+		t.Fatalf("server config = %#v", serverConfig)
+	}
+}
+
 func TestSaveRulesIncludesVersioning(t *testing.T) {
 	var got url.Values
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/client/types.go
+++ b/client/types.go
@@ -32,3 +32,11 @@ type PreviewResponse struct {
 	VersionCount int            `json:"version_count"`
 	Meta         map[string]any `json:"meta"`
 }
+
+// ServerConfig contains the search capabilities advertised by /api/config
+// that command-line clients need at runtime.
+type ServerConfig struct {
+	SemanticEnabled     bool    `json:"semanticEnabled"`
+	SemanticWeight      float64 `json:"semanticWeight"`
+	SimilarityThreshold float64 `json:"similarityThreshold"`
+}

--- a/cmd/index.go
+++ b/cmd/index.go
@@ -486,8 +486,7 @@ func markPersistentIndexFailure(jobID, rawURL string, err error) {
 		return
 	}
 	errCode := 0
-	var httpErr *client.HTTPError
-	if errors.As(err, &httpErr) {
+	if httpErr, ok := errors.AsType[*client.HTTPError](err); ok {
 		errCode = httpErr.StatusCode
 	}
 	if dbErr := model.MarkCrawlURLFailed(jobID, rawURL, errCode, err.Error()); dbErr != nil {

--- a/cmd/tui/handle/actions.go
+++ b/cmd/tui/handle/actions.go
@@ -46,7 +46,7 @@ func DispatchCommonAction(m *model.Model, action config.Action) (tea.Cmd, bool) 
 		}
 		return startSearch(m, m.FlashHint(config.ActionToggleSort)), true
 	case config.ActionToggleSemantic:
-		if !m.Cfg.SemanticSearch.Enable {
+		if !m.SemanticEnabled {
 			return m.Notify("Semantic search is not enabled on this server"), true
 		}
 		m.SemanticOn = !m.SemanticOn
@@ -143,19 +143,24 @@ func loadDetails(m *model.Model, focusPreview, activate bool) tea.Cmd {
 		return m.Notify("Nothing selected")
 	}
 	title := m.GetSelectedTitle()
+	startSpinner := !m.DetailsLoading
 	m.ResetDetails()
 	m.DetailsURL = u
 	m.DetailsHintTitle = title
 	m.DetailsLoading = true
 	m.DetailsFocused = focusPreview
-	m.Details.SetContent(render.ResultDetailsContent(m))
-	m.Details.GotoTop()
 	if activate && m.State != model.StateDetails {
 		m.OpenOverlay(model.StateDetails)
 	}
 	render.ResizeSearchViewports(m)
+	m.Details.SetContent(render.ResultDetailsContent(m))
+	m.Details.GotoTop()
 	render.RefreshAndScroll(m)
-	return tea.Batch(m.FetchPreviewCmd(u), m.Spinner.Tick)
+	cmds := []tea.Cmd{m.QueuePreviewCmd(u)}
+	if startSpinner {
+		cmds = append(cmds, m.Spinner.Tick)
+	}
+	return tea.Batch(cmds...)
 }
 
 func OpenLabelEditor(m *model.Model) tea.Cmd {
@@ -220,9 +225,9 @@ func SwitchTab(m *model.Model, action config.Action) tea.Cmd {
 		return nil
 	}
 	m.ResetDetails()
+	m.SetBaseState(model.StateResults)
 	m.Workspace.GotoTop()
 	m.TextInput.Blur()
-	m.State = model.StateResults
 	var cmd tea.Cmd
 	switch m.ActiveTab {
 	case model.TabSearch:
@@ -266,8 +271,8 @@ func doSearch(m *model.Model) tea.Cmd {
 		Limit:             m.Limit + 1,
 		Sort:              m.SortMode,
 		SemanticEnabled:   m.SemanticOn,
-		SemanticThreshold: m.Cfg.SemanticSearch.SimilarityThreshold,
-		SemanticWeight:    m.Cfg.SemanticSearch.SemanticWeight,
+		SemanticThreshold: m.SemanticThreshold,
+		SemanticWeight:    m.SemanticWeight,
 	})
 }
 

--- a/cmd/tui/handle/actions.go
+++ b/cmd/tui/handle/actions.go
@@ -5,6 +5,8 @@
 package handle
 
 import (
+	"fmt"
+	"os"
 	"strings"
 
 	"github.com/asciimoo/hister/cmd/tui/model"
@@ -13,6 +15,7 @@ import (
 	"github.com/asciimoo/hister/cmd/tui/theme"
 	"github.com/asciimoo/hister/config"
 
+	osc52 "github.com/aymanbagabas/go-osc52/v2"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/pkg/browser"
 	"github.com/rs/zerolog/log"
@@ -42,13 +45,46 @@ func DispatchCommonAction(m *model.Model, action config.Action) (tea.Cmd, bool) 
 			m.SortMode = ""
 		}
 		return startSearch(m, m.FlashHint(config.ActionToggleSort)), true
+	case config.ActionToggleSemantic:
+		if !m.Cfg.SemanticSearch.Enable {
+			return m.Notify("Semantic search is not enabled on this server"), true
+		}
+		m.SemanticOn = !m.SemanticOn
+		if m.SemanticOn {
+			return startSearch(m, m.Notify("Semantic search on"), m.FlashHint(action)), true
+		}
+		return startSearch(m, m.Notify("Semantic search off"), m.FlashHint(action)), true
 	case config.ActionScrollUp:
+		if m.State == model.StateDetails {
+			if m.DetailsFocused || !render.DetailsSplit(m) {
+				m.Details.ScrollUp(1)
+				return m.FlashHint(action), true
+			}
+			if m.SelectedIdx > 0 {
+				m.SelectedIdx--
+				render.RefreshAndScroll(m)
+				return tea.Batch(ReloadDetails(m), m.FlashHint(action)), true
+			}
+			return nil, true
+		}
 		if m.SelectedIdx > 0 {
 			m.SelectedIdx--
 			render.RefreshAndScroll(m)
 		}
 		return m.FlashHint(config.ActionScrollUp), true
 	case config.ActionScrollDown:
+		if m.State == model.StateDetails {
+			if m.DetailsFocused || !render.DetailsSplit(m) {
+				m.Details.ScrollDown(1)
+				return m.FlashHint(action), true
+			}
+			if m.SelectedIdx < m.GetTotalResults()-1 && m.SelectedIdx+1 != m.Limit {
+				m.SelectedIdx++
+				render.RefreshAndScroll(m)
+				return tea.Batch(ReloadDetails(m), m.FlashHint(action)), true
+			}
+			return nil, true
+		}
 		if m.SelectedIdx < m.GetTotalResults()-1 {
 			m.SelectedIdx++
 			render.RefreshAndScroll(m)
@@ -61,10 +97,78 @@ func DispatchCommonAction(m *model.Model, action config.Action) (tea.Cmd, bool) 
 			})
 		}
 		return m.FlashHint(config.ActionDeleteResult), true
+	case config.ActionCopyResult:
+		return copySelectedURL(m), true
+	case config.ActionTogglePreview:
+		if m.State == model.StateDetails {
+			return CloseDetails(m), true
+		}
+		return OpenDetails(m), true
+	case config.ActionEditLabel:
+		return OpenLabelEditor(m), true
 	case config.ActionTabSearch, config.ActionTabHistory, config.ActionTabRules, config.ActionTabAdd:
 		return SwitchTab(m, action), true
 	}
 	return nil, false
+}
+
+func copySelectedURL(m *model.Model) tea.Cmd {
+	u := m.GetSelectedURL()
+	if m.ActiveTab == model.TabHistory && m.HistoryIdx >= 0 && m.HistoryIdx < len(m.HistoryItems) {
+		u = m.HistoryItems[m.HistoryIdx].URL
+	}
+	if u == "" {
+		return m.Notify("Nothing selected")
+	}
+	copyCmd := func() tea.Msg {
+		fmt.Fprint(os.Stderr, osc52.New(u))
+		return nil
+	}
+	return tea.Batch(copyCmd, m.Notify("URL copied"), m.FlashHint(config.ActionCopyResult))
+}
+
+func OpenDetails(m *model.Model) tea.Cmd {
+	return loadDetails(m, true, true)
+}
+
+// ReloadDetails updates an already-open pane after its result selection
+// changes while retaining result-list focus.
+func ReloadDetails(m *model.Model) tea.Cmd {
+	return loadDetails(m, false, false)
+}
+
+func loadDetails(m *model.Model, focusPreview, activate bool) tea.Cmd {
+	u := m.GetSelectedURL()
+	if u == "" {
+		return m.Notify("Nothing selected")
+	}
+	title := m.GetSelectedTitle()
+	m.ResetDetails()
+	m.DetailsURL = u
+	m.DetailsHintTitle = title
+	m.DetailsLoading = true
+	m.DetailsFocused = focusPreview
+	m.Details.SetContent(render.ResultDetailsContent(m))
+	m.Details.GotoTop()
+	if activate && m.State != model.StateDetails {
+		m.OpenOverlay(model.StateDetails)
+	}
+	render.ResizeSearchViewports(m)
+	render.RefreshAndScroll(m)
+	return tea.Batch(m.FetchPreviewCmd(u), m.Spinner.Tick)
+}
+
+func OpenLabelEditor(m *model.Model) tea.Cmd {
+	doc := m.GetSelectedDocument()
+	if doc == nil {
+		return m.Notify("Labels are available for indexed documents")
+	}
+	m.LabelURL = doc.URL
+	m.LabelInput.SetValue(doc.Label)
+	m.LabelInput.SetCursor(len([]rune(doc.Label)))
+	m.LabelInput.Focus()
+	m.OpenOverlay(model.StateLabelInput)
+	return nil
 }
 
 func ExecuteAction(m *model.Model, action config.Action) tea.Cmd {
@@ -83,6 +187,12 @@ func ExecuteAction(m *model.Model, action config.Action) tea.Cmd {
 		}
 		return m.FlashHint(config.ActionOpenResult)
 	case config.ActionToggleFocus:
+		if m.State == model.StateDetails {
+			if render.DetailsSplit(m) {
+				m.DetailsFocused = !m.DetailsFocused
+			}
+			return m.FlashHint(action)
+		}
 		if m.State == model.StateInput {
 			if m.GetTotalResults() > 0 {
 				m.State = model.StateResults
@@ -109,6 +219,7 @@ func SwitchTab(m *model.Model, action config.Action) tea.Cmd {
 	if m.ActiveTab == prevTab {
 		return nil
 	}
+	m.ResetDetails()
 	m.Workspace.GotoTop()
 	m.TextInput.Blur()
 	m.State = model.StateResults
@@ -150,15 +261,32 @@ func doSearch(m *model.Model) tea.Cmd {
 		}
 	}
 	return network.Search(m.Conn, &m.WsMu, m.WsReady, model.SearchQuery{
-		Text:      strings.TrimSpace(q),
-		Highlight: "tui",
-		Limit:     m.Limit + 1,
-		Sort:      m.SortMode,
+		Text:              strings.TrimSpace(q),
+		Highlight:         "tui",
+		Limit:             m.Limit + 1,
+		Sort:              m.SortMode,
+		SemanticEnabled:   m.SemanticOn,
+		SemanticThreshold: m.Cfg.SemanticSearch.SimilarityThreshold,
+		SemanticWeight:    m.Cfg.SemanticSearch.SemanticWeight,
 	})
 }
 
 func CloseOverlay(m *model.Model) tea.Cmd {
+	if m.State == model.StateDetails {
+		return CloseDetails(m)
+	}
 	m.DismissOverlay()
+	if m.State == model.StateInput {
+		return m.TextInput.Focus()
+	}
+	return nil
+}
+
+func CloseDetails(m *model.Model) tea.Cmd {
+	m.ResetDetails()
+	m.DismissOverlay()
+	render.ResizeSearchViewports(m)
+	render.RefreshAndScroll(m)
 	if m.State == model.StateInput {
 		return m.TextInput.Focus()
 	}

--- a/cmd/tui/handle/mouse/mouse.go
+++ b/cmd/tui/handle/mouse/mouse.go
@@ -24,6 +24,7 @@ type Deps struct {
 	CloseThemePickerWithRevert func(*model.Model) tea.Cmd
 	PreviewTheme               func(*model.Model)
 	ExecuteContextMenuAction   func(*model.Model) tea.Cmd
+	ReloadDetails              func(*model.Model) tea.Cmd
 }
 
 type Handler struct{ Deps }
@@ -117,7 +118,8 @@ func isLeftClick(msg Event) bool {
 func isOverlayState(s model.ViewState) bool {
 	switch s {
 	case model.StateHelp, model.StateDialog, model.StateThemePicker,
-		model.StateSettings, model.StateContextMenu, model.StatePrioritizeInput:
+		model.StateSettings, model.StateContextMenu, model.StatePrioritizeInput,
+		model.StateLabelInput:
 		return true
 	default:
 		return false
@@ -164,7 +166,12 @@ func (h *Handler) Handle(m *model.Model, msg tea.MouseMsg) tea.Cmd {
 	event := newEvent(msg)
 	if m.ScrollbarDragging {
 		if event.Action == actionMotion {
+			oldIdx := m.SelectedIdx
 			scrollToPercent(m, event.Y)
+			if m.State == model.StateDetails && oldIdx != m.SelectedIdx {
+				m.DetailsFocused = false
+				return h.ReloadDetails(m)
+			}
 			return nil
 		}
 		if event.Action == actionRelease {
@@ -176,6 +183,10 @@ func (h *Handler) Handle(m *model.Model, msg tea.MouseMsg) tea.Cmd {
 	if isOverlayState(m.State) {
 		return h.overlay(m, event)
 	}
+	if m.State == model.StateDetails {
+		return h.details(m, event)
+	}
+
 	if m.ActiveTab != model.TabSearch {
 		return h.nonSearchTab(m, event)
 	}
@@ -207,6 +218,97 @@ func (h *Handler) Handle(m *model.Model, msg tea.MouseMsg) tea.Cmd {
 		return scrollbarClick(m, event)
 	}
 	return h.viewportClick(m, event)
+}
+
+func (h *Handler) details(m *model.Model, event Event) tea.Cmd {
+	paneX, paneY, paneW, _ := render.DetailsPaneBounds(m)
+	inPane := event.X >= paneX && event.X < paneX+paneW
+	if delta := wheelDelta(event); delta != 0 {
+		if !vpRegion(m).ContainsY(event.Y) {
+			return nil
+		}
+		if inPane || !render.DetailsSplit(m) {
+			m.DetailsFocused = true
+			if delta < 0 {
+				m.Details.ScrollUp(3)
+			} else {
+				m.Details.ScrollDown(3)
+			}
+			return nil
+		}
+		m.DetailsFocused = false
+		maxIdx := m.GetTotalResults() - 1
+		if maxIdx == m.Limit {
+			maxIdx--
+		}
+		if model.ScrollIdx(&m.SelectedIdx, delta, 0, maxIdx) {
+			render.RefreshAndScroll(m)
+			return h.ReloadDetails(m)
+		}
+		return nil
+	}
+	if event.Action == actionClick && event.Button == tea.MouseButtonRight && render.DetailsSplit(m) && !inPane {
+		oldIdx := m.SelectedIdx
+		cmd := rightClick(m, event)
+		if oldIdx != m.SelectedIdx {
+			m.DetailsFocused = false
+			return tea.Batch(cmd, h.ReloadDetails(m))
+		}
+		return cmd
+	}
+	if !isLeftClick(event) {
+		return nil
+	}
+	if event.Y == model.RowTabBar {
+		return h.tabBar(m, event)
+	}
+	if event.Y == model.RowInput {
+		closeCmd := h.CloseOverlay(m)
+		focusCmd := inputRow(m, event)
+		return tea.Batch(closeCmd, focusCmd)
+	}
+	if event.Y == model.RowHints(m.Height) {
+		return h.hintRegions(m, event)
+	}
+	if inPane {
+		if event.Y == paneY && event.X == paneX+paneW-1 {
+			return h.CloseOverlay(m)
+		}
+		m.DetailsFocused = true
+		return nil
+	}
+	if !render.DetailsSplit(m) {
+		return nil
+	}
+	if m.TotalLines > m.Viewport.Height && m.Viewport.Height > 0 && event.X == paneX-1 {
+		oldIdx := m.SelectedIdx
+		cmd := scrollbarClick(m, event)
+		if oldIdx != m.SelectedIdx {
+			m.DetailsFocused = false
+			return tea.Batch(cmd, h.ReloadDetails(m))
+		}
+		return cmd
+	}
+	return h.detailsResultClick(m, event)
+}
+
+func (h *Handler) detailsResultClick(m *model.Model, event Event) tea.Cmd {
+	vp := vpRegion(m)
+	if !vp.ContainsY(event.Y) || len(m.LineOffsets) == 0 {
+		return nil
+	}
+	contentY := event.Y - vp.Y + m.Viewport.YOffset
+	idx := m.FindResultAtY(contentY)
+	if idx < 0 || idx >= m.GetTotalResults() || idx == m.Limit {
+		return nil
+	}
+	m.DetailsFocused = false
+	if idx == m.SelectedIdx {
+		return nil
+	}
+	m.SelectedIdx = idx
+	render.RefreshAndScroll(m)
+	return h.ReloadDetails(m)
 }
 
 // --- search-tab handlers ---

--- a/cmd/tui/handle/overlays.go
+++ b/cmd/tui/handle/overlays.go
@@ -131,7 +131,7 @@ func ThemePickerKeys(m *model.Model, msg tea.KeyMsg) tea.Cmd {
 		p, _ := theme.ResolvePalette(&m.Cfg.TUI, m.IsDarkBg)
 		m.ApplyTheme(p)
 		render.RefreshViewport(m)
-		m.State = m.PrevState
+		m.DismissOverlay()
 		if m.State == model.StateInput {
 			return m.TextInput.Focus()
 		}
@@ -156,7 +156,7 @@ func SettingsKeys(m *model.Model, msg tea.KeyMsg) tea.Cmd {
 		m.SettingsEditErr = ""
 	case config.ActionToggleFocus:
 		if key == "esc" {
-			m.State = m.PrevState
+			m.DismissOverlay()
 			if m.State == model.StateInput {
 				return m.TextInput.Focus()
 			}
@@ -233,14 +233,14 @@ func ContextMenuKeys(m *model.Model, msg tea.KeyMsg) tea.Cmd {
 		return executeContextMenuAction(m)
 	case config.ActionToggleFocus:
 		if key == "esc" {
-			m.State = m.PrevState
+			m.DismissOverlay()
 		}
 	}
 	return nil
 }
 
 func executeContextMenuAction(m *model.Model) tea.Cmd {
-	m.State = m.PrevState
+	m.DismissOverlay()
 	option, ok := model.MenuOptionAt(m.MenuSelIdx)
 	if !ok {
 		return nil
@@ -271,7 +271,7 @@ func executeContextMenuAction(m *model.Model) tea.Cmd {
 			m.PrioritizeInput.SetValue("")
 			m.PrioritizeInput.Focus()
 			m.PrioritizeBtnIdx = 1
-			m.State = model.StatePrioritizeInput
+			m.OpenOverlay(model.StatePrioritizeInput)
 		}
 	}
 	return nil
@@ -289,18 +289,18 @@ func PrioritizeInputKeys(m *model.Model, msg tea.KeyMsg) tea.Cmd {
 		return nil
 	case key == "esc" || (action == config.ActionToggleFocus && key == "esc"):
 		m.PrioritizeInput.Blur()
-		m.State = m.PrevState
+		m.DismissOverlay()
 		return nil
 	case action == config.ActionOpenResult:
 		if m.PrioritizeBtnIdx == 0 {
 			// Cancel
 			m.PrioritizeInput.Blur()
-			m.State = m.PrevState
+			m.DismissOverlay()
 			return nil
 		}
 		pattern := strings.TrimSpace(m.PrioritizeInput.Value())
 		m.PrioritizeInput.Blur()
-		m.State = m.PrevState
+		m.DismissOverlay()
 		if pattern != "" {
 			return m.PrioritizeRuleCmd(pattern)
 		}

--- a/cmd/tui/handle/overlays.go
+++ b/cmd/tui/handle/overlays.go
@@ -253,6 +253,12 @@ func executeContextMenuAction(m *model.Model) tea.Cmd {
 			}
 			return m.PostHistoryCmd(u)
 		}
+	case model.MenuCopy:
+		return copySelectedURL(m)
+	case model.MenuDetails:
+		return OpenDetails(m)
+	case model.MenuLabel:
+		return OpenLabelEditor(m)
 	case model.MenuDelete:
 		if u := m.GetSelectedURL(); u != "" {
 			m.OpenDeleteDialog("Delete Result", u, -1, func() tea.Cmd {
@@ -302,5 +308,86 @@ func PrioritizeInputKeys(m *model.Model, msg tea.KeyMsg) tea.Cmd {
 	}
 	var cmd tea.Cmd
 	m.PrioritizeInput, cmd = m.PrioritizeInput.Update(msg)
+	return cmd
+}
+
+func DetailsKeys(m *model.Model, msg tea.KeyMsg) tea.Cmd {
+	action := m.Keys.Action(msg)
+	if msg.String() == "esc" || action == config.ActionTogglePreview {
+		return CloseDetails(m)
+	}
+	if action == config.ActionToggleHelp {
+		m.OpenOverlay(model.StateHelp)
+		return m.FlashHint(action)
+	}
+	if _, isTab := model.TabForAction(action); isTab {
+		return SwitchTab(m, action)
+	}
+	if action == config.ActionToggleFocus {
+		if render.DetailsSplit(m) {
+			m.DetailsFocused = !m.DetailsFocused
+		}
+		return m.FlashHint(action)
+	}
+	if !m.DetailsFocused && render.DetailsSplit(m) {
+		switch action {
+		case config.ActionScrollUp:
+			if m.SelectedIdx > 0 {
+				m.SelectedIdx--
+				render.RefreshAndScroll(m)
+				return ReloadDetails(m)
+			}
+			return nil
+		case config.ActionScrollDown:
+			if m.SelectedIdx < m.GetTotalResults()-1 && m.SelectedIdx+1 != m.Limit {
+				m.SelectedIdx++
+				render.RefreshAndScroll(m)
+				return ReloadDetails(m)
+			}
+			return nil
+		}
+	}
+	switch action {
+	case config.ActionCopyResult:
+		return copySelectedURL(m)
+	case config.ActionEditLabel:
+		return OpenLabelEditor(m)
+	case config.ActionOpenResult:
+		if u := m.GetSelectedURL(); u != "" {
+			if err := browser.OpenURL(u); err != nil {
+				log.Warn().Err(err).Msg("failed to open URL in browser")
+			}
+			return m.PostHistoryCmd(u)
+		}
+	case config.ActionScrollUp:
+		m.Details.ScrollUp(1)
+		return nil
+	case config.ActionScrollDown:
+		m.Details.ScrollDown(1)
+		return nil
+	}
+	var cmd tea.Cmd
+	m.Details, cmd = m.Details.Update(msg)
+	return cmd
+}
+
+func LabelInputKeys(m *model.Model, msg tea.KeyMsg) tea.Cmd {
+	action := m.Keys.Action(msg)
+	if msg.Type == tea.KeyRunes && !msg.Alt {
+		action = ""
+	}
+	if msg.String() == "esc" {
+		m.LabelInput.Blur()
+		return CloseOverlay(m)
+	}
+	if action == config.ActionOpenResult || msg.String() == "enter" {
+		label := strings.TrimSpace(m.LabelInput.Value())
+		url := m.LabelURL
+		m.LabelInput.Blur()
+		m.DismissOverlay()
+		return m.UpdateLabelCmd(url, label)
+	}
+	var cmd tea.Cmd
+	m.LabelInput, cmd = m.LabelInput.Update(msg)
 	return cmd
 }

--- a/cmd/tui/handle/tabs.go
+++ b/cmd/tui/handle/tabs.go
@@ -65,6 +65,8 @@ func HistoryKeys(m *model.Model, msg tea.KeyMsg) tea.Cmd {
 			}
 		}
 		return m.FlashHint(config.ActionOpenResult)
+	case config.ActionCopyResult:
+		return copySelectedURL(m)
 	case config.ActionDeleteResult:
 		if m.HistoryIdx >= 0 && m.HistoryIdx < len(m.HistoryItems) {
 			h := m.HistoryItems[m.HistoryIdx]

--- a/cmd/tui/handle/update.go
+++ b/cmd/tui/handle/update.go
@@ -56,9 +56,15 @@ func Update(m *model.Model, msg tea.Msg) tea.Cmd {
 			m.Viewport.SetContent("")
 			m.Ready = true
 			render.ResizeSearchViewports(m)
+			if render.DetailsVisible(m) {
+				m.Details.SetContent(render.ResultDetailsContent(m))
+			}
 			return tea.ClearScreen
 		}
 		render.ResizeSearchViewports(m)
+		if render.DetailsVisible(m) {
+			m.Details.SetContent(render.ResultDetailsContent(m))
+		}
 		render.RefreshAndScroll(m)
 		if changed {
 			return tea.ClearScreen
@@ -83,7 +89,7 @@ func Update(m *model.Model, msg tea.Msg) tea.Cmd {
 			}
 			return ResultsKeys(m, msg)
 		case model.StateHelp:
-			m.State = m.PrevState
+			m.DismissOverlay()
 			if m.State == model.StateInput {
 				return m.TextInput.Focus()
 			}
@@ -141,8 +147,7 @@ func Update(m *model.Model, msg tea.Msg) tea.Cmd {
 			return m.Notify("Could not delete result: " + msg.Err.Error())
 		}
 		m.ResetDetails()
-		m.State = model.StateResults
-		m.PrevState = model.StateResults
+		m.SetBaseState(model.StateResults)
 		render.ResizeSearchViewports(m)
 		render.RefreshAndScroll(m)
 		return tea.Batch(doSearch(m), m.Notify("Result deleted"))
@@ -202,14 +207,35 @@ func Update(m *model.Model, msg tea.Msg) tea.Cmd {
 		render.RefreshAndScroll(m)
 		return network.ListenToWebSocket(m.WsChan, m.WsDone)
 
-	case model.PreviewFetchedMsg:
-		if msg.URL != m.DetailsURL {
+	case model.ServerConfigFetchedMsg:
+		if msg.Err != nil {
+			return m.Notify("Could not load server capabilities: " + msg.Err.Error())
+		}
+		if msg.Config != nil {
+			m.SemanticEnabled = msg.Config.SemanticEnabled
+			m.SemanticThreshold = msg.Config.SimilarityThreshold
+			m.SemanticWeight = msg.Config.SemanticWeight
+			if !m.SemanticEnabled {
+				m.SemanticOn = false
+			}
+		}
+
+	case model.PreviewDebounceMsg:
+		if msg.ID != m.DetailsRequestID || msg.URL != m.DetailsURL {
 			return nil
 		}
-		m.DetailsLoading = false
-		m.DetailsErr = msg.Err
-		m.DetailsPreview = msg.Preview
-		m.Details.SetContent(render.ResultDetailsContent(m))
+		m.DetailsPendingReady = true
+		return m.StartPendingPreviewCmd()
+
+	case model.PreviewFetchedMsg:
+		m.DetailsFetching = false
+		if msg.URL == m.DetailsURL {
+			m.DetailsLoading = false
+			m.DetailsErr = msg.Err
+			m.DetailsPreview = msg.Preview
+			m.Details.SetContent(render.ResultDetailsContent(m))
+		}
+		return m.StartPendingPreviewCmd()
 
 	case model.WsConnectedMsg:
 		if msg.Conn != nil {

--- a/cmd/tui/handle/update.go
+++ b/cmd/tui/handle/update.go
@@ -27,6 +27,7 @@ var mouseHandler = mouse.New(mouse.Deps{
 	CloseThemePickerWithRevert: CloseThemePickerWithRevert,
 	PreviewTheme:               previewTheme,
 	ExecuteContextMenuAction:   executeContextMenuAction,
+	ReloadDetails:              ReloadDetails,
 })
 
 func Update(m *model.Model, msg tea.Msg) tea.Cmd {
@@ -45,6 +46,7 @@ func Update(m *model.Model, msg tea.Msg) tea.Cmd {
 		for i := range m.RulesPatternInputs {
 			m.RulesPatternInputs[i].Width = max(12, min(48, m.Width-24))
 		}
+		m.LabelInput.Width = max(12, min(64, m.Width-16))
 		m.Workspace.Width = max(1, m.Width-1)
 		m.Workspace.Height = max(1, vpH+2)
 		m.Help.Width = max(1, m.Width-4)
@@ -94,13 +96,17 @@ func Update(m *model.Model, msg tea.Msg) tea.Cmd {
 			return SettingsKeys(m, msg)
 		case model.StatePrioritizeInput:
 			return PrioritizeInputKeys(m, msg)
+		case model.StateDetails:
+			return DetailsKeys(m, msg)
+		case model.StateLabelInput:
+			return LabelInputKeys(m, msg)
 		}
 
 	case tea.MouseMsg:
 		return mouseHandler.Handle(m, msg)
 
 	case spinner.TickMsg:
-		if m.IsSearching || m.HistoryLoading || m.RulesLoading {
+		if m.IsSearching || m.HistoryLoading || m.RulesLoading || m.DetailsLoading {
 			var cmd tea.Cmd
 			m.Spinner, cmd = m.Spinner.Update(msg)
 			return cmd
@@ -134,6 +140,7 @@ func Update(m *model.Model, msg tea.Msg) tea.Cmd {
 		if msg.Err != nil {
 			return m.Notify("Could not delete result: " + msg.Err.Error())
 		}
+		m.ResetDetails()
 		m.State = model.StateResults
 		m.PrevState = model.StateResults
 		render.ResizeSearchViewports(m)
@@ -158,6 +165,31 @@ func Update(m *model.Model, msg tea.Msg) tea.Cmd {
 		}
 		return m.Notify("Could not save rules: " + msg.Err.Error())
 
+	case model.LabelSavedMsg:
+		if msg.Err != nil {
+			return m.Notify("Could not update label: " + msg.Err.Error())
+		}
+		if m.Results != nil {
+			for _, doc := range m.Results.Documents {
+				if doc.URL == msg.URL {
+					doc.Label = msg.Label
+				}
+			}
+			for _, hit := range m.Results.SemanticHits {
+				if hit.Document != nil && hit.Document.URL == msg.URL {
+					hit.Document.Label = msg.Label
+				}
+			}
+		}
+		render.RefreshViewport(m)
+		if m.DetailsURL != "" {
+			m.Details.SetContent(render.ResultDetailsContent(m))
+		}
+		if msg.Label == "" {
+			return m.Notify("Label cleared")
+		}
+		return m.Notify("Label saved")
+
 	case model.ResultsMsg:
 		m.IsSearching = false
 		m.Results = msg.Results
@@ -169,6 +201,15 @@ func Update(m *model.Model, msg tea.Msg) tea.Cmd {
 		}
 		render.RefreshAndScroll(m)
 		return network.ListenToWebSocket(m.WsChan, m.WsDone)
+
+	case model.PreviewFetchedMsg:
+		if msg.URL != m.DetailsURL {
+			return nil
+		}
+		m.DetailsLoading = false
+		m.DetailsErr = msg.Err
+		m.DetailsPreview = msg.Preview
+		m.Details.SetContent(render.ResultDetailsContent(m))
 
 	case model.WsConnectedMsg:
 		if msg.Conn != nil {

--- a/cmd/tui/handle/update_test.go
+++ b/cmd/tui/handle/update_test.go
@@ -4,6 +4,7 @@ import (
 	"maps"
 	"testing"
 
+	"github.com/asciimoo/hister/client"
 	"github.com/asciimoo/hister/cmd/tui/model"
 	"github.com/asciimoo/hister/config"
 	"github.com/asciimoo/hister/server/document"
@@ -60,5 +61,87 @@ func TestReloadDetailsPreservesOverlayState(t *testing.T) {
 	}
 	if m.DetailsURL != doc.URL || m.DetailsFocused {
 		t.Fatalf("reload url=%q focused=%v", m.DetailsURL, m.DetailsFocused)
+	}
+}
+
+func TestHelpOverDetailsClosesBackToResults(t *testing.T) {
+	m := handleTestModel(t)
+	doc := &document.Document{URL: "https://example.com/article", Title: "Article"}
+	m.Results = &indexer.Results{Documents: []*document.Document{doc}}
+	m.SelectedIdx = 0
+	m.State = model.StateResults
+
+	_ = OpenDetails(m)
+	m.OpenOverlay(model.StateHelp)
+	_ = CloseOverlay(m)
+	if m.State != model.StateDetails || m.PrevState != model.StateResults {
+		t.Fatalf("help returned to state=%s previous=%s", m.State, m.PrevState)
+	}
+	_ = CloseOverlay(m)
+	if m.State != model.StateResults || m.DetailsURL != "" {
+		t.Fatalf("details close left state=%s url=%q", m.State, m.DetailsURL)
+	}
+}
+
+func TestPreviewRequestsAreDebouncedAndSerialized(t *testing.T) {
+	m := handleTestModel(t)
+	m.DetailsLoading = true
+	m.DetailsURL = "https://example.com/one"
+	_ = m.QueuePreviewCmd(m.DetailsURL)
+	firstID := m.DetailsRequestID
+
+	firstCmd := Update(m, model.PreviewDebounceMsg{URL: m.DetailsURL, ID: firstID})
+	if firstCmd == nil || !m.DetailsFetching {
+		t.Fatal("first debounced preview did not start")
+	}
+
+	m.DetailsURL = "https://example.com/two"
+	_ = m.QueuePreviewCmd(m.DetailsURL)
+	secondID := m.DetailsRequestID
+	m.DetailsURL = "https://example.com/three"
+	_ = m.QueuePreviewCmd(m.DetailsURL)
+	thirdID := m.DetailsRequestID
+
+	if cmd := Update(m, model.PreviewDebounceMsg{URL: "https://example.com/two", ID: secondID}); cmd != nil {
+		t.Fatal("superseded debounce started a request")
+	}
+	if cmd := Update(m, model.PreviewDebounceMsg{URL: m.DetailsURL, ID: thirdID}); cmd != nil {
+		t.Fatal("latest preview started while an earlier request was in flight")
+	}
+	if m.DetailsPendingURL != m.DetailsURL || !m.DetailsPendingReady {
+		t.Fatalf("pending preview = %q ready=%v", m.DetailsPendingURL, m.DetailsPendingReady)
+	}
+
+	nextCmd := Update(m, model.PreviewFetchedMsg{URL: "https://example.com/one"})
+	if nextCmd == nil || !m.DetailsFetching || m.DetailsPendingURL != "" {
+		t.Fatal("latest pending preview did not start after the first request completed")
+	}
+	preview := &client.PreviewResponse{Title: "Latest"}
+	if cmd := Update(m, model.PreviewFetchedMsg{URL: m.DetailsURL, Preview: preview}); cmd != nil {
+		t.Fatal("completed latest preview unexpectedly started another request")
+	}
+	if m.DetailsLoading || m.DetailsFetching || m.DetailsPreview != preview {
+		t.Fatalf("latest preview was not settled: loading=%v fetching=%v preview=%#v", m.DetailsLoading, m.DetailsFetching, m.DetailsPreview)
+	}
+}
+
+func TestSemanticSettingsComeFromServerConfig(t *testing.T) {
+	m := handleTestModel(t)
+	m.Cfg.SemanticSearch.Enable = true
+	m.Cfg.SemanticSearch.SemanticWeight = 0.1
+
+	_, _ = DispatchCommonAction(m, config.ActionToggleSemantic)
+	if m.SemanticOn {
+		t.Fatal("local semantic configuration enabled remote search capability")
+	}
+
+	Update(m, model.ServerConfigFetchedMsg{Config: &client.ServerConfig{
+		SemanticEnabled:     true,
+		SemanticWeight:      0.7,
+		SimilarityThreshold: 0.8,
+	}})
+	_, _ = DispatchCommonAction(m, config.ActionToggleSemantic)
+	if !m.SemanticOn || m.SemanticWeight != 0.7 || m.SemanticThreshold != 0.8 {
+		t.Fatalf("server semantic settings not applied: on=%v weight=%v threshold=%v", m.SemanticOn, m.SemanticWeight, m.SemanticThreshold)
 	}
 }

--- a/cmd/tui/handle/update_test.go
+++ b/cmd/tui/handle/update_test.go
@@ -1,0 +1,64 @@
+package handle
+
+import (
+	"maps"
+	"testing"
+
+	"github.com/asciimoo/hister/cmd/tui/model"
+	"github.com/asciimoo/hister/config"
+	"github.com/asciimoo/hister/server/document"
+	"github.com/asciimoo/hister/server/indexer"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func handleTestModel(t *testing.T) *model.Model {
+	t.Helper()
+	t.Setenv("TERM", "xterm-256color")
+	t.Setenv("TERM_PROGRAM", "")
+	t.Setenv("KITTY_WINDOW_ID", "")
+	t.Setenv("GHOSTTY_RESOURCES_DIR", "")
+	cfg := config.CreateDefaultConfig()
+	cfg.TUI = config.DefaultTUIConfig
+	cfg.Hotkeys.TUI = maps.Clone(config.DefaultTUIHotkeys)
+	m := model.InitialModel(cfg)
+	Update(m, tea.WindowSizeMsg{Width: 120, Height: 30})
+	return m
+}
+
+func TestSuccessfulDeleteClosesPreviewAndClearsTerminalResources(t *testing.T) {
+	m := handleTestModel(t)
+	m.State = model.StateDetails
+	m.PrevState = model.StateResults
+	m.DetailsURL = "https://example.com/article"
+
+	if cmd := Update(m, model.DeleteResultMsg{}); cmd == nil {
+		t.Fatal("successful delete returned no follow-up commands")
+	}
+	if m.State != model.StateResults || m.PrevState != model.StateResults {
+		t.Fatalf("delete left state=%s previous=%s", m.State, m.PrevState)
+	}
+	if m.DetailsURL != "" {
+		t.Fatalf("delete left stale preview url=%q", m.DetailsURL)
+	}
+}
+
+func TestReloadDetailsPreservesOverlayState(t *testing.T) {
+	m := handleTestModel(t)
+	doc := &document.Document{URL: "https://example.com/new", Title: "New result"}
+	m.Results = &indexer.Results{Documents: []*document.Document{doc}}
+	m.SelectedIdx = 0
+	m.DetailsURL = "https://example.com/old"
+	m.State = model.StateContextMenu
+	m.PrevState = model.StateDetails
+
+	if cmd := ReloadDetails(m); cmd == nil {
+		t.Fatal("reload returned no preview command")
+	}
+	if m.State != model.StateContextMenu || m.PrevState != model.StateDetails {
+		t.Fatalf("reload changed overlay state=%s previous=%s", m.State, m.PrevState)
+	}
+	if m.DetailsURL != doc.URL || m.DetailsFocused {
+		t.Fatalf("reload url=%q focused=%v", m.DetailsURL, m.DetailsFocused)
+	}
+}

--- a/cmd/tui/model/model.go
+++ b/cmd/tui/model/model.go
@@ -12,6 +12,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/asciimoo/hister/client"
 	"github.com/asciimoo/hister/cmd/tui/component"
@@ -34,27 +35,32 @@ import (
 
 type Model struct {
 	// Core UI components
-	TextInput textinput.Model
-	Viewport  viewport.Model
-	Spinner   spinner.Model
-	Help      help.Model
-	Keys      component.KeyMap
-	Details   viewport.Model
-	Workspace viewport.Model
-	State     ViewState
-	PrevState ViewState
-	Cfg       *config.Config
-	Client    *client.Client
-	Results   *indexer.Results
+	TextInput    textinput.Model
+	Viewport     viewport.Model
+	Spinner      spinner.Model
+	Help         help.Model
+	Keys         component.KeyMap
+	Details      viewport.Model
+	Workspace    viewport.Model
+	State        ViewState
+	PrevState    ViewState
+	overlayStack []ViewState
+	Cfg          *config.Config
+	Client       *client.Client
+	Results      *indexer.Results
 
 	// Readable preview pane. DetailsURL is also the pane-open flag so modal
 	// dialogs can retain the split view behind them.
-	DetailsURL       string
-	DetailsHintTitle string
-	DetailsPreview   *client.PreviewResponse
-	DetailsErr       error
-	DetailsLoading   bool
-	DetailsFocused   bool
+	DetailsURL          string
+	DetailsHintTitle    string
+	DetailsPreview      *client.PreviewResponse
+	DetailsErr          error
+	DetailsLoading      bool
+	DetailsFocused      bool
+	DetailsRequestID    uint64
+	DetailsPendingURL   string
+	DetailsPendingReady bool
+	DetailsFetching     bool
 
 	// Dimensions and readiness
 	Width, Height int
@@ -75,11 +81,14 @@ type Model struct {
 	WsReady bool
 
 	// Selection and search state
-	SelectedIdx int
-	Limit       int
-	IsSearching bool
-	SortMode    string // "" for relevance, "domain" for domain
-	SemanticOn  bool
+	SelectedIdx       int
+	Limit             int
+	IsSearching       bool
+	SortMode          string // "" for relevance, "domain" for domain
+	SemanticOn        bool
+	SemanticEnabled   bool
+	SemanticThreshold float64
+	SemanticWeight    float64
 
 	// Rendering
 	Styles theme.Styles
@@ -398,7 +407,7 @@ func (m *Model) VisibleDocuments() []*document.Document {
 	for _, doc := range documents {
 		maxKeywordScore = max(maxKeywordScore, doc.Score)
 	}
-	weight := m.Cfg.SemanticSearch.SemanticWeight
+	weight := m.SemanticWeight
 	if weight <= 0 || weight >= 1 {
 		weight = 0.4
 	}
@@ -446,8 +455,7 @@ func (m *Model) RulesSectionLen(section int) int {
 }
 
 func (m *Model) OpenDeleteDialog(title, label string, returnTab int, confirm func() tea.Cmd) {
-	m.OverlayOffX, m.OverlayOffY = 0, 0
-	m.State = StateDialog
+	m.OpenOverlay(StateDialog)
 	m.DialogMsg = title
 	m.DialogURL = label
 	m.DialogBtnIdx = 0
@@ -488,7 +496,25 @@ func (m *Model) OpenThemePicker() {
 func (m *Model) DismissOverlay() {
 	m.IsDragging = false
 	m.OverlayOffX, m.OverlayOffY = 0, 0
-	m.State = m.PrevState
+	if len(m.overlayStack) == 0 {
+		m.State = m.PrevState
+		return
+	}
+	last := len(m.overlayStack) - 1
+	m.State = m.overlayStack[last]
+	m.overlayStack = m.overlayStack[:last]
+	if len(m.overlayStack) > 0 {
+		m.PrevState = m.overlayStack[len(m.overlayStack)-1]
+	} else {
+		m.PrevState = m.State
+	}
+}
+
+// SetBaseState leaves the overlay hierarchy and establishes a new root state.
+func (m *Model) SetBaseState(state ViewState) {
+	m.overlayStack = nil
+	m.State = state
+	m.PrevState = state
 }
 
 // DismissDialog returns to the correct state after closing a dialog.
@@ -496,7 +522,7 @@ func (m *Model) DismissDialog() {
 	m.DismissOverlay()
 	if m.DialogReturnTab >= 0 {
 		m.ActiveTab = m.DialogReturnTab
-		m.State = StateResults
+		m.SetBaseState(StateResults)
 		m.DialogReturnTab = -1
 		return
 	}
@@ -527,6 +553,9 @@ func (m *Model) Close() {
 }
 
 func (m *Model) ResetDetails() []int {
+	m.DetailsRequestID++
+	m.DetailsPendingURL = ""
+	m.DetailsPendingReady = false
 	m.DetailsURL = ""
 	m.DetailsHintTitle = ""
 	m.DetailsPreview = nil
@@ -573,6 +602,7 @@ func ScrollIdx(idx *int, delta, minVal, maxVal int) bool {
 // OpenOverlay sets up common overlay state.
 func (m *Model) OpenOverlay(state ViewState) {
 	m.OverlayOffX, m.OverlayOffY = 0, 0
+	m.overlayStack = append(m.overlayStack, m.State)
 	m.PrevState, m.State = m.State, state
 	m.TextInput.Blur()
 }
@@ -703,6 +733,40 @@ func (m *Model) FetchPreviewCmd(urlStr string) tea.Cmd {
 	return func() tea.Msg {
 		preview, err := m.Client.FetchPreview(urlStr)
 		return PreviewFetchedMsg{URL: urlStr, Preview: preview, Err: err}
+	}
+}
+
+const PreviewDebounceDelay = 120 * time.Millisecond
+
+// QueuePreviewCmd coalesces rapid selection changes before a preview request
+// is allowed to start. Preview requests themselves are run one at a time.
+func (m *Model) QueuePreviewCmd(urlStr string) tea.Cmd {
+	m.DetailsRequestID++
+	id := m.DetailsRequestID
+	m.DetailsPendingURL = urlStr
+	m.DetailsPendingReady = false
+	return tea.Tick(PreviewDebounceDelay, func(_ time.Time) tea.Msg {
+		return PreviewDebounceMsg{URL: urlStr, ID: id}
+	})
+}
+
+// StartPendingPreviewCmd starts the latest debounced request when no earlier
+// preview request is still in flight.
+func (m *Model) StartPendingPreviewCmd() tea.Cmd {
+	if m.DetailsFetching || !m.DetailsPendingReady || m.DetailsPendingURL == "" {
+		return nil
+	}
+	urlStr := m.DetailsPendingURL
+	m.DetailsPendingURL = ""
+	m.DetailsPendingReady = false
+	m.DetailsFetching = true
+	return m.FetchPreviewCmd(urlStr)
+}
+
+func (m *Model) FetchServerConfigCmd() tea.Cmd {
+	return func() tea.Msg {
+		serverConfig, err := m.Client.FetchConfig()
+		return ServerConfigFetchedMsg{Config: serverConfig, Err: err}
 	}
 }
 

--- a/cmd/tui/model/model.go
+++ b/cmd/tui/model/model.go
@@ -9,6 +9,7 @@ import (
 	"math/rand"
 	"os"
 	"slices"
+	"sort"
 	"strings"
 	"sync"
 
@@ -38,12 +39,22 @@ type Model struct {
 	Spinner   spinner.Model
 	Help      help.Model
 	Keys      component.KeyMap
+	Details   viewport.Model
 	Workspace viewport.Model
 	State     ViewState
 	PrevState ViewState
 	Cfg       *config.Config
 	Client    *client.Client
 	Results   *indexer.Results
+
+	// Readable preview pane. DetailsURL is also the pane-open flag so modal
+	// dialogs can retain the split view behind them.
+	DetailsURL       string
+	DetailsHintTitle string
+	DetailsPreview   *client.PreviewResponse
+	DetailsErr       error
+	DetailsLoading   bool
+	DetailsFocused   bool
 
 	// Dimensions and readiness
 	Width, Height int
@@ -68,6 +79,7 @@ type Model struct {
 	Limit       int
 	IsSearching bool
 	SortMode    string // "" for relevance, "domain" for domain
+	SemanticOn  bool
 
 	// Rendering
 	Styles theme.Styles
@@ -160,6 +172,8 @@ type Model struct {
 	PrioritizeURL    string
 	PrioritizeInput  textinput.Model
 	PrioritizeBtnIdx int // 0=Cancel, 1=Confirm
+	LabelInput       textinput.Model
+	LabelURL         string
 
 	// Tips rotation
 	TipIdx int
@@ -222,6 +236,7 @@ func InitialModel(cfg *config.Config) *Model {
 		RulesFormFocus:     RulesFocusList, // start on list
 		RulesEditingIdx:    -1,
 		PrioritizeInput:    newInput("URL pattern...", 500, 40, st),
+		LabelInput:         newInput("Label (empty clears it)", 200, 50, st),
 		TipIdx:             rand.Intn(len(SearchTips)),
 	}
 	for _, section := range RulesSections {
@@ -230,6 +245,7 @@ func InitialModel(cfg *config.Config) *Model {
 		}
 		m.RulesPatternInputs[section.ID] = newInput(section.Placeholder, 200, 40, st)
 	}
+	m.Details = viewport.New(72, 18)
 	m.Workspace = viewport.New(80, 20)
 	if m.ThemePickerMode == "" {
 		m.ThemePickerMode = "auto"
@@ -252,6 +268,7 @@ func (m *Model) ApplyTheme(p theme.Palette) {
 	applyInputStyles(&m.RulesAliasKeyInput, m.Styles)
 	applyInputStyles(&m.RulesAliasValInput, m.Styles)
 	applyInputStyles(&m.PrioritizeInput, m.Styles)
+	applyInputStyles(&m.LabelInput, m.Styles)
 	m.Spinner.Style = m.Styles.Spin
 	applyHelpStyles(&m.Help, m.Styles)
 	m.SetTerminalBg(p.Base00)
@@ -335,11 +352,63 @@ func (m *Model) GetSelectedDocument() *document.Document {
 	return nil
 }
 
+// VisibleDocuments merges keyword and semantic-only results into the order
+// presented by the TUI. It deliberately returns a new slice and never mutates
+// the server response, which keeps selection and re-rendering deterministic.
 func (m *Model) VisibleDocuments() []*document.Document {
 	if m.Results == nil {
 		return nil
 	}
-	return slices.Clone(m.Results.Documents)
+	documents := slices.Clone(m.Results.Documents)
+	if !m.SemanticOn || len(m.Results.SemanticHits) == 0 {
+		return documents
+	}
+
+	seen := make(map[string]bool, len(documents))
+	byID := make(map[string]*document.Document, len(documents))
+	for _, doc := range documents {
+		seen[doc.URL] = true
+		byID[document.GetDocID(doc.UserID, doc.URL)] = doc
+	}
+	semanticScores := make(map[string]float64, len(m.Results.SemanticHits))
+	for _, hit := range m.Results.SemanticHits {
+		if hit.Document != nil {
+			semanticScores[hit.Document.URL] = hit.Similarity
+			if !seen[hit.Document.URL] {
+				documents = append(documents, hit.Document)
+				seen[hit.Document.URL] = true
+				byID[document.GetDocID(hit.Document.UserID, hit.Document.URL)] = hit.Document
+			}
+		}
+		if doc := byID[hit.DocID]; doc != nil {
+			semanticScores[doc.URL] = hit.Similarity
+		}
+	}
+	if m.SortMode == "domain" {
+		sort.SliceStable(documents, func(i, j int) bool {
+			if documents[i].Domain == documents[j].Domain {
+				return documents[i].Score > documents[j].Score
+			}
+			return documents[i].Domain < documents[j].Domain
+		})
+		return documents
+	}
+
+	maxKeywordScore := 1.0
+	for _, doc := range documents {
+		maxKeywordScore = max(maxKeywordScore, doc.Score)
+	}
+	weight := m.Cfg.SemanticSearch.SemanticWeight
+	if weight <= 0 || weight >= 1 {
+		weight = 0.4
+	}
+	combinedScore := func(doc *document.Document) float64 {
+		return (1-weight)*(doc.Score/maxKeywordScore) + weight*semanticScores[doc.URL]
+	}
+	sort.SliceStable(documents, func(i, j int) bool {
+		return combinedScore(documents[i]) > combinedScore(documents[j])
+	})
+	return documents
 }
 
 func (m *Model) SortedSettingsItems() []SettingsItem {
@@ -431,7 +500,11 @@ func (m *Model) DismissDialog() {
 		m.DialogReturnTab = -1
 		return
 	}
-	m.State = StateResults
+	if m.DetailsURL != "" {
+		m.State = StateDetails
+	} else {
+		m.State = StateResults
+	}
 }
 
 func (m *Model) OpenContextMenu(idx, x, y, offX, offY int) {
@@ -451,6 +524,18 @@ func (m *Model) StartDrag(x, y int) {
 func (m *Model) Close() {
 	m.ResetTerminalBg()
 	close(m.WsDone)
+}
+
+func (m *Model) ResetDetails() []int {
+	m.DetailsURL = ""
+	m.DetailsHintTitle = ""
+	m.DetailsPreview = nil
+	m.DetailsErr = nil
+	m.DetailsLoading = false
+	m.DetailsFocused = false
+	m.Details.SetContent("")
+	m.Details.GotoTop()
+	return nil
 }
 
 func (m *Model) FocusedRulesInput() *textinput.Model {
@@ -605,6 +690,19 @@ func (m *Model) DeleteHistoryEntryCmd(query, url string) tea.Cmd {
 		}
 		items, err := m.Client.FetchHistory()
 		return HistoryFetchedMsg{Items: items, Err: err}
+	}
+}
+
+func (m *Model) UpdateLabelCmd(url, label string) tea.Cmd {
+	return func() tea.Msg {
+		return LabelSavedMsg{URL: url, Label: label, Err: m.Client.UpdateLabel(url, label)}
+	}
+}
+
+func (m *Model) FetchPreviewCmd(urlStr string) tea.Cmd {
+	return func() tea.Msg {
+		preview, err := m.Client.FetchPreview(urlStr)
+		return PreviewFetchedMsg{URL: urlStr, Preview: preview, Err: err}
 	}
 }
 

--- a/cmd/tui/model/model_test.go
+++ b/cmd/tui/model/model_test.go
@@ -1,0 +1,125 @@
+package model
+
+import (
+	"maps"
+	"testing"
+
+	"github.com/asciimoo/hister/config"
+	"github.com/asciimoo/hister/server/document"
+	"github.com/asciimoo/hister/server/indexer"
+	smodel "github.com/asciimoo/hister/server/model"
+)
+
+func testConfig() *config.Config {
+	cfg := config.CreateDefaultConfig()
+	cfg.TUI = config.DefaultTUIConfig
+	cfg.Hotkeys.TUI = maps.Clone(config.DefaultTUIHotkeys)
+	cfg.SemanticSearch.Enable = true
+	cfg.SemanticSearch.SemanticWeight = 0.4
+	return cfg
+}
+
+func TestVisibleDocumentsMergesAndRanksSemanticResults(t *testing.T) {
+	keywordOne := &document.Document{URL: "https://one.test", Domain: "one.test", Score: 10}
+	keywordTwo := &document.Document{UserID: 42, URL: "https://two.test", Domain: "two.test", Score: 5}
+	semanticOnly := &document.Document{URL: "https://three.test", Domain: "three.test"}
+	m := InitialModel(testConfig())
+	m.SemanticOn = true
+	m.Results = &indexer.Results{
+		History:   []*smodel.URLCount{{URL: "https://history.test"}},
+		Documents: []*document.Document{keywordOne, keywordTwo},
+		SemanticHits: []indexer.SemanticHit{
+			{DocID: document.GetDocID(keywordTwo.UserID, keywordTwo.URL), Similarity: 0.9},
+			{DocID: semanticOnly.URL, Similarity: 0.8, Document: semanticOnly},
+		},
+	}
+
+	got := m.VisibleDocuments()
+	want := []*document.Document{keywordTwo, keywordOne, semanticOnly}
+	if len(got) != len(want) {
+		t.Fatalf("VisibleDocuments length = %d, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("VisibleDocuments[%d] = %q, want %q", i, got[i].URL, want[i].URL)
+		}
+	}
+	if m.GetTotalResults() != 4 {
+		t.Fatalf("GetTotalResults() = %d, want 4", m.GetTotalResults())
+	}
+	m.SelectedIdx = 3
+	if got := m.GetSelectedDocument(); got != semanticOnly {
+		t.Fatalf("GetSelectedDocument() = %#v, want semantic-only document", got)
+	}
+}
+
+func TestNavigationDefinitionsAreSelfConsistent(t *testing.T) {
+	tabIDs := make(map[int]bool, len(Tabs))
+	tabActions := make(map[config.Action]bool, len(Tabs))
+	for _, tab := range Tabs {
+		if tab.Name == "" || tabIDs[tab.ID] || tabActions[tab.Action] {
+			t.Fatalf("invalid or duplicate tab definition: %#v", tab)
+		}
+		tabIDs[tab.ID] = true
+		tabActions[tab.Action] = true
+		if got, ok := TabForAction(tab.Action); !ok || got != tab.ID {
+			t.Fatalf("TabForAction(%q) = %d, %v; want %d, true", tab.Action, got, ok, tab.ID)
+		}
+	}
+
+	for i, option := range MenuOptions {
+		got, ok := MenuOptionAt(i)
+		if !ok || got != option || option.Label == "" {
+			t.Fatalf("MenuOptionAt(%d) = %#v, %v; want %#v, true", i, got, ok, option)
+		}
+	}
+	if _, ok := MenuOptionAt(-1); ok {
+		t.Fatal("MenuOptionAt(-1) unexpectedly succeeded")
+	}
+	if _, ok := MenuOptionAt(len(MenuOptions)); ok {
+		t.Fatal("MenuOptionAt(len(MenuOptions)) unexpectedly succeeded")
+	}
+}
+
+func TestRulesSectionDefinitionsInitializePatternInputs(t *testing.T) {
+	m := InitialModel(testConfig())
+	for _, section := range RulesSections {
+		if section.Aliases {
+			if m.RulesPatterns(section.ID) != nil {
+				t.Fatalf("alias section %d exposes pattern storage", section.ID)
+			}
+			continue
+		}
+		if section.ID < 0 || section.ID >= len(m.RulesPatternInputs) {
+			t.Fatalf("pattern section id %d is outside input storage", section.ID)
+		}
+		if got := m.RulesPatternInputs[section.ID].Placeholder; got != section.Placeholder {
+			t.Fatalf("section %d placeholder = %q, want %q", section.ID, got, section.Placeholder)
+		}
+		if m.RulesPatterns(section.ID) == nil {
+			t.Fatalf("pattern section %d has no data storage", section.ID)
+		}
+	}
+}
+
+func TestRulesPatternsIncludesVersioning(t *testing.T) {
+	m := InitialModel(testConfig())
+	*m.RulesPatterns(RulesSectionVersioning) = append(*m.RulesPatterns(RulesSectionVersioning), "example.com/*")
+	if got := m.RulesData.Versioning; len(got) != 1 || got[0] != "example.com/*" {
+		t.Fatalf("versioning patterns = %#v", got)
+	}
+}
+
+func TestDismissDialogReturnsToOpenDetailsPane(t *testing.T) {
+	m := InitialModel(testConfig())
+	m.State = StateDialog
+	m.PrevState = StateDetails
+	m.DetailsURL = "https://example.com/article"
+	m.DialogReturnTab = -1
+
+	m.DismissDialog()
+
+	if m.State != StateDetails {
+		t.Fatalf("dialog returned to %s, want details", m.State)
+	}
+}

--- a/cmd/tui/model/model_test.go
+++ b/cmd/tui/model/model_test.go
@@ -25,6 +25,7 @@ func TestVisibleDocumentsMergesAndRanksSemanticResults(t *testing.T) {
 	semanticOnly := &document.Document{URL: "https://three.test", Domain: "three.test"}
 	m := InitialModel(testConfig())
 	m.SemanticOn = true
+	m.SemanticWeight = 0.4
 	m.Results = &indexer.Results{
 		History:   []*smodel.URLCount{{URL: "https://history.test"}},
 		Documents: []*document.Document{keywordOne, keywordTwo},
@@ -121,5 +122,21 @@ func TestDismissDialogReturnsToOpenDetailsPane(t *testing.T) {
 
 	if m.State != StateDetails {
 		t.Fatalf("dialog returned to %s, want details", m.State)
+	}
+}
+
+func TestNestedOverlayRestoresEachReturnState(t *testing.T) {
+	m := InitialModel(testConfig())
+	m.State = StateResults
+	m.OpenOverlay(StateDetails)
+	m.OpenOverlay(StateHelp)
+
+	m.DismissOverlay()
+	if m.State != StateDetails || m.PrevState != StateResults {
+		t.Fatalf("help returned to state=%s previous=%s, want details/results", m.State, m.PrevState)
+	}
+	m.DismissOverlay()
+	if m.State != StateResults || m.PrevState != StateResults {
+		t.Fatalf("details returned to state=%s previous=%s, want results/results", m.State, m.PrevState)
 	}
 }

--- a/cmd/tui/model/types.go
+++ b/cmd/tui/model/types.go
@@ -49,11 +49,19 @@ type SearchQuery struct {
 
 // Message types for bubbletea
 type (
-	ResultsMsg          struct{ Results *indexer.Results }
-	ErrMsg              struct{ Err error }
-	WsConnectedMsg      struct{ Conn *websocket.Conn }
-	WsDisconnectedMsg   struct{ Err error }
-	ReconnectMsg        struct{}
+	ResultsMsg             struct{ Results *indexer.Results }
+	ErrMsg                 struct{ Err error }
+	WsConnectedMsg         struct{ Conn *websocket.Conn }
+	WsDisconnectedMsg      struct{ Err error }
+	ReconnectMsg           struct{}
+	ServerConfigFetchedMsg struct {
+		Config *client.ServerConfig
+		Err    error
+	}
+	PreviewDebounceMsg struct {
+		URL string
+		ID  uint64
+	}
 	HintClearMsg        struct{}
 	SettingsErrClearMsg struct{}
 	NoticeClearMsg      struct{ ID uint64 }

--- a/cmd/tui/model/types.go
+++ b/cmd/tui/model/types.go
@@ -28,18 +28,23 @@ const (
 	StateContextMenu
 	StateSettings
 	StatePrioritizeInput
+	StateDetails
+	StateLabelInput
 )
 
 func (s ViewState) String() string {
-	return []string{"INPUT", "RESULTS", "DIALOG", "HELP", "THEME_PICKER", "CONTEXT_MENU", "SETTINGS", "PRIORITIZE_INPUT"}[s]
+	return []string{"INPUT", "RESULTS", "DIALOG", "HELP", "THEME_PICKER", "CONTEXT_MENU", "SETTINGS", "PRIORITIZE_INPUT", "DETAILS", "LABEL_INPUT"}[s]
 }
 
 // sent over WebSocket to the search server
 type SearchQuery struct {
-	Text      string `json:"text"`
-	Highlight string `json:"highlight"`
-	Limit     int    `json:"limit"`
-	Sort      string `json:"sort,omitempty"`
+	Text              string  `json:"text"`
+	Highlight         string  `json:"highlight"`
+	Limit             int     `json:"limit"`
+	Sort              string  `json:"sort,omitempty"`
+	SemanticEnabled   bool    `json:"semantic_enabled,omitempty"`
+	SemanticThreshold float64 `json:"semantic_threshold,omitempty"`
+	SemanticWeight    float64 `json:"semantic_weight,omitempty"`
 }
 
 // Message types for bubbletea
@@ -63,6 +68,16 @@ type (
 	AddResultMsg    struct{ Err error }
 	RulesSavedMsg   struct{ Err error }
 	DeleteResultMsg struct{ Err error }
+	LabelSavedMsg   struct {
+		URL   string
+		Label string
+		Err   error
+	}
+	PreviewFetchedMsg struct {
+		URL     string
+		Preview *client.PreviewResponse
+		Err     error
+	}
 )
 
 type HistoryItem = client.HistoryItem
@@ -189,7 +204,19 @@ func RowVPEnd(height int) int { return height - 3 }
 const FixedLayoutRows = 6
 
 const (
+	// DetailsSplitMinWidth is the smallest terminal that can show useful
+	// result and preview columns side by side. Narrower terminals use the same
+	// preview pane full-width.
+	DetailsSplitMinWidth = 88
+	DetailsPaneMinWidth  = 38
+	DetailsPaneMaxWidth  = 68
+)
+
+const (
 	MenuOpen int = iota
+	MenuCopy
+	MenuDetails
+	MenuLabel
 	MenuPrioritize
 	MenuDelete
 )
@@ -201,6 +228,9 @@ type MenuOptionDefinition struct {
 
 var MenuOptions = []MenuOptionDefinition{
 	{ID: MenuOpen, Label: "Open"},
+	{ID: MenuCopy, Label: "Copy URL"},
+	{ID: MenuDetails, Label: "Details"},
+	{ID: MenuLabel, Label: "Edit label"},
 	{ID: MenuPrioritize, Label: "Prioritize"},
 	{ID: MenuDelete, Label: "Delete"},
 }
@@ -234,6 +264,7 @@ var SearchTips = []string{
 	"Tip: Press Tab to focus results",
 	"Tip: Press Ctrl+D to delete a result",
 	"Tip: Sort by domain with Ctrl+O",
+	"Tip: Toggle semantic search with Ctrl+E",
 	"Tip: Press Ctrl+T to change theme",
 	"Tip: Press Ctrl+S to edit keybindings",
 	"Tip: Press F1 for help",

--- a/cmd/tui/network/network.go
+++ b/cmd/tui/network/network.go
@@ -69,7 +69,7 @@ func ConnectWebSocket(wsURL, origin, token string, wsChan chan tea.Msg, wsDone c
 					if err := json.Unmarshal(data, &res); err != nil {
 						continue
 					}
-					if len(res.Documents) == 0 && len(res.History) == 0 {
+					if len(res.Documents) == 0 && len(res.History) == 0 && len(res.SemanticHits) == 0 {
 						res = &indexer.Results{}
 					}
 					select {

--- a/cmd/tui/render/layout.go
+++ b/cmd/tui/render/layout.go
@@ -28,6 +28,7 @@ var overlayDefs = map[model.ViewState]overlayDef{
 	model.StateSettings:        {func(m *model.Model) string { return Settings(m) }, func(m *model.Model) lipgloss.Color { return m.Styles.HelpBorder }, nil},
 	model.StateContextMenu:     {func(m *model.Model) string { return ContextMenu(m) }, func(m *model.Model) lipgloss.Color { return m.Styles.DialogBorder }, MenuOverlayOffset},
 	model.StatePrioritizeInput: {func(m *model.Model) string { return PrioritizeInput(m) }, func(m *model.Model) lipgloss.Color { return m.Styles.DialogBorder }, nil},
+	model.StateLabelInput:      {LabelInput, func(m *model.Model) lipgloss.Color { return m.Styles.ThemeBorder }, nil},
 }
 
 func View(m *model.Model) string {
@@ -90,17 +91,71 @@ func MainView(m *model.Model) string {
 	return strings.Join([]string{header, div, inputLine, div, body, div, hints}, "\n")
 }
 
+// DetailsVisible reports whether the Search workspace has a readable preview
+// open. It is intentionally independent of State so a label/dialog overlay can
+// retain the split pane behind it.
+func DetailsVisible(m *model.Model) bool {
+	return m.ActiveTab == model.TabSearch && m.DetailsURL != ""
+}
+
+func DetailsSplit(m *model.Model) bool {
+	return DetailsVisible(m) && m.Width >= model.DetailsSplitMinWidth
+}
+
+func DetailsPaneWidth(m *model.Model) int {
+	w := max(1, m.Width-1)
+	if !DetailsSplit(m) {
+		return w
+	}
+	return min(model.DetailsPaneMaxWidth, max(model.DetailsPaneMinWidth, w*46/100))
+}
+
+// ResizeSearchViewports applies the same geometry that SearchBody renders.
+// Keeping this calculation in one place prevents wrapping, scrollbar, and
+// pointer hitboxes from disagreeing when the details pane opens or closes.
 func ResizeSearchViewports(m *model.Model) {
 	w := max(1, m.Width-1)
 	bodyH := max(1, m.Height-model.FixedLayoutRows)
-	m.Viewport.Width = max(1, w-2)
+	leftW := w
+	if DetailsSplit(m) {
+		leftW -= DetailsPaneWidth(m)
+	}
+	m.Viewport.Width = max(1, leftW-2)
 	m.Viewport.Height = bodyH
+
+	if DetailsVisible(m) {
+		m.Details.Width = max(1, DetailsPaneWidth(m)-2)
+		m.Details.Height = max(1, bodyH-2)
+	}
+}
+
+// DetailsPaneBounds returns the screen-space pane body used by mouse hit
+// testing. Y begins below the search input and its divider.
+func DetailsPaneBounds(m *model.Model) (x, y, width, height int) {
+	width = DetailsPaneWidth(m)
+	x = 0
+	if DetailsSplit(m) {
+		x = max(0, m.Width-1-width)
+	}
+	return x, model.RowVPStart, width, max(1, m.Height-model.FixedLayoutRows)
 }
 
 func SearchBody(m *model.Model) string {
 	w := max(1, m.Width-1)
 	bodyH := max(1, m.Height-model.FixedLayoutRows)
-	return resultsViewport(m, w, bodyH)
+	if DetailsVisible(m) && !DetailsSplit(m) {
+		return DetailsPane(m, w, bodyH)
+	}
+
+	leftW := w
+	if DetailsSplit(m) {
+		leftW -= DetailsPaneWidth(m)
+	}
+	results := resultsViewport(m, leftW, bodyH)
+	if !DetailsSplit(m) {
+		return results
+	}
+	return lipgloss.JoinHorizontal(lipgloss.Top, results, DetailsPane(m, DetailsPaneWidth(m), bodyH))
 }
 
 func resultsViewport(m *model.Model, width, height int) string {
@@ -109,6 +164,32 @@ func resultsViewport(m *model.Model, width, height int) string {
 		content = lipgloss.JoinHorizontal(lipgloss.Top, content, " ", Scrollbar(m))
 	}
 	return normalizeBlock(content, width, height)
+}
+
+func DetailsPane(m *model.Model, width, height int) string {
+	innerW := max(1, width-2)
+	headerStyle := m.Styles.Gray
+	if m.DetailsFocused || !DetailsSplit(m) {
+		headerStyle = m.Styles.HelpHeader
+	}
+	title := headerStyle.Render("Preview")
+	if m.DetailsLoading {
+		title += " " + m.Styles.Spin.Render(m.Spinner.View())
+	}
+	closeButton := m.Styles.HintKey.Render("×")
+	header := truncateAnsi(title, max(1, innerW-2))
+	header = rightPad(header, max(1, innerW-lipgloss.Width(closeButton))) + closeButton
+	divider := m.Styles.Div.Render(strings.Repeat("─", innerW))
+	body := normalizeBlock(m.Details.View(), innerW, max(1, height-2))
+	content := strings.Join([]string{header, divider, body}, "\n")
+	content = normalizeBlock(content, innerW, height)
+
+	prefix := m.Styles.Div.Render("│") + " "
+	lines := strings.Split(content, "\n")
+	for i := range lines {
+		lines[i] = prefix + lines[i]
+	}
+	return strings.Join(lines, "\n")
 }
 
 func normalizeBlock(content string, width, height int) string {
@@ -164,6 +245,9 @@ func Header(m *model.Model) string {
 	if m.SortMode == "domain" {
 		appendMode("[domain]", "D")
 	}
+	if m.SemanticOn {
+		appendMode("[semantic]", "S")
+	}
 
 	cs := m.Styles.Disc.Render("● disconnected")
 	if m.WsReady {
@@ -200,6 +284,9 @@ func Header(m *model.Model) string {
 }
 
 func keyContext(m *model.Model) component.KeyContext {
+	if m.State == model.StateDetails {
+		return component.ContextDetails
+	}
 	switch m.ActiveTab {
 	case model.TabHistory:
 		return component.ContextHistory

--- a/cmd/tui/render/overlays.go
+++ b/cmd/tui/render/overlays.go
@@ -225,6 +225,19 @@ func PrioritizeInput(m *model.Model) string {
 	return m.Styles.Dialog.Render(strings.Join(lines, "\n"))
 }
 
+func LabelInput(m *model.Model) string {
+	lines := []string{
+		m.Styles.Title.Render("Edit label"),
+		"",
+		m.Styles.URL.Render(truncateLine(m.LabelURL, max(20, m.LabelInput.Width))),
+		"",
+		m.LabelInput.View(),
+		"",
+		m.Styles.Hint.Render("↵ save  ⎋ cancel  empty label clears it"),
+	}
+	return m.Styles.Dialog.Render(strings.Join(lines, "\n"))
+}
+
 func renderSwatch(p theme.Palette) string {
 	colors := []string{p.Base01, p.Base08, p.Base09, p.Base0A, p.Base0B, p.Base0C, p.Base0D, p.Base0E}
 	var sb strings.Builder

--- a/cmd/tui/render/preview.go
+++ b/cmd/tui/render/preview.go
@@ -1,0 +1,191 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package render
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	readabilityrender "codeberg.org/readeck/go-readability/v2/render"
+	"golang.org/x/net/html"
+
+	"github.com/asciimoo/hister/cmd/tui/model"
+	"github.com/asciimoo/hister/server/document"
+)
+
+func ResultDetailsContent(m *model.Model) string {
+	url := m.DetailsURL
+	if url == "" {
+		url = m.GetSelectedURL()
+	}
+	title := m.DetailsHintTitle
+	if m.DetailsPreview != nil && m.DetailsPreview.Title != "" {
+		title = m.DetailsPreview.Title
+	}
+	if title == "" {
+		title = url
+	}
+	title = sanitizeTerminalText(title)
+	url = sanitizeTerminalText(url)
+	lines := []string{m.Styles.Title.Render(title), m.Styles.URL.Render(url)}
+
+	doc := detailsDocument(m, url)
+	meta := map[string]any(nil)
+	if m.DetailsPreview != nil {
+		meta = m.DetailsPreview.Meta
+	}
+	facts := previewFacts(m, doc, meta)
+	if len(facts) > 0 {
+		lines = append(lines, "", m.Styles.Gray.Render(sanitizeTerminalText(strings.Join(facts, "  ·  "))))
+	}
+	if doc != nil && doc.Label != "" {
+		lines = append(lines, m.Styles.SuggTerm.Render(sanitizeTerminalText("label: "+doc.Label)))
+	}
+	if description := metaString(meta, "description"); description != "" {
+		lines = append(lines, "", m.Styles.SecText.UnsetItalic().Render(sanitizeTerminalText(description)))
+	}
+
+	lines = append(lines, "", m.Styles.HelpHeader.Render("Content"), "")
+	content := ""
+	switch {
+	case m.DetailsLoading:
+		content = "Loading readable preview…"
+	case m.DetailsErr != nil:
+		content = "Readable preview unavailable: " + m.DetailsErr.Error()
+		if doc != nil && strings.TrimSpace(doc.Text) != "" {
+			content += "\n\n" + strings.TrimSpace(doc.Text)
+		}
+	case m.DetailsPreview != nil:
+		content = previewPlainText(m.DetailsPreview.Template, m.DetailsPreview.Content)
+	case doc != nil:
+		content = strings.TrimSpace(doc.Text)
+	}
+	if content == "" {
+		content = "No readable content is available for this result."
+	}
+	content = sanitizeTerminalText(content)
+	lines = append(lines, m.Styles.SecText.UnsetItalic().UnsetFaint().Render(content))
+	return strings.Join(lines, "\n")
+}
+
+func detailsDocument(m *model.Model, url string) *document.Document {
+	for _, doc := range m.VisibleDocuments() {
+		if doc != nil && doc.URL == url {
+			return doc
+		}
+	}
+	return nil
+}
+
+func previewFacts(m *model.Model, doc *document.Document, meta map[string]any) []string {
+	var facts []string
+	for _, key := range []string{"author", "published", "type", "site_name"} {
+		if value := metaString(meta, key); value != "" {
+			if key == "published" {
+				value = formatPreviewDate(value)
+			}
+			facts = append(facts, value)
+		}
+	}
+	if len(facts) == 0 && doc != nil {
+		if doc.Domain != "" {
+			facts = append(facts, doc.Domain)
+		}
+		if doc.Language != "" {
+			facts = append(facts, "language "+doc.Language)
+		}
+		facts = append(facts, fmt.Sprintf("type %v", doc.Type))
+	}
+	added := int64(0)
+	versionCount := 0
+	if m.DetailsPreview != nil {
+		added = m.DetailsPreview.Added
+		versionCount = m.DetailsPreview.VersionCount
+	} else if doc != nil {
+		added = doc.Added
+	}
+	if age := relativeTime(added); age != "" {
+		facts = append(facts, "indexed "+age+" ago")
+	}
+	if versionCount > 0 {
+		facts = append(facts, fmt.Sprintf("%d previous version(s)", versionCount))
+	}
+	return facts
+}
+
+func metaString(meta map[string]any, key string) string {
+	value, _ := meta[key].(string)
+	return strings.TrimSpace(value)
+}
+
+func formatPreviewDate(raw string) string {
+	if parsed, err := time.Parse(time.RFC3339, raw); err == nil {
+		return parsed.Format("2 Jan 2006")
+	}
+	return raw
+}
+
+func previewPlainText(template, content string) string {
+	if template == "video" {
+		return videoPreviewText(content)
+	}
+	if !strings.Contains(content, "<") {
+		return strings.TrimSpace(content)
+	}
+	return htmlPreviewText(content)
+}
+
+func videoPreviewText(content string) string {
+	var video struct {
+		Uploader          string `json:"uploader"`
+		DurationFormatted string `json:"durationFormatted"`
+		UploadDate        string `json:"uploadDate"`
+		ViewCount         int64  `json:"viewCount"`
+		Description       string `json:"description"`
+		Transcript        string `json:"transcript"`
+		Chapters          []struct {
+			Title     string `json:"title"`
+			StartTime string `json:"startTime"`
+		} `json:"chapters"`
+	}
+	if err := json.Unmarshal([]byte(content), &video); err != nil {
+		return strings.TrimSpace(content)
+	}
+	var sections []string
+	var facts []string
+	for _, value := range []string{video.Uploader, video.UploadDate, video.DurationFormatted} {
+		if value != "" {
+			facts = append(facts, value)
+		}
+	}
+	if video.ViewCount > 0 {
+		facts = append(facts, fmt.Sprintf("%d views", video.ViewCount))
+	}
+	if len(facts) > 0 {
+		sections = append(sections, strings.Join(facts, " · "))
+	}
+	if video.Description != "" {
+		sections = append(sections, video.Description)
+	}
+	if len(video.Chapters) > 0 {
+		chapters := []string{"Chapters"}
+		for _, chapter := range video.Chapters {
+			chapters = append(chapters, chapter.StartTime+"  "+chapter.Title)
+		}
+		sections = append(sections, strings.Join(chapters, "\n"))
+	}
+	if video.Transcript != "" {
+		sections = append(sections, "Transcript\n"+video.Transcript)
+	}
+	return strings.Join(sections, "\n\n")
+}
+
+func htmlPreviewText(content string) string {
+	doc, err := html.Parse(strings.NewReader(content))
+	if err != nil {
+		return strings.TrimSpace(content)
+	}
+	return strings.TrimSpace(readabilityrender.InnerText(doc))
+}

--- a/cmd/tui/render/preview.go
+++ b/cmd/tui/render/preview.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	readabilityrender "codeberg.org/readeck/go-readability/v2/render"
+	"github.com/charmbracelet/x/ansi"
 	"golang.org/x/net/html"
 
 	"github.com/asciimoo/hister/cmd/tui/model"
@@ -67,7 +68,12 @@ func ResultDetailsContent(m *model.Model) string {
 	}
 	content = sanitizeTerminalText(content)
 	lines = append(lines, m.Styles.SecText.UnsetItalic().UnsetFaint().Render(content))
-	return strings.Join(lines, "\n")
+	return wrapDetailsText(strings.Join(lines, "\n"), max(1, DetailsPaneWidth(m)-2))
+}
+
+func wrapDetailsText(content string, width int) string {
+	width = max(1, width)
+	return ansi.Hardwrap(ansi.Wordwrap(content, width, "/"), width, false)
 }
 
 func detailsDocument(m *model.Model, url string) *document.Document {

--- a/cmd/tui/render/render_test.go
+++ b/cmd/tui/render/render_test.go
@@ -1,0 +1,192 @@
+package render
+
+import (
+	"maps"
+	"strings"
+	"testing"
+
+	"github.com/asciimoo/hister/client"
+	"github.com/asciimoo/hister/cmd/tui/model"
+	"github.com/asciimoo/hister/config"
+	"github.com/asciimoo/hister/server/document"
+	"github.com/asciimoo/hister/server/indexer"
+
+	"github.com/charmbracelet/bubbles/viewport"
+	"github.com/charmbracelet/lipgloss"
+)
+
+func renderModel() *model.Model {
+	cfg := config.CreateDefaultConfig()
+	cfg.TUI = config.DefaultTUIConfig
+	cfg.Hotkeys.TUI = maps.Clone(config.DefaultTUIHotkeys)
+	m := model.InitialModel(cfg)
+	m.Width = 90
+	m.Height = 30
+	return m
+}
+
+func prepareSearchRender(m *model.Model) {
+	m.Ready = true
+	m.Viewport = viewport.New(1, 1)
+	ResizeSearchViewports(m)
+	RefreshViewport(m)
+	if m.DetailsURL != "" {
+		m.Details.SetContent(ResultDetailsContent(m))
+	}
+}
+
+func TestDetailsRenderAsRightSideSearchPane(t *testing.T) {
+	m := renderModel()
+	m.Width = 120
+	doc := &document.Document{URL: "https://example.com/article", Title: "Left result", Text: "excerpt"}
+	m.Results = &indexer.Results{Documents: []*document.Document{doc}}
+	m.SelectedIdx = 0
+	m.State = model.StateDetails
+	m.DetailsURL = doc.URL
+	m.DetailsHintTitle = doc.Title
+	m.DetailsFocused = true
+	m.DetailsPreview = &client.PreviewResponse{Title: "Readable preview", Content: "Full article body"}
+	prepareSearchRender(m)
+
+	view := MainView(m)
+	if !strings.Contains(view, "Left result") || !strings.Contains(view, "Readable preview") || !strings.Contains(view, "Preview") {
+		t.Fatalf("split view is missing results or preview:\n%s", view)
+	}
+	if got := lipgloss.Width(view); got != m.Width-1 {
+		t.Fatalf("split view width = %d, want %d", got, m.Width-1)
+	}
+	if got := lipgloss.Height(view); got != m.Height {
+		t.Fatalf("split view height = %d, want %d", got, m.Height)
+	}
+	x, _, width, _ := DetailsPaneBounds(m)
+	if x <= 0 || x+width != m.Width-1 {
+		t.Fatalf("details pane bounds = x%d width%d for terminal width %d", x, width, m.Width)
+	}
+}
+
+func TestDetailsUseFullWidthOnNarrowTerminal(t *testing.T) {
+	m := renderModel()
+	m.Width = 70
+	doc := &document.Document{URL: "https://example.com/article", Title: "Left-only result"}
+	m.Results = &indexer.Results{Documents: []*document.Document{doc}}
+	m.SelectedIdx = 0
+	m.State = model.StateDetails
+	m.DetailsURL = doc.URL
+	m.DetailsHintTitle = doc.Title
+	m.DetailsPreview = &client.PreviewResponse{Title: "Narrow preview", Content: "Readable body"}
+	prepareSearchRender(m)
+
+	view := MainView(m)
+	if strings.Contains(view, "Left-only result") || !strings.Contains(view, "Narrow preview") {
+		t.Fatalf("narrow view did not replace results with preview:\n%s", view)
+	}
+	if DetailsSplit(m) {
+		t.Fatal("narrow terminal unexpectedly uses split details")
+	}
+}
+
+func TestResultDetailsRendersHTMLAsReadableText(t *testing.T) {
+	m := renderModel()
+	m.DetailsURL = "https://example.com/article"
+	m.DetailsPreview = &client.PreviewResponse{
+		Title:   "Article",
+		Content: `<h1>Heading</h1><p>First <strong>paragraph</strong>.</p><script>bad()</script><span aria-hidden="true">hidden</span><ul><li>One</li></ul>`,
+	}
+	content := ResultDetailsContent(m)
+
+	for _, want := range []string{"Heading", "First paragraph.", "One"} {
+		if !strings.Contains(content, want) {
+			t.Errorf("details content is missing %q:\n%s", want, content)
+		}
+	}
+	if strings.Contains(content, "bad()") {
+		t.Fatalf("details content includes script text:\n%s", content)
+	}
+}
+
+func TestRulesTabRendersVersioningAndEmitsTargets(t *testing.T) {
+	m := renderModel()
+	m.RulesData.Versioning = []string{"example.com/article/*"}
+	view := RulesTab(m)
+
+	if !strings.Contains(view, "Versioning Patterns") || !strings.Contains(view, "example.com/article/*") {
+		t.Fatalf("rules view is missing versioning section:\n%s", view)
+	}
+	if len(m.WorkspaceTargets) != 5 {
+		t.Fatalf("workspace target count = %d, want 5 (four forms and one item)", len(m.WorkspaceTargets))
+	}
+	found := false
+	for _, target := range m.WorkspaceTargets {
+		if target.Kind == model.WorkspaceRulesItem && target.Section == model.RulesSectionVersioning {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("renderer did not emit a hit target for the versioning item")
+	}
+}
+
+func TestAddTabUsesComponentGeometry(t *testing.T) {
+	m := renderModel()
+	m.AddFocusIdx = 2
+	_ = AddTab(m)
+
+	if len(m.WorkspaceTargets) != 4 {
+		t.Fatalf("workspace target count = %d, want 4", len(m.WorkspaceTargets))
+	}
+	if got := m.WorkspaceTargets[2]; got.Kind != model.WorkspaceAddField || got.Index != 2 || got.Height < model.AddTextHeight {
+		t.Fatalf("text area target = %#v", got)
+	}
+	if m.WorkspaceSelectionY != m.WorkspaceTargets[2].Y {
+		t.Fatalf("selection y = %d, want %d", m.WorkspaceSelectionY, m.WorkspaceTargets[2].Y)
+	}
+}
+
+func TestOverlayCompositorPreservesCanvasSize(t *testing.T) {
+	background := strings.TrimSuffix(strings.Repeat(strings.Repeat("b", 30)+"\n", 10), "\n")
+	view := renderOverlay(background, "dialog", 30, 10, 0, 0)
+	if got := lipgloss.Width(view); got != 30 {
+		t.Fatalf("overlay width = %d, want 30", got)
+	}
+	if got := lipgloss.Height(view); got != 10 {
+		t.Fatalf("overlay height = %d, want 10", got)
+	}
+	if !strings.Contains(view, "dialog") {
+		t.Fatal("composited overlay is missing foreground content")
+	}
+}
+
+func TestHeaderCompactsTabsAndOwnsTheirHitboxes(t *testing.T) {
+	m := renderModel()
+	m.Width = 24
+	header := Header(m)
+
+	if got := lipgloss.Width(header); got != m.Width-1 {
+		t.Fatalf("header width = %d, want %d", got, m.Width-1)
+	}
+	if !strings.Contains(header, "[S]") {
+		t.Fatalf("compact header is missing active search tab: %q", header)
+	}
+	if len(m.TabTargets) != len(model.Tabs) {
+		t.Fatalf("tab target count = %d, want %d", len(m.TabTargets), len(model.Tabs))
+	}
+	for i := 1; i < len(m.TabTargets); i++ {
+		if m.TabTargets[i].X0 <= m.TabTargets[i-1].X1 {
+			t.Fatalf("tab targets overlap: %#v", m.TabTargets)
+		}
+	}
+}
+
+func TestLongOverlaysFitShortTerminal(t *testing.T) {
+	m := renderModel()
+	m.Height = 14
+
+	settings := renderOverlayBox(Settings(m), m.Styles.HelpBorder, m.Width-5)
+	if got := lipgloss.Height(settings); got > m.Height {
+		t.Fatalf("settings overlay height = %d, terminal height = %d", got, m.Height)
+	}
+	themes := renderOverlayBox(ThemePicker(m), m.Styles.ThemeBorder, m.Width-5)
+	if got := lipgloss.Height(themes); got > m.Height {
+		t.Fatalf("theme overlay height = %d, terminal height = %d", got, m.Height)
+	}
+}

--- a/cmd/tui/render/render_test.go
+++ b/cmd/tui/render/render_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/charmbracelet/bubbles/viewport"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
 )
 
 func renderModel() *model.Model {
@@ -101,6 +102,27 @@ func TestResultDetailsRendersHTMLAsReadableText(t *testing.T) {
 	}
 	if strings.Contains(content, "bad()") {
 		t.Fatalf("details content includes script text:\n%s", content)
+	}
+}
+
+func TestResultDetailsWrapsDocumentTextToViewport(t *testing.T) {
+	m := renderModel()
+	m.Width = 27
+	m.DetailsURL = "https://example.com/article-with-a-very-long-path"
+	m.DetailsPreview = &client.PreviewResponse{
+		Title:   "A long readable article title",
+		Content: "Document text should wrap at natural word boundaries instead of being clipped by the details viewport. supercalifragilisticexpialidocious",
+	}
+
+	content := ResultDetailsContent(m)
+	contentWidth := DetailsPaneWidth(m) - 2
+	if len(strings.Split(content, "\n")) < 8 {
+		t.Fatalf("details content was not wrapped:\n%s", content)
+	}
+	for i, line := range strings.Split(content, "\n") {
+		if width := ansi.StringWidth(line); width > contentWidth {
+			t.Fatalf("line %d width = %d, want <= %d: %q", i, width, contentWidth, line)
+		}
 	}
 }
 

--- a/cmd/tui/render/util.go
+++ b/cmd/tui/render/util.go
@@ -95,7 +95,7 @@ func renderURL(st theme.Styles, rawURL, domain string, maxW int) string {
 }
 
 func isLocalHost(host string) bool {
-	h := strings.SplitN(host, ":", 2)[0]
+	h, _, _ := strings.Cut(host, ":")
 	return h == "localhost" || h == "127.0.0.1" || h == "::1"
 }
 

--- a/cmd/tui/tui.go
+++ b/cmd/tui/tui.go
@@ -20,6 +20,7 @@ type app struct{ m *model.Model }
 func (a *app) Init() tea.Cmd {
 	return tea.Batch(
 		textinput.Blink,
+		a.m.FetchServerConfigCmd(),
 		network.ConnectWebSocket(a.m.Cfg.WebSocketURL(), a.m.Cfg.BaseURL(""), a.m.Cfg.App.AccessToken, a.m.WsChan, a.m.WsDone),
 		network.ListenToWebSocket(a.m.WsChan, a.m.WsDone),
 	)

--- a/server/vectorstore/embedder.go
+++ b/server/vectorstore/embedder.go
@@ -191,8 +191,7 @@ func shouldRetryEmbeddingError(ctx context.Context, err error) bool {
 		return false
 	}
 
-	var statusErr *embeddingStatusError
-	if errors.As(err, &statusErr) {
+	if statusErr, ok := errors.AsType[*embeddingStatusError](err); ok {
 		return statusErr.transient()
 	}
 

--- a/webui/website/src/content/docs/terminal-client.md
+++ b/webui/website/src/content/docs/terminal-client.md
@@ -220,44 +220,57 @@ hister search
 
 - **Multi-tab interface**: Search, History, Rules, and Add tabs
 - **Mouse support**: Scroll with mouse wheel, click to select, right-click for context menu
+- **Result actions**: Copy URLs, read full previews, edit labels, prioritize, or delete
+- **Responsive preview pane**: Read results beside the result list on wide terminals; smaller terminals switch the preview to full width
+- **Semantic search**: Toggle hybrid keyword/semantic results when semantic search is enabled
 - **Theming**: Built-in color themes with interactive picker (press `ctrl+t`)
 - **Settings overlay**: Edit keybindings interactively (press `ctrl+s`)
-- **Context menu**: Right-click on results for quick actions (open, delete, prioritize)
+- **Responsive workspaces**: Every tab scrolls and adapts to the terminal size
+- **Contextual help and feedback**: Footer shortcuts match the active tab, while notices confirm actions
 
 ### Tabs
 
 - **Search** (Alt+1): Main search interface
 - **History** (Alt+2): View your recent search history
 - **Rules** (Alt+3): Manage skip, priority, versioning, and alias rules
-- **Add** (Alt+4): Manually add URLs to the index
+- **Add** (Alt+4): Manually add URLs, titles, and multiline text to the index
 
 ### TUI Keybindings
 
 The TUI uses the following keybindings by default:
 
-| Key          | Action          | Description                                    |
-| ------------ | --------------- | ---------------------------------------------- |
-| `ctrl+c`     | quit            | Exit the TUI                                   |
-| `f1`         | toggle_help     | Show/hide keybindings help overlay             |
-| `tab`, `esc` | toggle_focus    | Switch between search input and results list   |
-| `up`, `k`    | scroll_up       | Navigate up in results                         |
-| `down`, `j`  | scroll_down     | Navigate down in results                       |
-| `enter`      | open_result     | Open the selected result in your browser       |
-| `ctrl+d`     | delete_result   | Delete the selected result from the index      |
-| `ctrl+t`     | toggle_theme    | Open the interactive theme picker              |
-| `ctrl+s`     | toggle_settings | Open the keybinding editor overlay             |
-| `ctrl+o`     | toggle_sort     | Toggle domain-based sorting for search results |
-| `alt+1`      | tab_search      | Switch to the Search tab                       |
-| `alt+2`      | tab_history     | Switch to the History tab                      |
-| `alt+3`      | tab_rules       | Switch to the Rules tab                        |
-| `alt+4`      | tab_add         | Switch to the Add tab                          |
+| Key          | Action          | Description                                          |
+| ------------ | --------------- | ---------------------------------------------------- |
+| `ctrl+c`     | quit            | Exit the TUI                                         |
+| `f1`         | toggle_help     | Show/hide the complete keybindings help overlay      |
+| `tab`, `esc` | toggle_focus    | Change focus or return to the previous workspace     |
+| `up`, `k`    | scroll_up       | Navigate up                                          |
+| `down`, `j`  | scroll_down     | Navigate down                                        |
+| `enter`      | open_result     | Open, edit, or submit the focused item               |
+| `y`          | copy_result     | Copy the selected URL using the terminal clipboard   |
+| `v`          | toggle_preview  | Show or hide the readable preview pane               |
+| `l`          | edit_label      | Edit the selected document's label                   |
+| `ctrl+d`     | delete_result   | Delete the selected item                             |
+| `ctrl+t`     | toggle_theme    | Open the interactive theme picker                    |
+| `ctrl+s`     | toggle_settings | Open the keybinding editor overlay                   |
+| `ctrl+o`     | toggle_sort     | Toggle domain-based sorting for search results       |
+| `ctrl+e`     | toggle_semantic | Toggle semantic search when enabled in server config |
+| `alt+1`      | tab_search      | Switch to the Search tab                             |
+| `alt+2`      | tab_history     | Switch to the History tab                            |
+| `alt+3`      | tab_rules       | Switch to the Rules tab                              |
+| `alt+4`      | tab_add         | Switch to the Add tab                                |
 
 ### Mouse Controls
 
 - **Left-click**: Select results or open tabs
-- **Right-click**: Open context menu (open, delete, prioritize)
-- **Scroll wheel**: Navigate through results
+- **Right-click**: Open the result menu (open, copy, details, label, prioritize, delete)
+- **Scroll wheel**: Navigate results or scroll the active workspace/overlay
 - **Scrollbar drag**: Quick scroll through long result lists
+
+When a preview is open on a wide terminal, use `tab` to move focus between the
+result list and the preview. Arrow keys or `j`/`k` then navigate the focused
+side. Clicking or scrolling either side focuses it. Press `v`, `esc`, or the
+`×` in the preview header to close it.
 
 ### Customizing TUI
 
@@ -280,6 +293,10 @@ hotkeys:
   ctrl+t: 'toggle_theme'
   ctrl+s: 'toggle_settings'
   ctrl+o: 'toggle_sort'
+  ctrl+e: 'toggle_semantic'
+  y: 'copy_result'
+  v: 'toggle_preview'
+  l: 'edit_label'
   alt+1: 'tab_search'
   alt+2: 'tab_history'
   alt+3: 'tab_rules'
@@ -291,13 +308,17 @@ hotkeys:
 
 - `quit` - Exit the TUI application
 - `toggle_help` - Show/hide the help overlay
-- `toggle_focus` - Switch between input and results views
+- `toggle_focus` - Change focus or return to the previous workspace
 - `scroll_up`/`scroll_down` - Move selection up/down
 - `open_result` - Open selected URL in browser
+- `copy_result` - Copy the selected URL
+- `toggle_preview` - Show/hide selected result details
+- `edit_label` - Edit the selected document label
 - `delete_result` - Delete selected entry from index
 - `toggle_theme` - Open theme picker
 - `toggle_settings` - Open keybinding editor
 - `toggle_sort` - Toggle sorting mode
+- `toggle_semantic` - Toggle semantic search
 - `tab_search`/`tab_history`/`tab_rules`/`tab_add` - Switch tabs
 
 Note: After modifying `tui.yaml`, restart the `hister search` command to apply changes.


### PR DESCRIPTION
Add a focused details view for reading full previews and managing the
selected result. Wide terminals use a split pane, while narrow terminals
give the preview the full workspace