### PR TITLE
[enh] inherit the terminal color palette by default

### DIFF
--- a/cmd/tui/handle/actions.go
+++ b/cmd/tui/handle/actions.go
@@ -312,9 +312,8 @@ func CloseThemePickerWithRevert(m *model.Model) tea.Cmd {
 	m.Cfg.TUI.LightTheme = m.OrigLightTheme
 	m.Cfg.TUI.ColorScheme = m.OrigColorScheme
 	m.ThemePickerMode = m.OrigColorScheme
-	if p, ok := theme.GetPalette(m.OrigThemeName); ok {
-		m.ApplyTheme(p)
-		render.RefreshViewport(m)
-	}
+	p, _ := theme.ResolvePalette(&m.Cfg.TUI, m.IsDarkBg)
+	m.ApplyTheme(p)
+	render.RefreshViewport(m)
 	return CloseOverlay(m)
 }

--- a/cmd/tui/handle/mouse/mouse.go
+++ b/cmd/tui/handle/mouse/mouse.go
@@ -23,6 +23,7 @@ type Deps struct {
 	SubmitAdd                  func(*model.Model) tea.Cmd
 	CloseThemePickerWithRevert func(*model.Model) tea.Cmd
 	PreviewTheme               func(*model.Model)
+	CycleAppearance            func(*model.Model) tea.Cmd
 	ExecuteContextMenuAction   func(*model.Model) tea.Cmd
 	ReloadDetails              func(*model.Model) tea.Cmd
 }

--- a/cmd/tui/handle/mouse/mouse_test.go
+++ b/cmd/tui/handle/mouse/mouse_test.go
@@ -5,7 +5,12 @@
 package mouse
 
 import (
+	"maps"
 	"testing"
+
+	"github.com/asciimoo/hister/cmd/tui/model"
+	"github.com/asciimoo/hister/cmd/tui/theme"
+	"github.com/asciimoo/hister/config"
 
 	tea "charm.land/bubbletea/v2"
 )
@@ -30,5 +35,73 @@ func TestNewEventPreservesTypedMouseMessages(t *testing.T) {
 				t.Fatalf("newEvent() = %#v, want position (3,4), button %v, action %v", event, tt.wantButton, tt.wantAction)
 			}
 		})
+	}
+}
+
+func mouseTestModel(t *testing.T) *model.Model {
+	t.Helper()
+	t.Setenv("NO_COLOR", "")
+	cfg := config.CreateDefaultConfig()
+	cfg.TUI = config.DefaultTUIConfig
+	cfg.Hotkeys.TUI = maps.Clone(config.DefaultTUIHotkeys)
+	return model.InitialModel(cfg)
+}
+
+func TestThemePickerWheelLeavesTerminalModeAtListEdge(t *testing.T) {
+	m := mouseTestModel(t)
+	darkNames, _ := theme.ClassifyThemes()
+	if len(darkNames) == 0 {
+		t.Fatal("no dark themes available")
+	}
+	m.ThemePickerMode = theme.TerminalName
+	m.ThemePickerSection = 0
+	m.DarkThemeIdx = len(darkNames) - 1
+	previews := 0
+	h := &Handler{Deps: Deps{PreviewTheme: func(*model.Model) { previews++ }}}
+
+	h.themePickerScroll(m, Event{
+		Mouse:  tea.Mouse{Button: tea.MouseWheelDown},
+		Action: actionWheel,
+	})
+
+	if m.ThemePickerMode != "dark" || m.Cfg.TUI.ColorScheme != "dark" {
+		t.Fatalf("wheel left mode = %q/%q, want dark", m.ThemePickerMode, m.Cfg.TUI.ColorScheme)
+	}
+	if previews != 1 {
+		t.Fatalf("wheel preview count = %d, want 1", previews)
+	}
+}
+
+func TestThemePickerMouseSelectsTerminalMode(t *testing.T) {
+	m := mouseTestModel(t)
+	m.ThemePickerMode = "auto"
+	m.Cfg.TUI.ColorScheme = "auto"
+
+	themePickerInside(m, Event{
+		Mouse: tea.Mouse{
+			X: themeModeLeftPad + themeModeLabelStartX,
+			Y: themeModeRowY,
+		},
+		Action: actionClick,
+	}, 0, 0)
+
+	if m.ThemePickerMode != theme.TerminalName || m.ThemeName != theme.TerminalName {
+		t.Fatalf("mouse selected mode = %q/%q, want terminal", m.ThemePickerMode, m.ThemeName)
+	}
+}
+
+func TestSettingsAppearanceRowCyclesWhenSelected(t *testing.T) {
+	m := mouseTestModel(t)
+	m.SettingsIdx = 0
+	cycles := 0
+	h := &Handler{Deps: Deps{CycleAppearance: func(*model.Model) tea.Cmd {
+		cycles++
+		return nil
+	}}}
+
+	h.settingsInside(m, Event{Mouse: tea.Mouse{Y: settingsAppearanceRowY}, Action: actionClick}, 0)
+
+	if cycles != 1 {
+		t.Fatalf("appearance cycle count = %d, want 1", cycles)
 	}
 }

--- a/cmd/tui/handle/mouse/overlays.go
+++ b/cmd/tui/handle/mouse/overlays.go
@@ -20,6 +20,11 @@ const (
 	closeBtnOffset = 4 // right edge to close btn start (btn + border)
 )
 
+const (
+	settingsAppearanceRowY = 3
+	settingsListStartY     = 6
+)
+
 // Theme picker layout (relative to overlay origin)
 const (
 	themeModeRowY        = 2 // relative Y of mode row
@@ -77,11 +82,34 @@ func (h *Handler) overlayClick(m *model.Model, msg Event) tea.Cmd {
 			return overlayDialog(m, msg, ox, oy, ow)
 		case model.StatePrioritizeInput:
 			return overlayPrioritize(m, msg, ox, oy, ow)
+		case model.StateSettings:
+			return h.settingsInside(m, msg, oy)
 		}
 		return nil
 	}
 
 	return h.closeOverlayForState(m)
+}
+
+func (h *Handler) settingsInside(m *model.Model, msg Event, oy int) tea.Cmd {
+	relY := msg.Y - oy
+	if relY == settingsAppearanceRowY {
+		if m.SettingsIdx == 0 {
+			return h.CycleAppearance(m)
+		}
+		m.SettingsIdx = 0
+		return nil
+	}
+	if relY >= settingsListStartY && relY < settingsListStartY+m.SettingsCount {
+		idx := 1 + m.SettingsStart + relY - settingsListStartY
+		if idx == m.SettingsIdx {
+			m.SettingsEditMode = true
+			m.SettingsEditErr = ""
+		} else {
+			m.SettingsIdx = idx
+		}
+	}
+	return nil
 }
 
 // --- overlay click handlers ---
@@ -133,9 +161,8 @@ func themePickerInside(m *model.Model, msg Event, ox, oy int) tea.Cmd {
 
 	if relY == themeModeRowY {
 		relX := msg.X - ox - themeModeLeftPad
-		modes := []string{"auto", "dark", "light"}
 		cur := themeModeLabelStartX
-		for _, mode := range modes {
+		for _, mode := range theme.ColorSchemeModes {
 			labelW := len(mode) + themeModeLabelPad
 			if relX >= cur && relX < cur+labelW {
 				m.ThemePickerMode = mode
@@ -170,6 +197,7 @@ func themePickerInside(m *model.Model, msg Event, ox, oy int) tea.Cmd {
 				idx := l.start + relY - l.items.Y
 				m.ThemePickerSection = l.section
 				*l.idx = idx
+				leaveTerminalModeForThemeList(m)
 				if p, ok := theme.GetPalette(l.names[idx]); ok {
 					m.ApplyTheme(p)
 					render.RefreshViewport(m)
@@ -182,16 +210,41 @@ func themePickerInside(m *model.Model, msg Event, ox, oy int) tea.Cmd {
 }
 
 func (h *Handler) themePickerScroll(m *model.Model, msg Event) tea.Cmd {
+	if wheelDelta(msg) == 0 {
+		return nil
+	}
 	darkNames, lightNames := theme.ClassifyThemes()
+	wasTerminal := m.ThemePickerMode == theme.TerminalName
+	leaveTerminalModeForThemeList(m)
 	if m.ThemePickerSection == 0 {
+		oldIdx := m.DarkThemeIdx
 		handleScroll(msg, &m.DarkThemeIdx, 0, len(darkNames)-1, func() { h.PreviewTheme(m) })
+		if wasTerminal && oldIdx == m.DarkThemeIdx {
+			h.PreviewTheme(m)
+		}
 	} else {
+		oldIdx := m.LightThemeIdx
 		handleScroll(msg, &m.LightThemeIdx, 0, len(lightNames)-1, func() { h.PreviewTheme(m) })
+		if wasTerminal && oldIdx == m.LightThemeIdx {
+			h.PreviewTheme(m)
+		}
 	}
 	return nil
 }
 
 func settingsScroll(m *model.Model, msg Event) tea.Cmd {
-	handleScroll(msg, &m.SettingsIdx, 0, len(m.Cfg.Hotkeys.TUI)-1, nil)
+	handleScroll(msg, &m.SettingsIdx, 0, len(m.Cfg.Hotkeys.TUI), nil)
 	return nil
+}
+
+func leaveTerminalModeForThemeList(m *model.Model) {
+	if m.ThemePickerMode != theme.TerminalName {
+		return
+	}
+	if m.ThemePickerSection == 0 {
+		m.ThemePickerMode = "dark"
+	} else {
+		m.ThemePickerMode = "light"
+	}
+	m.Cfg.TUI.ColorScheme = m.ThemePickerMode
 }

--- a/cmd/tui/handle/overlays.go
+++ b/cmd/tui/handle/overlays.go
@@ -66,12 +66,25 @@ func previewTheme(m *model.Model) {
 	}
 }
 
+func leaveTerminalModeForThemeList(m *model.Model) {
+	if m.ThemePickerMode != theme.TerminalName {
+		return
+	}
+	if m.ThemePickerSection == 0 {
+		m.ThemePickerMode = "dark"
+	} else {
+		m.ThemePickerMode = "light"
+	}
+	m.Cfg.TUI.ColorScheme = m.ThemePickerMode
+}
+
 func ThemePickerKeys(m *model.Model, msg tea.KeyPressMsg) tea.Cmd {
 	darkNames, lightNames := theme.ClassifyThemes()
 	action := m.Keys.Action(msg)
 	key := msg.String()
 	switch action {
 	case config.ActionScrollUp:
+		leaveTerminalModeForThemeList(m)
 		if m.ThemePickerSection == 0 {
 			if m.DarkThemeIdx > 0 {
 				m.DarkThemeIdx--
@@ -83,6 +96,7 @@ func ThemePickerKeys(m *model.Model, msg tea.KeyPressMsg) tea.Cmd {
 		}
 		previewTheme(m)
 	case config.ActionScrollDown:
+		leaveTerminalModeForThemeList(m)
 		if m.ThemePickerSection == 0 {
 			if m.DarkThemeIdx < len(darkNames)-1 {
 				m.DarkThemeIdx++
@@ -103,19 +117,12 @@ func ThemePickerKeys(m *model.Model, msg tea.KeyPressMsg) tea.Cmd {
 			} else {
 				m.ThemePickerSection = 0
 			}
-			previewTheme(m)
+			if m.ThemePickerMode != theme.TerminalName {
+				previewTheme(m)
+			}
 		}
 	case config.ActionToggleTheme:
-		switch m.ThemePickerMode {
-		case "auto":
-			m.ThemePickerMode = "dark"
-		case "dark":
-			m.ThemePickerMode = "light"
-		case "light":
-			m.ThemePickerMode = "auto"
-		default:
-			m.ThemePickerMode = "auto"
-		}
+		m.ThemePickerMode = theme.NextColorSchemeMode(m.ThemePickerMode)
 		m.Cfg.TUI.ColorScheme = m.ThemePickerMode
 		p, _ := theme.ResolvePalette(&m.Cfg.TUI, m.IsDarkBg)
 		m.ApplyTheme(p)
@@ -131,6 +138,9 @@ func ThemePickerKeys(m *model.Model, msg tea.KeyPressMsg) tea.Cmd {
 		p, _ := theme.ResolvePalette(&m.Cfg.TUI, m.IsDarkBg)
 		m.ApplyTheme(p)
 		render.RefreshViewport(m)
+		if err := m.Cfg.SaveTUIConfig(); err != nil {
+			log.Warn().Err(err).Msg("failed to save TUI theme")
+		}
 		m.DismissOverlay()
 		if m.State == model.StateInput {
 			return m.TextInput.Focus()
@@ -143,7 +153,7 @@ func SettingsKeys(m *model.Model, msg tea.KeyPressMsg) tea.Cmd {
 	if m.SettingsEditMode {
 		return settingsEditKey(m, msg)
 	}
-	totalItems := len(m.Cfg.Hotkeys.TUI)
+	totalItems := len(m.Cfg.Hotkeys.TUI) + 1
 	action := m.Keys.Action(msg)
 	key := msg.String()
 	switch action {
@@ -152,8 +162,13 @@ func SettingsKeys(m *model.Model, msg tea.KeyPressMsg) tea.Cmd {
 	case config.ActionScrollDown:
 		model.ScrollIdx(&m.SettingsIdx, 1, 0, totalItems-1)
 	case config.ActionOpenResult:
+		if m.SettingsIdx == 0 {
+			return cycleAppearanceMode(m)
+		}
 		m.SettingsEditMode = true
 		m.SettingsEditErr = ""
+	case config.ActionToggleTheme:
+		m.OpenThemePicker()
 	case config.ActionToggleFocus:
 		if key == "esc" {
 			m.DismissOverlay()
@@ -165,13 +180,31 @@ func SettingsKeys(m *model.Model, msg tea.KeyPressMsg) tea.Cmd {
 	return nil
 }
 
+func cycleAppearanceMode(m *model.Model) tea.Cmd {
+	mode := m.Cfg.TUI.ColorScheme
+	if mode == "" {
+		mode = theme.TerminalName
+	}
+	m.Cfg.TUI.ColorScheme = theme.NextColorSchemeMode(mode)
+	m.ThemePickerMode = m.Cfg.TUI.ColorScheme
+	p, _ := theme.ResolvePalette(&m.Cfg.TUI, m.IsDarkBg)
+	m.ApplyTheme(p)
+	render.RefreshViewport(m)
+	if err := m.Cfg.SaveTUIConfig(); err != nil {
+		log.Warn().Err(err).Msg("failed to save TUI appearance")
+		m.SettingsEditErr = "Could not save appearance"
+	}
+	return nil
+}
+
 func settingsEditKey(m *model.Model, msg tea.KeyPressMsg) tea.Cmd {
 	newKey := msg.String()
 	if newKey == "esc" {
 		items := m.SortedSettingsItems()
-		if m.SettingsIdx >= 0 && m.SettingsIdx < len(items) {
-			action := items[m.SettingsIdx].Action
-			oldKey := items[m.SettingsIdx].Key
+		itemIdx := m.SettingsIdx - 1
+		if itemIdx >= 0 && itemIdx < len(items) {
+			action := items[itemIdx].Action
+			oldKey := items[itemIdx].Key
 			defaults := config.DefaultTUIHotkeys
 			defaultKey := ""
 			for k, v := range defaults {
@@ -199,12 +232,13 @@ func settingsEditKey(m *model.Model, msg tea.KeyPressMsg) tea.Cmd {
 		return tea.Tick(2*time.Second, func(_ time.Time) tea.Msg { return model.SettingsErrClearMsg{} })
 	}
 	items := m.SortedSettingsItems()
-	if m.SettingsIdx < 0 || m.SettingsIdx >= len(items) {
+	itemIdx := m.SettingsIdx - 1
+	if itemIdx < 0 || itemIdx >= len(items) {
 		m.SettingsEditMode = false
 		return nil
 	}
-	oldKey := items[m.SettingsIdx].Key
-	action := items[m.SettingsIdx].Action
+	oldKey := items[itemIdx].Key
+	action := items[itemIdx].Action
 
 	if existingAction, exists := m.Cfg.Hotkeys.TUI[newKey]; exists && existingAction != string(action) {
 		m.SettingsEditErr = fmt.Sprintf("%s already bound to %s", component.FormatKey(newKey), existingAction)

--- a/cmd/tui/handle/update.go
+++ b/cmd/tui/handle/update.go
@@ -27,6 +27,7 @@ var mouseHandler = mouse.New(mouse.Deps{
 	SubmitAdd:                  submitAdd,
 	CloseThemePickerWithRevert: CloseThemePickerWithRevert,
 	PreviewTheme:               previewTheme,
+	CycleAppearance:            cycleAppearanceMode,
 	ExecuteContextMenuAction:   executeContextMenuAction,
 	ReloadDetails:              ReloadDetails,
 })

--- a/cmd/tui/handle/update_test.go
+++ b/cmd/tui/handle/update_test.go
@@ -7,10 +7,14 @@ package handle
 import (
 	"image/color"
 	"maps"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/asciimoo/hister/client"
 	"github.com/asciimoo/hister/cmd/tui/model"
+	"github.com/asciimoo/hister/cmd/tui/theme"
 	"github.com/asciimoo/hister/config"
 	"github.com/asciimoo/hister/server/document"
 	"github.com/asciimoo/hister/server/indexer"
@@ -72,6 +76,123 @@ func TestBackgroundColorSelectsMatchingAutomaticTheme(t *testing.T) {
 	}
 	if m.ThemeName != m.Cfg.TUI.DarkTheme {
 		t.Fatalf("theme = %q, want dark theme %q", m.ThemeName, m.Cfg.TUI.DarkTheme)
+	}
+}
+
+func TestThemePickerCyclesThroughTerminalMode(t *testing.T) {
+	t.Setenv("NO_COLOR", "")
+	m := handleTestModel(t)
+	m.OpenThemePicker()
+
+	ThemePickerKeys(m, tea.KeyPressMsg{Code: 't', Mod: tea.ModCtrl})
+	if m.ThemePickerMode != "auto" || m.Cfg.TUI.ColorScheme != "auto" {
+		t.Fatalf("first mode cycle = %q/%q, want auto", m.ThemePickerMode, m.Cfg.TUI.ColorScheme)
+	}
+
+	m.ThemePickerMode = "light"
+	m.Cfg.TUI.ColorScheme = "light"
+	ThemePickerKeys(m, tea.KeyPressMsg{Code: 't', Mod: tea.ModCtrl})
+	if m.ThemePickerMode != theme.TerminalName || m.ThemeName != theme.TerminalName {
+		t.Fatalf("wrapped mode cycle = %q/%q, want terminal", m.ThemePickerMode, m.ThemeName)
+	}
+}
+
+func TestThemeListNavigationLeavesTerminalMode(t *testing.T) {
+	t.Setenv("NO_COLOR", "")
+	m := handleTestModel(t)
+	m.OpenThemePicker()
+
+	ThemePickerKeys(m, tea.KeyPressMsg{Code: tea.KeyDown})
+	if m.ThemePickerMode != "dark" || m.Cfg.TUI.ColorScheme != "dark" {
+		t.Fatalf("theme navigation left mode = %q/%q, want dark", m.ThemePickerMode, m.Cfg.TUI.ColorScheme)
+	}
+	if m.ThemeName == theme.TerminalName {
+		t.Fatal("theme navigation did not preview the dark theme")
+	}
+}
+
+func TestThemePickerCancelRestoresTerminalAppearance(t *testing.T) {
+	t.Setenv("NO_COLOR", "")
+	m := handleTestModel(t)
+	m.OpenThemePicker()
+
+	p, ok := theme.GetPalette(m.Cfg.TUI.DarkTheme)
+	if !ok {
+		t.Fatalf("dark theme %q is unavailable", m.Cfg.TUI.DarkTheme)
+	}
+	m.ApplyTheme(p)
+	CloseThemePickerWithRevert(m)
+
+	if m.ThemeName != theme.TerminalName || m.Cfg.TUI.ColorScheme != theme.TerminalName {
+		t.Fatalf("cancel restored %q/%q, want terminal", m.ThemeName, m.Cfg.TUI.ColorScheme)
+	}
+}
+
+func TestSettingsCycleAndPersistAppearance(t *testing.T) {
+	t.Setenv("NO_COLOR", "")
+	configHome := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", configHome)
+	m := handleTestModel(t)
+	m.State = model.StateSettings
+	m.SettingsIdx = 0
+
+	for _, want := range []string{"auto", "dark", "light", theme.TerminalName} {
+		SettingsKeys(m, tea.KeyPressMsg{Code: tea.KeyEnter})
+		if m.Cfg.TUI.ColorScheme != want {
+			t.Fatalf("appearance cycle = %q, want %q", m.Cfg.TUI.ColorScheme, want)
+		}
+	}
+
+	data, err := os.ReadFile(filepath.Join(configHome, "hister", "tui.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "color_scheme: terminal") {
+		t.Fatalf("saved appearance is not terminal:\n%s", data)
+	}
+}
+
+func TestSettingsOpenThemePickerAndReturn(t *testing.T) {
+	t.Setenv("NO_COLOR", "")
+	m := handleTestModel(t)
+	m.OpenOverlay(model.StateSettings)
+
+	SettingsKeys(m, tea.KeyPressMsg{Code: 't', Mod: tea.ModCtrl})
+	if m.State != model.StateThemePicker {
+		t.Fatalf("theme shortcut opened %s, want theme picker", m.State)
+	}
+	CloseThemePickerWithRevert(m)
+	if m.State != model.StateSettings {
+		t.Fatalf("theme picker returned to %s, want settings", m.State)
+	}
+}
+
+func TestSettingsKeybindingEditUsesBindingIndex(t *testing.T) {
+	configHome := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", configHome)
+	m := handleTestModel(t)
+	m.State = model.StateSettings
+	items := m.SortedSettingsItems()
+	if len(items) == 0 {
+		t.Fatal("no keybindings available")
+	}
+	oldKey, action := items[0].Key, items[0].Action
+	m.SettingsIdx = 1
+
+	SettingsKeys(m, tea.KeyPressMsg{Code: tea.KeyEnter})
+	if !m.SettingsEditMode {
+		t.Fatal("binding row did not enter edit mode")
+	}
+	SettingsKeys(m, tea.KeyPressMsg{Code: tea.KeyF12})
+
+	if m.SettingsEditMode {
+		t.Fatal("binding edit mode did not close")
+	}
+	if _, exists := m.Cfg.Hotkeys.TUI[oldKey]; exists {
+		t.Fatalf("old key %q remains bound", oldKey)
+	}
+	if got := m.Cfg.Hotkeys.TUI["f12"]; got != string(action) {
+		t.Fatalf("f12 binding = %q, want %q", got, action)
 	}
 }
 

--- a/cmd/tui/model/model.go
+++ b/cmd/tui/model/model.go
@@ -128,7 +128,7 @@ type Model struct {
 	ThemeName          string
 	ThemePickerIdx     int
 	OrigThemeName      string
-	ThemePickerMode    string // "auto", "dark", "light"
+	ThemePickerMode    string // "terminal", "auto", "dark", "light"
 	ThemePickerSection int    // 0=dark, 1=light
 	DarkThemeIdx       int
 	LightThemeIdx      int
@@ -149,6 +149,8 @@ type Model struct {
 	SettingsIdx      int
 	SettingsEditMode bool
 	SettingsEditErr  string
+	SettingsStart    int
+	SettingsCount    int
 
 	// Tab bar
 	ActiveTab int // 0=Search, 1=History, 2=Rules, 3=Add
@@ -263,7 +265,7 @@ func InitialModel(cfg *config.Config) *Model {
 	m.Workspace = viewport.New(viewport.WithWidth(80), viewport.WithHeight(20))
 	m.Workspace.FillHeight = true
 	if m.ThemePickerMode == "" {
-		m.ThemePickerMode = "auto"
+		m.ThemePickerMode = theme.TerminalName
 	}
 	return m
 }
@@ -787,6 +789,10 @@ func newInput(placeholder string, charLimit int, width int, st theme.Styles) tex
 
 func applyInputStyles(inp *textinput.Model, st theme.Styles) {
 	s := inp.Styles()
+	s.Focused.Text = st.Text
+	s.Blurred.Text = st.Text
+	s.Focused.Prompt = st.Text
+	s.Blurred.Prompt = st.Text
 	s.Focused.Placeholder = st.Placeholder
 	s.Focused.Suggestion = st.Placeholder
 	s.Blurred.Placeholder = st.Placeholder
@@ -797,6 +803,14 @@ func applyInputStyles(inp *textinput.Model, st theme.Styles) {
 
 func applyTextareaStyles(input *textarea.Model, st theme.Styles) {
 	s := input.Styles()
+	s.Focused.Base = st.Text
+	s.Blurred.Base = st.Text
+	s.Focused.Text = st.Text
+	s.Blurred.Text = st.Text
+	s.Focused.Prompt = st.Text
+	s.Blurred.Prompt = st.Text
+	s.Focused.EndOfBuffer = st.Text
+	s.Blurred.EndOfBuffer = st.Text
 	s.Focused.Placeholder = st.Placeholder
 	s.Blurred.Placeholder = st.Placeholder
 	s.Focused.CursorLine = lipgloss.NewStyle()

--- a/cmd/tui/model/model_test.go
+++ b/cmd/tui/model/model_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/asciimoo/hister/server/document"
 	"github.com/asciimoo/hister/server/indexer"
 	smodel "github.com/asciimoo/hister/server/model"
+
+	"charm.land/lipgloss/v2"
 )
 
 func testConfig() *config.Config {
@@ -138,5 +140,25 @@ func TestNestedOverlayRestoresEachReturnState(t *testing.T) {
 	m.DismissOverlay()
 	if m.State != StateResults || m.PrevState != StateResults {
 		t.Fatalf("details returned to state=%s previous=%s, want results/results", m.State, m.PrevState)
+	}
+}
+
+func TestTerminalAppearanceReachesTextEntryComponents(t *testing.T) {
+	t.Setenv("NO_COLOR", "")
+	m := InitialModel(testConfig())
+	if m.ThemeName != "terminal" {
+		t.Fatalf("theme = %q, want terminal", m.ThemeName)
+	}
+
+	inputStyles := m.TextInput.Styles()
+	for label, foreground := range map[string]any{
+		"focused input":    inputStyles.Focused.Text.GetForeground(),
+		"blurred input":    inputStyles.Blurred.Text.GetForeground(),
+		"focused textarea": m.AddText.Styles().Focused.Text.GetForeground(),
+		"blurred textarea": m.AddText.Styles().Blurred.Text.GetForeground(),
+	} {
+		if _, ok := foreground.(lipgloss.NoColor); !ok {
+			t.Errorf("%s foreground = %T, want lipgloss.NoColor", label, foreground)
+		}
 	}
 }

--- a/cmd/tui/render/overlays.go
+++ b/cmd/tui/render/overlays.go
@@ -32,9 +32,8 @@ func ThemePicker(m *model.Model) string {
 		}
 	}
 
-	modes := []string{"auto", "dark", "light"}
 	var modeParts []string
-	for _, mode := range modes {
+	for _, mode := range theme.ColorSchemeModes {
 		if mode == m.ThemePickerMode {
 			modeParts = append(modeParts, m.Styles.ThemePickerSelected.Render("["+mode+"]"))
 		} else {
@@ -140,7 +139,9 @@ func Settings(m *model.Model) string {
 	if m.SettingsEditErr != "" {
 		errorRows = 2
 	}
-	start, end := windowRange(len(items), m.SettingsIdx, max(1, m.Height-8-errorRows))
+	bindingCursor := max(0, m.SettingsIdx-1)
+	start, end := windowRange(len(items), bindingCursor, max(1, m.Height-10-errorRows))
+	m.SettingsStart, m.SettingsCount = start, end-start
 
 	maxKeyW := 0
 	for _, it := range items {
@@ -151,10 +152,18 @@ func Settings(m *model.Model) string {
 	}
 
 	var lines []string
-	lines = append(lines, m.Styles.Title.Render(rangeHeader("Keybindings", start, end, len(items))))
+	lines = append(lines, m.Styles.Title.Render("Settings"))
+	appearance := "  Appearance  " + appearanceModeLabel(m.Cfg.TUI.ColorScheme)
+	if m.SettingsIdx == 0 {
+		appearance = m.Styles.ThemePickerSelected.Render("▸ Appearance  " + appearanceModeLabel(m.Cfg.TUI.ColorScheme))
+	} else {
+		appearance = m.Styles.ThemePickerItem.Render(appearance)
+	}
+	lines = append(lines, appearance)
 	lines = append(lines, "")
+	lines = append(lines, m.Styles.HelpHeader.Render(rangeHeader("Keybindings", start, end, len(items))))
 	for i, it := range items[start:end] {
-		absoluteIdx := start + i
+		absoluteIdx := start + i + 1
 		if absoluteIdx == m.SettingsIdx && m.SettingsEditMode {
 			lines = append(lines, m.Styles.ThemePickerSelected.Render("  Press a key...  →  "+string(it.Action)))
 		} else {
@@ -178,9 +187,29 @@ func Settings(m *model.Model) string {
 	} else {
 		sNav := m.Keys.BestKey(config.ActionScrollDown)
 		sEdit := m.Keys.BestKey(config.ActionOpenResult)
-		lines = append(lines, m.Styles.Hint.Render(sNav+" navigate  "+sEdit+" edit  ⎋ close"))
+		sTheme := m.Keys.BestKey(config.ActionToggleTheme)
+		action := "edit"
+		if m.SettingsIdx == 0 {
+			action = "change mode"
+		}
+		lines = append(lines, m.Styles.Hint.Render(sNav+" navigate  "+sEdit+" "+action+"  "+sTheme+" themes  ⎋ close"))
 	}
 	return m.Styles.Help.Render(strings.Join(lines, "\n"))
+}
+
+func appearanceModeLabel(mode string) string {
+	switch mode {
+	case "", theme.TerminalName:
+		return "Terminal (pass-through)"
+	case "auto":
+		return "Auto (dark/light)"
+	case "dark":
+		return "Dark theme"
+	case "light":
+		return "Light theme"
+	default:
+		return mode
+	}
 }
 
 func windowRange(length, cursor, budget int) (int, int) {

--- a/cmd/tui/render/render_test.go
+++ b/cmd/tui/render/render_test.go
@@ -234,6 +234,26 @@ func TestHeaderCompactsTabsAndOwnsTheirHitboxes(t *testing.T) {
 	}
 }
 
+func TestThemePickerPresentsTerminalAppearance(t *testing.T) {
+	t.Setenv("NO_COLOR", "")
+	m := renderModel()
+	picker := ansi.Strip(ThemePicker(m))
+
+	if !strings.Contains(picker, "Mode: [terminal]") {
+		t.Fatalf("theme picker does not present terminal mode:\n%s", picker)
+	}
+}
+
+func TestSettingsExposeTerminalAppearance(t *testing.T) {
+	t.Setenv("NO_COLOR", "")
+	m := renderModel()
+	settings := ansi.Strip(Settings(m))
+
+	if !strings.Contains(settings, "Appearance  Terminal (pass-through)") {
+		t.Fatalf("settings do not expose terminal appearance:\n%s", settings)
+	}
+}
+
 func TestLongOverlaysFitShortTerminal(t *testing.T) {
 	m := renderModel()
 	m.Height = 14

--- a/cmd/tui/theme/styles.go
+++ b/cmd/tui/theme/styles.go
@@ -12,6 +12,7 @@ import (
 
 type Styles struct {
 	// Layout chrome
+	Text         lipgloss.Style
 	Brand        lipgloss.Style
 	Div          lipgloss.Style
 	PromptActive lipgloss.Style
@@ -98,6 +99,7 @@ func BuildStyles(p Palette) Styles {
 	c := func(hex string) color.Color { return lipgloss.Color(hex) }
 
 	return Styles{
+		Text:         lipgloss.NewStyle().Foreground(c(p.Base05)),
 		Brand:        lipgloss.NewStyle().Foreground(c(p.Base0D)).Bold(true),
 		Div:          lipgloss.NewStyle().Foreground(c(p.Base03)),
 		PromptActive: lipgloss.NewStyle().Foreground(c(p.Base09)).Bold(true),

--- a/cmd/tui/theme/theme.go
+++ b/cmd/tui/theme/theme.go
@@ -8,6 +8,7 @@ import (
 	"embed"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -81,6 +82,25 @@ var (
 	themeRegistry = map[string]Palette{}
 	themeOrder    []string
 )
+
+const TerminalName = "terminal"
+
+// ColorSchemeModes is ordered for both presentation and keyboard cycling.
+// Terminal comes first because it is the least surprising default: it leaves
+// the terminal-wide foreground and background alone and derives accents from
+// the user's ANSI palette.
+var ColorSchemeModes = []string{TerminalName, "auto", "dark", "light"}
+
+// TerminalPalette maps semantic colors to the terminal's configurable ANSI
+// palette. Empty base colors intentionally resolve to lipgloss.NoColor, so
+// normal text and every background inherit the user's terminal defaults.
+var TerminalPalette = Palette{
+	Name:   TerminalName,
+	Base00: "", Base01: "", Base02: "",
+	Base03: "8", Base04: "8", Base05: "", Base06: "", Base07: "",
+	Base08: "1", Base09: "3", Base0A: "3", Base0B: "2",
+	Base0C: "6", Base0D: "4", Base0E: "5", Base0F: "5",
+}
 
 func init() {
 	entries, err := embeddedThemes.ReadDir("themes")
@@ -187,7 +207,7 @@ func IsLightPalette(p Palette) bool {
 }
 
 func ThemeNames() []string {
-	return themeOrder
+	return slices.Clone(themeOrder)
 }
 
 func GetPalette(name string) (Palette, bool) {
@@ -211,6 +231,9 @@ func ClassifyThemes() (darkNames, lightNames []string) {
 func ResolvePalette(tui *config.TUI, isDark bool) (Palette, string) {
 	if os.Getenv("NO_COLOR") != "" {
 		return Palette{Name: "no-color"}, "no-color"
+	}
+	if tui.ColorScheme == TerminalName {
+		return TerminalPalette, TerminalName
 	}
 
 	var chosen string
@@ -237,4 +260,11 @@ func ResolvePalette(tui *config.TUI, isDark bool) (Palette, string) {
 		return p, p.Name
 	}
 	return Palette{Name: "catppuccin-mocha"}, "catppuccin-mocha"
+}
+
+func NextColorSchemeMode(current string) string {
+	if i := slices.Index(ColorSchemeModes, current); i >= 0 {
+		return ColorSchemeModes[(i+1)%len(ColorSchemeModes)]
+	}
+	return ColorSchemeModes[0]
 }

--- a/cmd/tui/theme/theme_test.go
+++ b/cmd/tui/theme/theme_test.go
@@ -1,0 +1,71 @@
+// SPDX-FileContributor: 4evy <git@evy.pink>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package theme
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/asciimoo/hister/config"
+
+	"charm.land/lipgloss/v2"
+)
+
+func TestTerminalPaletteInheritsBaseColorsAndBackgrounds(t *testing.T) {
+	t.Setenv("NO_COLOR", "")
+	p, name := ResolvePalette(&config.TUI{ColorScheme: TerminalName}, true)
+	if name != TerminalName || p.Name != TerminalName {
+		t.Fatalf("resolved palette = %q/%q, want terminal", name, p.Name)
+	}
+
+	styles := BuildStyles(p)
+	styleType := reflect.TypeFor[lipgloss.Style]()
+	stylesValue := reflect.ValueOf(styles)
+	stylesType := stylesValue.Type()
+	for i := range stylesValue.NumField() {
+		if stylesType.Field(i).Type != styleType {
+			continue
+		}
+		style := stylesValue.Field(i).Interface().(lipgloss.Style)
+		if background := style.GetBackground(); !isNoColor(background) {
+			t.Errorf("%s background = %T, want lipgloss.NoColor", stylesType.Field(i).Name, background)
+		}
+	}
+	if foreground := styles.Title.GetForeground(); !isNoColor(foreground) {
+		t.Errorf("normal title foreground = %T, want lipgloss.NoColor", foreground)
+	}
+
+	// Semantic accents remain ANSI colors, which means the terminal profile
+	// chooses their actual RGB values.
+	accent := styles.SelTitle.Render("selected")
+	if !strings.Contains(accent, "\x1b[") {
+		t.Fatalf("selected style emitted no ANSI accent: %q", accent)
+	}
+}
+
+func isNoColor(value any) bool {
+	_, ok := value.(lipgloss.NoColor)
+	return ok
+}
+
+func TestNoColorOverridesTerminalMode(t *testing.T) {
+	t.Setenv("NO_COLOR", "1")
+	_, name := ResolvePalette(&config.TUI{ColorScheme: TerminalName}, true)
+	if name != "no-color" {
+		t.Fatalf("resolved palette = %q, want no-color", name)
+	}
+}
+
+func TestColorSchemeModeCycleIncludesTerminal(t *testing.T) {
+	want := []string{"terminal", "auto", "dark", "light", "terminal"}
+	got := []string{ColorSchemeModes[0]}
+	for range 4 {
+		got = append(got, NextColorSchemeMode(got[len(got)-1]))
+	}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("mode cycle = %v, want %v", got, want)
+	}
+}

--- a/cmd/tui/tui.go
+++ b/cmd/tui/tui.go
@@ -9,6 +9,7 @@ import (
 	"github.com/asciimoo/hister/cmd/tui/model"
 	"github.com/asciimoo/hister/cmd/tui/network"
 	"github.com/asciimoo/hister/cmd/tui/render"
+	"github.com/asciimoo/hister/cmd/tui/theme"
 	"github.com/asciimoo/hister/config"
 
 	"charm.land/bubbles/v2/textinput"
@@ -36,7 +37,7 @@ func (a *app) View() tea.View {
 	v := tea.NewView(render.View(a.m))
 	v.AltScreen = true
 	v.MouseMode = tea.MouseModeCellMotion
-	if a.m.ThemeName != "no-color" {
+	if a.m.Cfg.TUI.ColorScheme != theme.TerminalName && a.m.ThemeName != "no-color" {
 		v.BackgroundColor = a.m.BackgroundColor
 		v.ForegroundColor = a.m.ForegroundColor
 	}

--- a/cmd/tui/tui_test.go
+++ b/cmd/tui/tui_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/asciimoo/hister/cmd/tui/model"
+	"github.com/asciimoo/hister/cmd/tui/theme"
 	"github.com/asciimoo/hister/config"
 
 	tea "charm.land/bubbletea/v2"
@@ -28,6 +29,7 @@ func TestViewDeclaresTerminalFeatures(t *testing.T) {
 	a := testApp(t)
 	// Keep this test independent of the configured default appearance. The
 	// View contract is that a named theme declares its resolved screen colors.
+	a.m.Cfg.TUI.ColorScheme = "dark"
 	a.m.ThemeName = "test-theme"
 	a.m.BackgroundColor = color.Black
 	a.m.ForegroundColor = color.White
@@ -51,5 +53,32 @@ func TestNoColorViewLeavesTerminalColorsUnset(t *testing.T) {
 
 	if v.BackgroundColor != nil || v.ForegroundColor != nil {
 		t.Fatalf("no-color view declared terminal colors: background=%v foreground=%v", v.BackgroundColor, v.ForegroundColor)
+	}
+}
+
+func TestTerminalAppearanceLeavesTerminalColorsUnset(t *testing.T) {
+	t.Setenv("NO_COLOR", "")
+	a := testApp(t)
+	v := a.View()
+
+	if a.m.ThemeName != theme.TerminalName {
+		t.Fatalf("theme = %q, want terminal", a.m.ThemeName)
+	}
+	if v.BackgroundColor != nil || v.ForegroundColor != nil {
+		t.Fatalf("terminal view declared screen colors: background=%v foreground=%v", v.BackgroundColor, v.ForegroundColor)
+	}
+}
+
+func TestFullThemeNamedTerminalStillDeclaresScreenColors(t *testing.T) {
+	t.Setenv("NO_COLOR", "")
+	a := testApp(t)
+	a.m.Cfg.TUI.ColorScheme = "dark"
+	a.m.ThemeName = theme.TerminalName
+	a.m.BackgroundColor = color.Black
+	a.m.ForegroundColor = color.White
+	v := a.View()
+
+	if v.BackgroundColor == nil || v.ForegroundColor == nil {
+		t.Fatal("full theme named terminal did not declare screen colors")
 	}
 }

--- a/config/config.go
+++ b/config/config.go
@@ -269,7 +269,7 @@ var DefaultTUIHotkeys = map[string]string{
 var DefaultTUIConfig = TUI{
 	DarkTheme:   "tokyonight",
 	LightTheme:  "catppuccin-latte",
-	ColorScheme: "auto",
+	ColorScheme: "terminal",
 }
 
 func copyMap(m map[string]string) map[string]string {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -535,3 +535,9 @@ func TestMergeDefaultTUIHotkeysPreservesCustomBindings(t *testing.T) {
 		t.Fatalf("new semantic binding = %q, want %q", got, ActionToggleSemantic)
 	}
 }
+
+func TestDefaultTUIUsesTerminalAppearance(t *testing.T) {
+	if got := DefaultTUIConfig.ColorScheme; got != "terminal" {
+		t.Fatalf("default TUI color scheme = %q, want terminal", got)
+	}
+}

--- a/webui/website/src/content/docs/configuration.md
+++ b/webui/website/src/content/docs/configuration.md
@@ -168,8 +168,8 @@ description: 'Explore every configuration section, option, default value, enviro
     {
       name: 'color_scheme',
       type: 'string',
-      defaultValue: 'auto',
-      description: 'Color scheme mode. Use auto to follow the system, or select dark or light.',
+      defaultValue: 'terminal',
+      description: 'Appearance mode. Terminal inherits your terminal background, foreground, and ANSI palette. Use auto to choose the configured dark or light Hister theme, or select dark or light explicitly.',
     },
     {
       name: 'themes_dir',
@@ -981,7 +981,7 @@ TUI-specific settings are stored in a separate `tui.yaml` file in the same direc
 ```yaml
 dark_theme: 'tokyonight'
 light_theme: 'catppuccin-latte'
-color_scheme: 'auto'
+color_scheme: 'terminal'
 
 hotkeys:
   ctrl+c: 'quit'
@@ -1007,6 +1007,13 @@ hotkeys:
   alt+4: 'tab_add'
 ```
 
+The default `terminal` mode does not paint a terminal-wide foreground or
+background. Normal text inherits your terminal colors, while semantic accents
+use its configurable ANSI palette. Set `color_scheme` to `auto`, `dark`, or
+`light` to opt into Hister's full built-in themes. The Settings overlay
+(`ctrl+s`) exposes this as **Appearance — Terminal (pass-through)**; press Enter
+to cycle modes, or use `ctrl+t` for the full theme picker.
+
 ### TUI Hotkeys
 
 TUI keyboard shortcuts are configured in `tui.yaml` under the `hotkeys` section. See the [tui.yaml example](#tui-configuration) above.
@@ -1024,7 +1031,7 @@ TUI keyboard shortcuts are configured in `tui.yaml` under the `hotkeys` section.
 | `edit_label`      | Edit the selected document label                                            |
 | `delete_result`   | Delete the selected entry from the index                                    |
 | `toggle_theme`    | Open the interactive theme picker overlay                                   |
-| `toggle_settings` | Open the keybinding editor overlay                                          |
+| `toggle_settings` | Open appearance and keybinding settings                                     |
 | `toggle_sort`     | Toggle domain-based sorting for search results                              |
 | `toggle_semantic` | Toggle semantic search when enabled                                         |
 | `tab_search`      | Switch to the Search tab                                                    |


### PR DESCRIPTION
The TUI currently resolves its default `auto` mode to a bundled Hister theme

That replaces the terminal profile's foreground, background, and ANSI colors even when
the user hasn't chosen a theme

Make a new `terminal` mode the default. It leaves normal text and the screen background
unset while semantic accents use the terminal's ANSI palette

Keep `auto`, `dark`, and `light` as opt-in Hister themes, and expose all four modes
through Settings and the theme picker