### PR TITLE
[enh] make TUI focus and feedback explicit

### DIFF
--- a/cmd/tui/component/keymap.go
+++ b/cmd/tui/component/keymap.go
@@ -14,13 +14,17 @@ import (
 
 	"charm.land/bubbles/v2/key"
 	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/x/ansi"
 )
 
 // KeyContext selects the concise, task-specific bindings shown in the footer.
 type KeyContext uint8
 
 const (
-	ContextSearch KeyContext = iota
+	ContextSearchInput KeyContext = iota
+	ContextSearchInputEmpty
+	ContextSearchSuggestion
+	ContextSearchResults
 	ContextHistory
 	ContextRules
 	ContextAdd
@@ -133,26 +137,56 @@ func (k KeyMap) Binding(action config.Action) (key.Binding, bool) {
 // Bubbles binding. Overlays use this instead of scanning persisted config a
 // second time, so edited bindings update every help surface immediately.
 func (k KeyMap) BestKey(action config.Action) string {
+	return k.bestKey(action, func(string) bool { return true })
+}
+
+func (k KeyMap) bestKey(action config.Action, usable func(string) bool) string {
 	binding, ok := k.bindings[action]
 	if !ok {
 		return ""
 	}
 	best := ""
 	for _, name := range binding.Keys() {
+		if !usable(name) {
+			continue
+		}
 		formatted := FormatKey(name)
-		if best == "" || len([]rune(formatted)) < len([]rune(best)) {
+		if best == "" || ansi.StringWidth(formatted) < ansi.StringWidth(best) {
 			best = formatted
 		}
 	}
 	return best
 }
 
-func (k KeyMap) hint(action config.Action, label string) (Hint, bool) {
+func (k KeyMap) searchInputKey(action config.Action) string {
+	return k.bestKey(action, func(name string) bool { return len([]rune(name)) != 1 })
+}
+
+func (k KeyMap) preferredSearchInputKey(action config.Action, preferred string) string {
+	binding, ok := k.bindings[action]
+	if ok && slices.Contains(binding.Keys(), preferred) {
+		return FormatKey(preferred)
+	}
+	return k.searchInputKey(action)
+}
+
+func (k KeyMap) focusResultsKeys() string {
+	keys := []string{
+		k.searchInputKey(config.ActionScrollDown),
+		k.preferredSearchInputKey(config.ActionToggleFocus, "tab"),
+	}
+	return strings.Join(slices.DeleteFunc(keys, func(key string) bool { return key == "" }), "/")
+}
+
+func (k KeyMap) hint(action config.Action, keyLabel, label string) (Hint, bool) {
 	binding, ok := k.bindings[action]
 	if !ok {
 		return Hint{}, false
 	}
 	help := binding.Help()
+	if keyLabel != "" {
+		help.Key = keyLabel
+	}
 	if label != "" {
 		help.Desc = label
 		binding.SetHelp(help.Key, help.Desc)
@@ -164,60 +198,86 @@ func (k KeyMap) hint(action config.Action, label string) (Hint, bool) {
 func (k KeyMap) ShortHints() []Hint {
 	type entry struct {
 		action config.Action
+		key    string
 		label  string
 	}
 	var entries []entry
 	switch k.context {
 	case ContextDetails:
 		entries = []entry{
-			{config.ActionToggleFocus, "results/preview"},
-			{config.ActionScrollDown, "navigate/scroll"},
-			{config.ActionOpenResult, "open"},
-			{config.ActionCopyResult, "copy"},
-			{config.ActionEditLabel, "label"},
-			{config.ActionTogglePreview, "close preview"},
-			{config.ActionToggleHelp, "help"},
+			{action: config.ActionToggleFocus, label: "results/preview"},
+			{action: config.ActionScrollDown, label: "navigate/scroll"},
+			{action: config.ActionOpenResult, label: "open"},
+			{action: config.ActionCopyResult, label: "copy"},
+			{action: config.ActionEditLabel, label: "label"},
+			{action: config.ActionTogglePreview, label: "close preview"},
+			{action: config.ActionToggleHelp, label: "help"},
 		}
 	case ContextHistory:
 		entries = []entry{
-			{config.ActionScrollDown, "navigate"},
-			{config.ActionOpenResult, "open"},
-			{config.ActionCopyResult, "copy"},
-			{config.ActionDeleteResult, "delete"},
-			{config.ActionToggleFocus, "back"},
-			{config.ActionToggleHelp, "help"},
+			{action: config.ActionScrollDown, label: "navigate"},
+			{action: config.ActionOpenResult, label: "open"},
+			{action: config.ActionCopyResult, label: "copy"},
+			{action: config.ActionDeleteResult, label: "delete"},
+			{action: config.ActionToggleFocus, label: "back"},
+			{action: config.ActionToggleHelp, label: "help"},
 		}
 	case ContextRules:
 		entries = []entry{
-			{config.ActionToggleFocus, "form/list"},
-			{config.ActionScrollDown, "navigate"},
-			{config.ActionOpenResult, "add/edit"},
-			{config.ActionDeleteResult, "delete"},
-			{config.ActionToggleHelp, "help"},
+			{action: config.ActionToggleFocus, label: "form/list"},
+			{action: config.ActionScrollDown, label: "navigate"},
+			{action: config.ActionOpenResult, label: "add/edit"},
+			{action: config.ActionDeleteResult, label: "delete"},
+			{action: config.ActionToggleHelp, label: "help"},
 		}
 	case ContextAdd:
 		entries = []entry{
-			{config.ActionToggleFocus, "next/back"},
-			{config.ActionOpenResult, "submit"},
-			{config.ActionToggleHelp, "help"},
+			{action: config.ActionToggleFocus, label: "next/back"},
+			{action: config.ActionOpenResult, label: "continue/submit"},
+			{action: config.ActionToggleHelp, label: "help"},
 		}
-	default:
+	case ContextSearchInput:
+		focusAction := config.Action("")
+		if k.searchInputKey(config.ActionToggleFocus) != "" {
+			focusAction = config.ActionToggleFocus
+		} else if k.searchInputKey(config.ActionScrollDown) != "" {
+			focusAction = config.ActionScrollDown
+		}
 		entries = []entry{
-			{config.ActionScrollDown, "navigate"},
-			{config.ActionOpenResult, "open"},
-			{config.ActionCopyResult, "copy"},
-			{config.ActionTogglePreview, "details"},
-			{config.ActionDeleteResult, "delete"},
-			{config.ActionToggleSort, "sort"},
-			{config.ActionToggleSemantic, "semantic"},
-			{config.ActionToggleHelp, "help"},
-			{config.ActionQuit, "quit"},
+			{action: focusAction, key: k.focusResultsKeys(), label: "focus results"},
+			{action: config.ActionToggleSort, label: "sort"},
+			{action: config.ActionToggleSemantic, label: "semantic"},
+			{action: config.ActionToggleHelp, label: "help"},
+			{action: config.ActionQuit, label: "quit"},
+		}
+	case ContextSearchSuggestion:
+		entries = []entry{
+			{action: config.ActionOpenResult, label: "try suggestion"},
+			{action: config.ActionToggleHelp, label: "help"},
+			{action: config.ActionQuit, label: "quit"},
+		}
+	case ContextSearchInputEmpty:
+		entries = []entry{
+			{action: config.ActionTabHistory, label: "history"},
+			{action: config.ActionToggleTheme, label: "appearance"},
+			{action: config.ActionToggleHelp, label: "help"},
+			{action: config.ActionQuit, label: "quit"},
+		}
+	default: // ContextSearchResults
+		entries = []entry{
+			{action: config.ActionToggleFocus, label: "search"},
+			{action: config.ActionScrollDown, label: "navigate"},
+			{action: config.ActionOpenResult, label: "open"},
+			{action: config.ActionCopyResult, label: "copy"},
+			{action: config.ActionTogglePreview, label: "preview"},
+			{action: config.ActionDeleteResult, label: "delete"},
+			{action: config.ActionToggleHelp, label: "help"},
 		}
 	}
 
 	hints := make([]Hint, 0, len(entries))
 	for _, entry := range entries {
-		if hint, ok := k.hint(entry.action, entry.label); ok {
+		if hint, ok := k.hint(entry.action, entry.key, entry.label); ok {
 			hints = append(hints, hint)
 		}
 	}

--- a/cmd/tui/component/keymap_test.go
+++ b/cmd/tui/component/keymap_test.go
@@ -73,3 +73,66 @@ func TestShortHelpIsContextual(t *testing.T) {
 		}
 	}
 }
+
+func TestSearchHelpMatchesKeyboardOwnership(t *testing.T) {
+	keys := NewKeyMap(config.DefaultTUIHotkeys)
+	inputHints := keys.For(ContextSearchInput).ShortHints()
+	inputActions := make(map[config.Action]bool, len(inputHints))
+	for _, hint := range inputHints {
+		inputActions[hint.Action] = true
+	}
+	for _, unavailable := range []config.Action{
+		config.ActionOpenResult,
+		config.ActionCopyResult,
+		config.ActionTogglePreview,
+		config.ActionDeleteResult,
+	} {
+		if inputActions[unavailable] {
+			t.Errorf("typing help advertises unavailable action %q", unavailable)
+		}
+	}
+	if len(inputHints) == 0 || inputHints[0].Binding.Help().Key != "↓/⇥" {
+		t.Fatalf("typing help does not expose result focus: %#v", inputHints)
+	}
+
+	resultActions := map[config.Action]bool{}
+	for _, hint := range keys.For(ContextSearchResults).ShortHints() {
+		resultActions[hint.Action] = true
+	}
+	for _, available := range []config.Action{
+		config.ActionToggleFocus,
+		config.ActionOpenResult,
+		config.ActionCopyResult,
+		config.ActionTogglePreview,
+	} {
+		if !resultActions[available] {
+			t.Errorf("result help omits available action %q", available)
+		}
+	}
+}
+
+func TestSearchFocusHintUsesConfiguredBindings(t *testing.T) {
+	keys := NewKeyMap(map[string]string{
+		"ctrl+n": string(config.ActionScrollDown),
+		"f2":     string(config.ActionToggleFocus),
+	})
+	hints := keys.For(ContextSearchInput).ShortHints()
+	if len(hints) != 1 {
+		t.Fatalf("input hint count = %d, want 1", len(hints))
+	}
+	want := FormatKey("ctrl+n") + "/" + FormatKey("f2")
+	if got := hints[0].Binding.Help().Key; got != want {
+		t.Fatalf("focus hint = %q, want %q", got, want)
+	}
+
+	keys.Rebuild(map[string]string{"ctrl+n": string(config.ActionScrollDown)})
+	hints = keys.For(ContextSearchInput).ShortHints()
+	if len(hints) != 1 || hints[0].Action != config.ActionScrollDown {
+		t.Fatalf("navigation-only focus hint = %#v", hints)
+	}
+
+	keys.Rebuild(map[string]string{"j": string(config.ActionScrollDown)})
+	if hints := keys.For(ContextSearchInput).ShortHints(); len(hints) != 0 {
+		t.Fatalf("typing-only focus hints = %#v, want none", hints)
+	}
+}

--- a/cmd/tui/handle/actions.go
+++ b/cmd/tui/handle/actions.go
@@ -44,7 +44,7 @@ func DispatchCommonAction(m *model.Model, action config.Action) (tea.Cmd, bool) 
 		return startSearch(m, m.FlashHint(config.ActionToggleSort)), true
 	case config.ActionToggleSemantic:
 		if !m.SemanticEnabled {
-			return m.Notify("Semantic search is not enabled on this server"), true
+			return m.NotifyWarning("Semantic search is not enabled on this server"), true
 		}
 		m.SemanticOn = !m.SemanticOn
 		if m.SemanticOn {
@@ -64,6 +64,12 @@ func DispatchCommonAction(m *model.Model, action config.Action) (tea.Cmd, bool) 
 			}
 			return nil, true
 		}
+		enteredResults := m.FocusSearchResults()
+		if enteredResults && m.SelectedIdx < 0 {
+			m.SelectedIdx = 0
+			render.RefreshAndScroll(m)
+			return m.FlashHint(config.ActionScrollUp), true
+		}
 		if m.SelectedIdx > 0 {
 			m.SelectedIdx--
 			render.RefreshAndScroll(m)
@@ -81,6 +87,12 @@ func DispatchCommonAction(m *model.Model, action config.Action) (tea.Cmd, bool) 
 				return tea.Batch(ReloadDetails(m), m.FlashHint(action)), true
 			}
 			return nil, true
+		}
+		enteredResults := m.FocusSearchResults()
+		if enteredResults && m.SelectedIdx < 0 {
+			m.SelectedIdx = 0
+			render.RefreshAndScroll(m)
+			return m.FlashHint(config.ActionScrollDown), true
 		}
 		if m.SelectedIdx < m.GetTotalResults()-1 {
 			m.SelectedIdx++
@@ -115,9 +127,9 @@ func copySelectedURL(m *model.Model) tea.Cmd {
 		u = m.HistoryItems[m.HistoryIdx].URL
 	}
 	if u == "" {
-		return m.Notify("Nothing selected")
+		return m.NotifyWarning("Nothing selected")
 	}
-	return tea.Batch(tea.SetClipboard(u), m.Notify("URL copied"), m.FlashHint(config.ActionCopyResult))
+	return tea.Batch(tea.SetClipboard(u), m.NotifySuccess("URL copied"), m.FlashHint(config.ActionCopyResult))
 }
 
 func OpenDetails(m *model.Model) tea.Cmd {
@@ -133,7 +145,7 @@ func ReloadDetails(m *model.Model) tea.Cmd {
 func loadDetails(m *model.Model, focusPreview, activate bool) tea.Cmd {
 	u := m.GetSelectedURL()
 	if u == "" {
-		return m.Notify("Nothing selected")
+		return m.NotifyWarning("Nothing selected")
 	}
 	title := m.GetSelectedTitle()
 	startSpinner := !m.DetailsLoading
@@ -159,7 +171,7 @@ func loadDetails(m *model.Model, focusPreview, activate bool) tea.Cmd {
 func OpenLabelEditor(m *model.Model) tea.Cmd {
 	doc := m.GetSelectedDocument()
 	if doc == nil {
-		return m.Notify("Labels are available for indexed documents")
+		return m.NotifyWarning("Labels are available for indexed documents")
 	}
 	m.LabelURL = doc.URL
 	m.LabelInput.SetValue(doc.Label)
@@ -295,6 +307,9 @@ func submitAdd(m *model.Model) tea.Cmd {
 	u := strings.TrimSpace(m.AddInputs[0].Value())
 	if u == "" {
 		m.AddStatus = "URL is required"
+		m.AddStatusKind = model.NoticeError
+		m.AddFocusIdx = 0
+		m.AddInputs[0].Focus()
 		return nil
 	}
 	if !strings.Contains(u, "://") {
@@ -304,6 +319,7 @@ func submitAdd(m *model.Model) tea.Cmd {
 	title := strings.TrimSpace(m.AddInputs[1].Value())
 	text := strings.TrimSpace(m.AddText.Value())
 	m.AddStatus = "Adding..."
+	m.AddStatusKind = model.NoticeInfo
 	return m.AddPageCmd(u, title, text)
 }
 

--- a/cmd/tui/handle/input.go
+++ b/cmd/tui/handle/input.go
@@ -28,9 +28,7 @@ func InputKeys(m *model.Model, msg tea.KeyPressMsg) tea.Cmd {
 
 	switch action {
 	case config.ActionToggleFocus:
-		if m.GetTotalResults() > 0 {
-			m.State = model.StateResults
-			m.TextInput.Blur()
+		if m.FocusSearchResults() {
 			if m.SelectedIdx < 0 {
 				m.SelectedIdx = 0
 			}
@@ -38,17 +36,13 @@ func InputKeys(m *model.Model, msg tea.KeyPressMsg) tea.Cmd {
 		}
 		return m.FlashHint(config.ActionToggleFocus)
 	case config.ActionOpenResult:
-		if m.SelectedIdx >= 0 {
-			if m.SelectedIdx == m.Limit {
-				m.Limit += model.ResultsPageSize
-				render.RefreshAndScroll(m)
-				return startSearch(m, m.FlashHint(config.ActionOpenResult))
-			} else if u := m.GetSelectedURL(); u != "" {
-				if err := browser.OpenURL(u); err != nil {
-					log.Warn().Err(err).Msg("failed to open URL in browser")
-				}
-				return tea.Batch(m.FlashHint(config.ActionOpenResult), m.PostHistoryCmd(u))
-			}
+		if m.Results != nil && m.Results.QuerySuggestion != "" {
+			suggestion := m.Results.QuerySuggestion
+			m.TextInput.SetValue(suggestion)
+			m.TextInput.SetCursor(len([]rune(suggestion)))
+			m.Limit = model.ResultsPageSize
+			m.SelectedIdx = -1
+			return startSearch(m, m.FlashHint(config.ActionOpenResult))
 		}
 		return m.FlashHint(config.ActionOpenResult)
 	}

--- a/cmd/tui/handle/mouse/mouse.go
+++ b/cmd/tui/handle/mouse/mouse.go
@@ -191,10 +191,16 @@ func (h *Handler) Handle(m *model.Model, msg tea.MouseMsg) tea.Cmd {
 		return h.nonSearchTab(m, event)
 	}
 
-	if cmd, ok := handleScroll(event, &m.SelectedIdx, 0, m.GetTotalResults()-1, func() {
-		render.RefreshAndScroll(m)
-	}); ok {
-		return cmd
+	// Scrolling the results is a focus-changing interaction: selection and
+	// keyboard routing must never disagree. Ignore wheel events over the input,
+	// header, and hints instead of silently moving the result selection.
+	if wheelDelta(event) != 0 && vpRegion(m).Contains(event) {
+		m.FocusSearchResults()
+		if cmd, ok := handleScroll(event, &m.SelectedIdx, 0, m.GetTotalResults()-1, func() {
+			render.RefreshAndScroll(m)
+		}); ok {
+			return cmd
+		}
 	}
 
 	if event.Action == actionClick && event.Button == tea.MouseRight {
@@ -323,6 +329,7 @@ func rightClick(m *model.Model, msg Event) tea.Cmd {
 	if idx < 0 || idx >= m.GetTotalResults() || idx == m.Limit {
 		return nil
 	}
+	m.FocusSearchResults()
 	m.SelectedIdx = idx
 	render.RefreshViewport(m)
 	offX, offY := render.MenuOverlayOffset(m)
@@ -341,6 +348,7 @@ func inputRow(m *model.Model, msg Event) tea.Cmd {
 func scrollbarClick(m *model.Model, msg Event) tea.Cmd {
 	vp := vpRegion(m)
 	if vp.ContainsY(msg.Y) {
+		m.FocusSearchResults()
 		m.ScrollbarDragging = true
 		scrollToPercent(m, msg.Y)
 	}
@@ -364,10 +372,7 @@ func (h *Handler) viewportClick(m *model.Model, msg Event) tea.Cmd {
 	if idx < 0 || idx >= m.GetTotalResults() {
 		return nil
 	}
-	if m.State == model.StateInput {
-		m.State = model.StateResults
-		m.TextInput.Blur()
-	}
+	m.FocusSearchResults()
 	if idx == m.SelectedIdx {
 		if m.SelectedIdx == m.Limit {
 			m.Limit += model.ResultsPageSize

--- a/cmd/tui/handle/update.go
+++ b/cmd/tui/handle/update.go
@@ -145,7 +145,7 @@ func Update(m *model.Model, msg tea.Msg) tea.Cmd {
 	case model.HistoryFetchedMsg:
 		m.HistoryLoading = false
 		if msg.Err != nil {
-			return m.Notify("Could not load history: " + msg.Err.Error())
+			return m.NotifyError("Could not load history: " + msg.Err.Error())
 		}
 		m.HistoryItems = msg.Items
 		m.HistoryIdx = 0
@@ -153,42 +153,48 @@ func Update(m *model.Model, msg tea.Msg) tea.Cmd {
 	case model.RulesFetchedMsg:
 		m.RulesLoading = false
 		if msg.Err != nil {
-			return m.Notify("Could not load rules: " + msg.Err.Error())
+			return m.NotifyError("Could not load rules: " + msg.Err.Error())
 		}
 		m.RulesData = msg.Data
 		m.RulesIdx = 0
 
 	case model.DeleteResultMsg:
 		if msg.Err != nil {
-			return m.Notify("Could not delete result: " + msg.Err.Error())
+			return m.NotifyError("Could not delete result: " + msg.Err.Error())
 		}
 		m.ResetDetails()
 		m.SetBaseState(model.StateResults)
 		render.ResizeSearchViewports(m)
 		render.RefreshAndScroll(m)
-		return tea.Batch(doSearch(m), m.Notify("Result deleted"))
+		return tea.Batch(doSearch(m), m.NotifySuccess("Result deleted"))
 
 	case model.AddResultMsg:
 		if msg.Err != nil {
-			m.AddStatus = "Error: " + msg.Err.Error()
+			m.AddStatus = "Could not add document: " + msg.Err.Error()
+			m.AddStatusKind = model.NoticeError
 		} else {
-			m.AddStatus = "Added successfully!"
+			m.AddStatus = "Document added"
+			m.AddStatusKind = model.NoticeSuccess
 			for i := range m.AddInputs {
 				m.AddInputs[i].SetValue("")
+				m.AddInputs[i].Blur()
 			}
 			m.AddText.SetValue("")
+			m.AddText.Blur()
+			m.AddFocusIdx = 0
+			return m.AddInputs[0].Focus()
 		}
 
 	case model.RulesSavedMsg:
 		if msg.Err == nil {
 			m.RulesLoading = true
-			return tea.Batch(m.FetchRulesCmd(), m.Notify("Rules saved"))
+			return tea.Batch(m.FetchRulesCmd(), m.NotifySuccess("Rules saved"))
 		}
-		return m.Notify("Could not save rules: " + msg.Err.Error())
+		return m.NotifyError("Could not save rules: " + msg.Err.Error())
 
 	case model.LabelSavedMsg:
 		if msg.Err != nil {
-			return m.Notify("Could not update label: " + msg.Err.Error())
+			return m.NotifyError("Could not update label: " + msg.Err.Error())
 		}
 		if m.Results != nil {
 			for _, doc := range m.Results.Documents {
@@ -207,9 +213,9 @@ func Update(m *model.Model, msg tea.Msg) tea.Cmd {
 			m.Details.SetContent(render.ResultDetailsContent(m))
 		}
 		if msg.Label == "" {
-			return m.Notify("Label cleared")
+			return m.NotifySuccess("Label cleared")
 		}
-		return m.Notify("Label saved")
+		return m.NotifySuccess("Label saved")
 
 	case model.ResultsMsg:
 		m.IsSearching = false
@@ -217,11 +223,19 @@ func Update(m *model.Model, msg tea.Msg) tea.Cmd {
 		if m.SelectedIdx >= m.GetTotalResults() {
 			m.SelectedIdx = m.GetTotalResults() - 1
 		}
-		if m.SelectedIdx < 0 && m.GetTotalResults() > 0 {
+		focusInput := false
+		if m.GetTotalResults() == 0 {
+			focusInput = m.ReplaceBaseState(model.StateResults, model.StateInput)
+		}
+		if m.SelectedIdx < 0 && m.GetTotalResults() > 0 && m.State != model.StateInput {
 			m.SelectedIdx = 0
 		}
 		render.RefreshAndScroll(m)
-		return network.ListenToWebSocket(m.WsChan, m.WsDone)
+		listen := network.ListenToWebSocket(m.WsChan, m.WsDone)
+		if focusInput {
+			return tea.Batch(m.TextInput.Focus(), listen)
+		}
+		return listen
 
 	case model.ServerConfigFetchedMsg:
 		if msg.Err != nil {
@@ -273,7 +287,7 @@ func Update(m *model.Model, msg tea.Msg) tea.Cmd {
 		return network.ConnectWebSocket(m.Cfg.WebSocketURL(), m.Cfg.BaseURL(""), m.Cfg.App.AccessToken, m.WsChan, m.WsDone)
 
 	case model.ErrMsg:
-		return tea.Batch(m.Notify(msg.Err.Error()), network.ListenToWebSocket(m.WsChan, m.WsDone))
+		return tea.Batch(m.NotifyError(msg.Err.Error()), network.ListenToWebSocket(m.WsChan, m.WsDone))
 	}
 	return nil
 }

--- a/cmd/tui/handle/update_test.go
+++ b/cmd/tui/handle/update_test.go
@@ -196,6 +196,170 @@ func TestSettingsKeybindingEditUsesBindingIndex(t *testing.T) {
 	}
 }
 
+func TestArrowNavigationTransfersSearchFocusToResults(t *testing.T) {
+	m := handleTestModel(t)
+	m.Results = &indexer.Results{Documents: []*document.Document{
+		{URL: "https://example.com/first", Title: "First"},
+		{URL: "https://example.com/second", Title: "Second"},
+	}}
+	m.SelectedIdx = -1
+
+	Update(m, tea.KeyPressMsg(tea.Key{Code: tea.KeyDown}))
+
+	if m.State != model.StateResults || m.TextInput.Focused() {
+		t.Fatalf("navigation left focus on search input: state=%s focused=%v", m.State, m.TextInput.Focused())
+	}
+	if m.SelectedIdx != 0 {
+		t.Fatalf("first navigation selected index %d, want 0", m.SelectedIdx)
+	}
+}
+
+func TestSearchResponseDoesNotStealSelectionWhileTyping(t *testing.T) {
+	m := handleTestModel(t)
+	m.TextInput.SetValue("query")
+	m.SelectedIdx = -1
+
+	Update(m, model.ResultsMsg{Results: &indexer.Results{Documents: []*document.Document{{
+		URL: "https://example.com/first", Title: "First",
+	}}}})
+
+	if m.State != model.StateInput || m.SelectedIdx != -1 || !m.TextInput.Focused() {
+		t.Fatalf("search response created false result focus: state=%s selected=%d focused=%v",
+			m.State, m.SelectedIdx, m.TextInput.Focused())
+	}
+}
+
+func TestEmptyResponseReturnsOrphanedResultFocusToSearch(t *testing.T) {
+	m := handleTestModel(t)
+	m.State = model.StateResults
+	m.TextInput.Blur()
+	m.SelectedIdx = 0
+
+	if cmd := Update(m, model.ResultsMsg{Results: &indexer.Results{}}); cmd == nil {
+		t.Fatal("empty response did not resume input and websocket commands")
+	}
+	if m.State != model.StateInput || m.SelectedIdx != -1 || !m.TextInput.Focused() {
+		t.Fatalf("empty response orphaned focus: state=%s selected=%d focused=%v",
+			m.State, m.SelectedIdx, m.TextInput.Focused())
+	}
+}
+
+func TestEmptyResponseUpdatesResultFocusUnderNestedOverlays(t *testing.T) {
+	m := handleTestModel(t)
+	m.Results = &indexer.Results{Documents: []*document.Document{{
+		URL: "https://example.com/first", Title: "First",
+	}}}
+	m.State = model.StateResults
+	m.SelectedIdx = 0
+	m.TextInput.Blur()
+	m.OpenOverlay(model.StateDetails)
+	m.OpenOverlay(model.StateHelp)
+
+	Update(m, model.ResultsMsg{Results: &indexer.Results{}})
+	if m.State != model.StateHelp {
+		t.Fatalf("empty response dismissed visible overlay: state=%s", m.State)
+	}
+
+	_ = CloseOverlay(m)
+	if m.State != model.StateDetails {
+		t.Fatalf("help returned to state=%s, want details", m.State)
+	}
+	_ = CloseOverlay(m)
+	if m.State != model.StateInput || m.SelectedIdx != -1 || !m.TextInput.Focused() {
+		t.Fatalf("details returned to orphaned focus: state=%s selected=%d focused=%v",
+			m.State, m.SelectedIdx, m.TextInput.Focused())
+	}
+}
+
+func TestEnterAcceptsNoResultQuerySuggestion(t *testing.T) {
+	m := handleTestModel(t)
+	m.TextInput.SetValue("wrod")
+	m.Results = &indexer.Results{QuerySuggestion: "word"}
+
+	if cmd := Update(m, tea.KeyPressMsg(tea.Key{Code: tea.KeyEnter})); cmd == nil {
+		t.Fatal("Enter did not schedule the suggested search")
+	}
+	if got := m.TextInput.Value(); got != "word" {
+		t.Fatalf("suggested query = %q, want word", got)
+	}
+	if m.State != model.StateInput || m.SelectedIdx != -1 {
+		t.Fatalf("suggestion changed focus state=%s selected=%d", m.State, m.SelectedIdx)
+	}
+}
+
+func TestEnterAcceptsSuggestionInsteadOfRetainedResult(t *testing.T) {
+	m := handleTestModel(t)
+	m.TextInput.SetValue("wrod")
+	m.Results = &indexer.Results{
+		Documents:       []*document.Document{{URL: "https://example.com/result", Title: "Result"}},
+		QuerySuggestion: "word",
+	}
+	m.SelectedIdx = 0
+
+	if cmd := Update(m, tea.KeyPressMsg(tea.Key{Code: tea.KeyEnter})); cmd == nil {
+		t.Fatal("Enter did not schedule the suggested search")
+	}
+	if got := m.TextInput.Value(); got != "word" {
+		t.Fatalf("suggested query = %q, want word", got)
+	}
+	if m.State != model.StateInput || m.SelectedIdx != -1 {
+		t.Fatalf("suggestion changed focus state=%s selected=%d", m.State, m.SelectedIdx)
+	}
+}
+
+func TestAddValidationReturnsFocusToRequiredURL(t *testing.T) {
+	m := handleTestModel(t)
+	m.ActiveTab = model.TabAdd
+	m.State = model.StateResults
+	m.AddFocusIdx = model.AddSubmitFieldIdx
+
+	if cmd := submitAdd(m); cmd != nil {
+		t.Fatal("invalid add unexpectedly called the server")
+	}
+	if m.AddFocusIdx != 0 || !m.AddInputs[0].Focused() {
+		t.Fatalf("URL validation left focus at %d", m.AddFocusIdx)
+	}
+	if m.AddStatus != "URL is required" || m.AddStatusKind != model.NoticeError {
+		t.Fatalf("URL validation status = %q (%d)", m.AddStatus, m.AddStatusKind)
+	}
+}
+
+func TestResultWheelTransfersFocusAndRoutesPrintableActions(t *testing.T) {
+	m := handleTestModel(t)
+	m.TextInput.SetValue("query")
+	m.Results = &indexer.Results{Documents: []*document.Document{
+		{URL: "https://example.com/first", Title: "First"},
+		{URL: "https://example.com/second", Title: "Second"},
+	}}
+	m.SelectedIdx = -1
+
+	// A wheel event over the input must not silently alter the result selection.
+	Update(m, tea.MouseWheelMsg(tea.Mouse{X: 10, Y: model.RowInput, Button: tea.MouseWheelDown}))
+	if m.State != model.StateInput || m.SelectedIdx != -1 || !m.TextInput.Focused() {
+		t.Fatalf("input wheel changed result focus: state=%s selected=%d focused=%v", m.State, m.SelectedIdx, m.TextInput.Focused())
+	}
+
+	Update(m, tea.MouseWheelMsg(tea.Mouse{X: 10, Y: model.RowVPStart, Button: tea.MouseWheelDown}))
+	if m.State != model.StateResults || m.TextInput.Focused() || m.SelectedIdx != 0 {
+		t.Fatalf("result wheel did not transfer focus: state=%s selected=%d focused=%v", m.State, m.SelectedIdx, m.TextInput.Focused())
+	}
+
+	before := m.TextInput.Value()
+	if cmd := Update(m, tea.KeyPressMsg(tea.Key{Text: "y", Code: 'y'})); cmd == nil {
+		t.Fatal("y did not dispatch the selected-result copy action")
+	}
+	if got := m.TextInput.Value(); got != before {
+		t.Fatalf("y was inserted into search input: got %q, want %q", got, before)
+	}
+
+	if cmd := Update(m, tea.KeyPressMsg(tea.Key{Text: "v", Code: 'v'})); cmd == nil {
+		t.Fatal("v did not dispatch the selected-result preview action")
+	}
+	if m.State != model.StateDetails || m.TextInput.Value() != before {
+		t.Fatalf("v did not open preview without typing: state=%s query=%q", m.State, m.TextInput.Value())
+	}
+}
+
 func TestSuccessfulDeleteClosesPreviewAndClearsTerminalResources(t *testing.T) {
 	m := handleTestModel(t)
 	m.State = model.StateDetails

--- a/cmd/tui/model/model.go
+++ b/cmd/tui/model/model.go
@@ -5,10 +5,10 @@
 package model
 
 import (
+	"cmp"
 	"image/color"
-	"math/rand"
+	"maps"
 	"slices"
-	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -101,10 +101,11 @@ type Model struct {
 	DialogReturnTab int // -1 = return to results/search, >=0 = stay on that tab
 
 	// Connection state
-	ConnError error
-	HintFlash config.Action
-	Notice    string
-	NoticeID  uint64
+	ConnError  error
+	HintFlash  config.Action
+	Notice     string
+	NoticeKind NoticeKind
+	NoticeID   uint64
 
 	// Scrollbar interaction
 	ScrollbarDragging bool
@@ -173,10 +174,11 @@ type Model struct {
 	RulesEditingSection int // section containing the item being edited
 
 	// Add tab
-	AddInputs   [2]textinput.Model // URL and title
-	AddText     textarea.Model
-	AddFocusIdx int
-	AddStatus   string
+	AddInputs     [2]textinput.Model // URL and title
+	AddText       textarea.Model
+	AddFocusIdx   int
+	AddStatus     string
+	AddStatusKind NoticeKind
 
 	// Prioritize dialog
 	PrioritizeURL    string
@@ -184,9 +186,6 @@ type Model struct {
 	PrioritizeBtnIdx int // 0=Cancel, 1=Confirm
 	LabelInput       textinput.Model
 	LabelURL         string
-
-	// Tips rotation
-	TipIdx int
 }
 
 func InitialModel(cfg *config.Config) *Model {
@@ -251,7 +250,6 @@ func InitialModel(cfg *config.Config) *Model {
 		RulesEditingIdx:    -1,
 		PrioritizeInput:    newInput("URL pattern...", 500, 40, st),
 		LabelInput:         newInput("Label (empty clears it)", 200, 50, st),
-		TipIdx:             rand.Intn(len(SearchTips)),
 	}
 	for _, section := range RulesSections {
 		if section.Aliases {
@@ -381,19 +379,19 @@ func (m *Model) VisibleDocuments() []*document.Document {
 		return documents
 	}
 
-	seen := make(map[string]bool, len(documents))
+	seen := make(map[string]struct{}, len(documents))
 	byID := make(map[string]*document.Document, len(documents))
 	for _, doc := range documents {
-		seen[doc.URL] = true
+		seen[doc.URL] = struct{}{}
 		byID[document.GetDocID(doc.UserID, doc.URL)] = doc
 	}
 	semanticScores := make(map[string]float64, len(m.Results.SemanticHits))
 	for _, hit := range m.Results.SemanticHits {
 		if hit.Document != nil {
 			semanticScores[hit.Document.URL] = hit.Similarity
-			if !seen[hit.Document.URL] {
+			if _, ok := seen[hit.Document.URL]; !ok {
 				documents = append(documents, hit.Document)
-				seen[hit.Document.URL] = true
+				seen[hit.Document.URL] = struct{}{}
 				byID[document.GetDocID(hit.Document.UserID, hit.Document.URL)] = hit.Document
 			}
 		}
@@ -402,11 +400,11 @@ func (m *Model) VisibleDocuments() []*document.Document {
 		}
 	}
 	if m.SortMode == "domain" {
-		sort.SliceStable(documents, func(i, j int) bool {
-			if documents[i].Domain == documents[j].Domain {
-				return documents[i].Score > documents[j].Score
+		slices.SortStableFunc(documents, func(a, b *document.Document) int {
+			if n := cmp.Compare(a.Domain, b.Domain); n != 0 {
+				return n
 			}
-			return documents[i].Domain < documents[j].Domain
+			return cmp.Compare(b.Score, a.Score)
 		})
 		return documents
 	}
@@ -422,8 +420,8 @@ func (m *Model) VisibleDocuments() []*document.Document {
 	combinedScore := func(doc *document.Document) float64 {
 		return (1-weight)*(doc.Score/maxKeywordScore) + weight*semanticScores[doc.URL]
 	}
-	sort.SliceStable(documents, func(i, j int) bool {
-		return combinedScore(documents[i]) > combinedScore(documents[j])
+	slices.SortStableFunc(documents, func(a, b *document.Document) int {
+		return cmp.Compare(combinedScore(b), combinedScore(a))
 	})
 	return documents
 }
@@ -440,12 +438,7 @@ func (m *Model) SortedSettingsItems() []SettingsItem {
 }
 
 func (m *Model) SortedAliasKeys() []string {
-	keys := make([]string, 0, len(m.RulesData.Aliases))
-	for k := range m.RulesData.Aliases {
-		keys = append(keys, k)
-	}
-	slices.Sort(keys)
-	return keys
+	return slices.Sorted(maps.Keys(m.RulesData.Aliases))
 }
 
 func (m *Model) RulesSectionLen(section int) int {
@@ -477,26 +470,11 @@ func (m *Model) OpenThemePicker() {
 	m.OrigLightTheme = m.Cfg.TUI.LightTheme
 	m.OrigColorScheme = m.Cfg.TUI.ColorScheme
 	darkNames, lightNames := theme.ClassifyThemes()
-	m.DarkThemeIdx = 0
-	for i, name := range darkNames {
-		if name == m.Cfg.TUI.DarkTheme {
-			m.DarkThemeIdx = i
-			break
-		}
-	}
-	m.LightThemeIdx = 0
-	for i, name := range lightNames {
-		if name == m.Cfg.TUI.LightTheme {
-			m.LightThemeIdx = i
-			break
-		}
-	}
+	m.DarkThemeIdx = max(0, slices.Index(darkNames, m.Cfg.TUI.DarkTheme))
+	m.LightThemeIdx = max(0, slices.Index(lightNames, m.Cfg.TUI.LightTheme))
 	m.ThemePickerSection = 0
-	for i, name := range theme.ThemeNames() {
-		if name == m.ThemeName {
-			m.ThemePickerIdx = i
-			break
-		}
+	if idx := slices.Index(theme.ThemeNames(), m.ThemeName); idx >= 0 {
+		m.ThemePickerIdx = idx
 	}
 	m.OpenOverlay(StateThemePicker)
 }
@@ -523,6 +501,28 @@ func (m *Model) SetBaseState(state ViewState) {
 	m.overlayStack = nil
 	m.State = state
 	m.PrevState = state
+}
+
+// ReplaceBaseState updates the root interaction state without dismissing any
+// overlays above it. It reports whether the currently visible state changed.
+func (m *Model) ReplaceBaseState(from, to ViewState) bool {
+	if len(m.overlayStack) == 0 {
+		if m.State != from {
+			return false
+		}
+		m.State = to
+		m.PrevState = to
+		return true
+	}
+
+	if m.overlayStack[0] != from {
+		return false
+	}
+	m.overlayStack[0] = to
+	if m.PrevState == from {
+		m.PrevState = to
+	}
+	return false
 }
 
 // DismissDialog returns to the correct state after closing a dialog.
@@ -597,6 +597,18 @@ func (m *Model) BlurAllRulesInputs() {
 	m.RulesAliasValInput.Blur()
 }
 
+// FocusSearchResults keeps keyboard routing aligned with result interaction.
+// Callers still own selection movement so the first wheel/arrow event can
+// choose the first result without accidentally skipping it.
+func (m *Model) FocusSearchResults() bool {
+	if m.ActiveTab != TabSearch || m.State != StateInput || m.GetTotalResults() == 0 {
+		return false
+	}
+	m.State = StateResults
+	m.TextInput.Blur()
+	return true
+}
+
 func ScrollIdx(idx *int, delta, minVal, maxVal int) bool {
 	n := max(minVal, min(maxVal, *idx+delta))
 	if n == *idx {
@@ -617,12 +629,11 @@ func (m *Model) OpenOverlay(state ViewState) {
 // returns the result index at the given content Y offset,
 // or -1 if no result is found.
 func (m *Model) FindResultAtY(contentY int) int {
-	for i, offset := range slices.Backward(m.LineOffsets) {
-		if offset <= contentY {
-			return i
-		}
+	i, exact := slices.BinarySearch(m.LineOffsets, contentY)
+	if exact {
+		return i
 	}
-	return -1
+	return i - 1
 }
 
 func (m *Model) PostHistoryCmd(u string) tea.Cmd {

--- a/cmd/tui/model/types.go
+++ b/cmd/tui/model/types.go
@@ -5,6 +5,7 @@
 package model
 
 import (
+	"slices"
 	"time"
 
 	"github.com/gorilla/websocket"
@@ -35,6 +36,18 @@ const (
 func (s ViewState) String() string {
 	return []string{"INPUT", "RESULTS", "DIALOG", "HELP", "THEME_PICKER", "CONTEXT_MENU", "SETTINGS", "PRIORITIZE_INPUT", "DETAILS", "LABEL_INPUT"}[s]
 }
+
+// NoticeKind lets transient and inline messages communicate meaning with
+// words/symbols as well as color. This matters in terminal and no-color modes,
+// where hue alone is not a reliable status indicator.
+type NoticeKind uint8
+
+const (
+	NoticeInfo NoticeKind = iota
+	NoticeSuccess
+	NoticeWarning
+	NoticeError
+)
 
 // sent over WebSocket to the search server
 type SearchQuery struct {
@@ -147,10 +160,8 @@ var Tabs = []TabDefinition{
 }
 
 func TabForAction(action config.Action) (int, bool) {
-	for _, tab := range Tabs {
-		if tab.Action == action {
-			return tab.ID, true
-		}
+	if i := slices.IndexFunc(Tabs, func(tab TabDefinition) bool { return tab.Action == action }); i >= 0 {
+		return Tabs[i].ID, true
 	}
 	return 0, false
 }
@@ -266,20 +277,6 @@ func PrioritizeBtnRowY() int { return 7 }
 
 const AddTextHeight = 5
 
-var SearchTips = []string{
-	"Type to search...",
-	"Tip: Use quotes for exact phrases",
-	"Tip: Press Tab to focus results",
-	"Tip: Press Ctrl+D to delete a result",
-	"Tip: Sort by domain with Ctrl+O",
-	"Tip: Toggle semantic search with Ctrl+E",
-	"Tip: Press Ctrl+T to change theme",
-	"Tip: Press Ctrl+S to edit keybindings",
-	"Tip: Press F1 for help",
-	"Tip: Right-click for context menu",
-	"Tip: Press Alt+2/3/4 for History/Rules/Add",
-}
-
 func (m *Model) FlashHint(action config.Action) tea.Cmd {
 	m.HintFlash = action
 	return ClearHintAfter()
@@ -292,10 +289,34 @@ func ClearHintAfter() tea.Cmd {
 }
 
 func (m *Model) Notify(message string) tea.Cmd {
+	return m.notify(message, NoticeInfo)
+}
+
+func (m *Model) NotifySuccess(message string) tea.Cmd {
+	return m.notify(message, NoticeSuccess)
+}
+
+func (m *Model) NotifyWarning(message string) tea.Cmd {
+	return m.notify(message, NoticeWarning)
+}
+
+func (m *Model) NotifyError(message string) tea.Cmd {
+	return m.notify(message, NoticeError)
+}
+
+func (m *Model) notify(message string, kind NoticeKind) tea.Cmd {
 	m.Notice = message
+	m.NoticeKind = kind
 	m.NoticeID++
 	id := m.NoticeID
-	return tea.Tick(2500*time.Millisecond, func(_ time.Time) tea.Msg {
+	duration := 2500 * time.Millisecond
+	switch kind {
+	case NoticeWarning:
+		duration = 4 * time.Second
+	case NoticeError:
+		duration = 6 * time.Second
+	}
+	return tea.Tick(duration, func(_ time.Time) tea.Msg {
 		return NoticeClearMsg{ID: id}
 	})
 }

--- a/cmd/tui/network/network.go
+++ b/cmd/tui/network/network.go
@@ -65,12 +65,9 @@ func ConnectWebSocket(wsURL, origin, token string, wsChan chan tea.Msg, wsDone c
 						}
 						return
 					}
-					var res *indexer.Results
-					if err := json.Unmarshal(data, &res); err != nil {
+					res, err := decodeResults(data)
+					if err != nil {
 						continue
-					}
-					if len(res.Documents) == 0 && len(res.History) == 0 && len(res.SemanticHits) == 0 {
-						res = &indexer.Results{}
 					}
 					select {
 					case wsChan <- model.ResultsMsg{Results: res}:
@@ -82,6 +79,14 @@ func ConnectWebSocket(wsURL, origin, token string, wsChan chan tea.Msg, wsDone c
 		}()
 		return model.WsConnectedMsg{Conn: conn}
 	}
+}
+
+func decodeResults(data []byte) (*indexer.Results, error) {
+	var results indexer.Results
+	if err := json.Unmarshal(data, &results); err != nil {
+		return nil, err
+	}
+	return &results, nil
 }
 
 func Search(conn *websocket.Conn, wsMu *sync.Mutex, wsReady bool, q model.SearchQuery) tea.Cmd {

--- a/cmd/tui/network/network_test.go
+++ b/cmd/tui/network/network_test.go
@@ -1,0 +1,26 @@
+// SPDX-FileContributor: 4evy <git@evy.pink>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package network
+
+import "testing"
+
+func TestDecodeResultsPreservesEmptyResultMetadata(t *testing.T) {
+	results, err := decodeResults([]byte(`{
+		"documents": [],
+		"history": [],
+		"semantic_hits": [],
+		"query_suggestion": "corrected query",
+		"search_duration": "0.01 seconds"
+	}`))
+	if err != nil {
+		t.Fatalf("decodeResults() error = %v", err)
+	}
+	if results.QuerySuggestion != "corrected query" {
+		t.Fatalf("query suggestion = %q, want corrected query", results.QuerySuggestion)
+	}
+	if results.SearchDuration != "0.01 seconds" {
+		t.Fatalf("search duration = %q, want 0.01 seconds", results.SearchDuration)
+	}
+}

--- a/cmd/tui/render/layout.go
+++ b/cmd/tui/render/layout.go
@@ -34,10 +34,10 @@ var overlayDefs = map[model.ViewState]overlayDef{
 
 func View(m *model.Model) string {
 	if !m.Ready {
-		return "Loading..."
+		return "Starting Hister…"
 	}
 	if m.Width < 20 || m.Height < 14 {
-		return "Terminal too small"
+		return fmt.Sprintf("Terminal too small\nNeed at least 20×14; current size is %d×%d.", m.Width, m.Height)
 	}
 
 	main := MainView(m)
@@ -80,10 +80,12 @@ func MainView(m *model.Model) string {
 	}
 
 	pStyle := m.Styles.PromptActive
+	prompt := "▶"
 	if m.State != model.StateInput {
 		pStyle = m.Styles.PromptBlur
+		prompt = "·"
 	}
-	inputLine := "  " + pStyle.Render("❯") + " " + m.TextInput.View()
+	inputLine := "  " + pStyle.Render(prompt) + " " + m.TextInput.View()
 	ResizeSearchViewports(m)
 	body := SearchBody(m)
 
@@ -170,10 +172,15 @@ func resultsViewport(m *model.Model, width, height int) string {
 func DetailsPane(m *model.Model, width, height int) string {
 	innerW := max(1, width-2)
 	headerStyle := m.Styles.Gray
-	if m.DetailsFocused || !DetailsSplit(m) {
+	previewFocused := m.DetailsFocused || !DetailsSplit(m)
+	if previewFocused {
 		headerStyle = m.Styles.HelpHeader
 	}
-	title := headerStyle.Render("Preview")
+	previewLabel := "  Preview"
+	if previewFocused {
+		previewLabel = "▶ Preview"
+	}
+	title := headerStyle.Render(previewLabel)
 	if m.DetailsLoading {
 		title += " " + m.Styles.Spin.Render(m.Spinner.View())
 	}
@@ -210,10 +217,14 @@ func normalizeBlock(content string, width, height int) string {
 
 func Header(m *model.Model) string {
 	w := max(1, m.Width-1)
-	compact := w < 56
+	compact := w < 64
 	var tabs []string
 	m.TabTargets = nil
-	x := model.TabBarLeftPad
+	prefix := " "
+	if !compact {
+		prefix += m.Styles.Brand.Render("hister") + "  "
+	}
+	x := lipgloss.Width(prefix)
 	for _, definition := range model.Tabs {
 		label := definition.Name
 		if compact {
@@ -232,7 +243,7 @@ func Header(m *model.Model) string {
 		})
 		x += tabWidth + model.TabGap
 	}
-	tabBar := " " + strings.Join(tabs, " ")
+	tabBar := prefix + strings.Join(tabs, " ")
 	appendMode := func(full, short string) {
 		label := full
 		if compact {
@@ -250,28 +261,22 @@ func Header(m *model.Model) string {
 		appendMode("[semantic]", "S")
 	}
 
-	cs := m.Styles.Disc.Render("● disconnected")
+	connection := m.Styles.Disc.Render("● offline · retrying…")
 	if m.WsReady {
-		cs = m.Styles.Conn.Render("● connected")
+		connection = m.Styles.Conn.Render("●")
 	}
 
-	var right string
+	var status string
 	if m.Notice != "" {
-		right = m.Styles.Conn.Render("◆ " + m.Notice)
-	} else if m.ConnError != nil && !m.WsReady {
-		right = m.Styles.Disc.Render(m.ConnError.Error())
-	} else if m.IsSearching {
-		right = cs + "  " + m.Styles.Spin.Render(m.Spinner.View()+" searching…")
+		status = renderNotice(m)
+	} else if !m.WsReady {
+		status = connection
 	} else {
-		countStr := "0 results"
-		if m.Results != nil {
-			visibleCount := len(m.Results.History) + len(m.VisibleDocuments())
-			countStr = fmt.Sprintf("%d results", max(int(m.Results.Total)+len(m.Results.History), visibleCount))
-			if m.Results.SearchDuration != "" {
-				countStr += "  " + m.Results.SearchDuration
-			}
-		}
-		right = cs + "  " + m.Styles.Status.Render(countStr)
+		status = workspaceStatus(m)
+	}
+	right := status
+	if m.WsReady && m.Notice == "" {
+		right = connection + "  " + status
 	}
 
 	leftW := lipgloss.Width(tabBar)
@@ -282,6 +287,66 @@ func Header(m *model.Model) string {
 	}
 	pad := max(0, w-leftW-rightW)
 	return tabBar + strings.Repeat(" ", pad) + right
+}
+
+func renderNotice(m *model.Model) string {
+	return renderStatusMessage(m, m.Notice, m.NoticeKind)
+}
+
+func renderStatusMessage(m *model.Model, message string, kind model.NoticeKind) string {
+	prefix := "◆ "
+	style := m.Styles.Status
+	switch kind {
+	case model.NoticeSuccess:
+		prefix, style = "✓ ", m.Styles.Conn
+	case model.NoticeWarning:
+		prefix, style = "! ", m.Styles.Spin
+	case model.NoticeError:
+		prefix, style = "! ", m.Styles.Disc
+	}
+	return style.Render(prefix + sanitizeTerminalLine(message))
+}
+
+func workspaceStatus(m *model.Model) string {
+	switch m.ActiveTab {
+	case model.TabHistory:
+		if m.HistoryLoading {
+			return m.Styles.Spin.Render(m.Spinner.View() + " loading history…")
+		}
+		return m.Styles.Status.Render(itemCount(len(m.HistoryItems), "history item"))
+	case model.TabRules:
+		if m.RulesLoading {
+			return m.Styles.Spin.Render(m.Spinner.View() + " loading rules…")
+		}
+		total := len(m.RulesData.Skip) + len(m.RulesData.Priority) + len(m.RulesData.Versioning) + len(m.RulesData.Aliases)
+		return m.Styles.Status.Render(itemCount(total, "rule"))
+	case model.TabAdd:
+		return m.Styles.Status.Render("Add a document")
+	}
+
+	if m.IsSearching {
+		return m.Styles.Spin.Render(m.Spinner.View() + " searching…")
+	}
+	if strings.TrimSpace(m.TextInput.Value()) == "" {
+		return m.Styles.Status.Render("Type to search")
+	}
+	if m.Results == nil {
+		return m.Styles.Status.Render("No results")
+	}
+	visibleCount := len(m.Results.History) + len(m.VisibleDocuments())
+	total := max(int(m.Results.Total)+len(m.Results.History), visibleCount)
+	count := itemCount(total, "result")
+	if m.Results.SearchDuration != "" {
+		count += "  " + m.Results.SearchDuration
+	}
+	return m.Styles.Status.Render(count)
+}
+
+func itemCount(count int, singular string) string {
+	if count == 1 {
+		return "1 " + singular
+	}
+	return fmt.Sprintf("%d %ss", count, singular)
 }
 
 func keyContext(m *model.Model) component.KeyContext {
@@ -296,7 +361,16 @@ func keyContext(m *model.Model) component.KeyContext {
 	case model.TabAdd:
 		return component.ContextAdd
 	default:
-		return component.ContextSearch
+		if m.State != model.StateInput {
+			return component.ContextSearchResults
+		}
+		if m.Results != nil && m.Results.QuerySuggestion != "" {
+			return component.ContextSearchSuggestion
+		}
+		if m.GetTotalResults() == 0 {
+			return component.ContextSearchInputEmpty
+		}
+		return component.ContextSearchInput
 	}
 }
 
@@ -328,12 +402,7 @@ func overlayMaxWidth(m *model.Model) int {
 // wraps content in a rounded border with drag handle and close button.
 func renderOverlayBox(content string, borderColor color.Color, maxWidth int) string {
 	lines := strings.Split(content, "\n")
-	maxW := 0
-	for _, l := range lines {
-		if w := lipgloss.Width(l); w > maxW {
-			maxW = w
-		}
-	}
+	maxW := lipgloss.Width(content)
 	if maxWidth > 0 && maxW > maxWidth {
 		maxW = maxWidth
 		for i, l := range lines {
@@ -349,7 +418,7 @@ func renderOverlayBox(content string, borderColor color.Color, maxWidth int) str
 	handle := " ≡ "
 	closeBtn := closeSt.Render("[x]")
 	closeBtnW := lipgloss.Width(closeBtn)
-	handleW := len([]rune(handle))
+	handleW := lipgloss.Width(handle)
 	barW := maxW
 	leftHandleW := (barW - handleW) / 2
 	rightHandleW := max(barW-handleW-leftHandleW-closeBtnW, 0)
@@ -402,14 +471,7 @@ func renderOverlay(bg, fg string, bgW, bgH, offX, offY int) string {
 
 func MenuOverlayOffset(m *model.Model) (int, int) {
 	fg := renderOverlayBox(ContextMenu(m), m.Styles.DialogBorder, overlayMaxWidth(m))
-	fgLines := strings.Split(fg, "\n")
-	fgH := len(fgLines)
-	fgW := 0
-	for _, l := range fgLines {
-		if w := lipgloss.Width(l); w > fgW {
-			fgW = w
-		}
-	}
+	fgW, fgH := lipgloss.Width(fg), lipgloss.Height(fg)
 	bgW, bgH := m.Width-1, m.Height
 	offX := m.MenuX - (bgW-fgW)/2
 	offY := m.MenuY - (bgH-fgH)/2
@@ -422,13 +484,7 @@ func OverlayBounds(m *model.Model) (x, y, w, h int) {
 		return
 	}
 	fg := renderOverlayBox(def.content(m), def.border(m), overlayMaxWidth(m))
-	fgLines := strings.Split(fg, "\n")
-	h = len(fgLines)
-	for _, l := range fgLines {
-		if lw := lipgloss.Width(l); lw > w {
-			w = lw
-		}
-	}
+	w, h = lipgloss.Width(fg), lipgloss.Height(fg)
 	bgW, bgH := m.Width-1, m.Height
 	y = max(0, min(bgH-h, (bgH-h)/2+m.OverlayOffY))
 	x = max(0, min(bgW-w, (bgW-w)/2+m.OverlayOffX))

--- a/cmd/tui/render/overlays.go
+++ b/cmd/tui/render/overlays.go
@@ -6,6 +6,7 @@ package render
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/asciimoo/hister/cmd/tui/model"
@@ -26,9 +27,9 @@ func ThemePicker(m *model.Model) string {
 	m.ThemeLightStart, m.ThemeLightCount = lightStart, lightEnd-lightStart
 
 	maxNameW := 0
-	for _, name := range append(darkNames, lightNames...) {
-		if len(name) > maxNameW {
-			maxNameW = len(name)
+	for _, name := range slices.Concat(darkNames, lightNames) {
+		if width := lipgloss.Width(name); width > maxNameW {
+			maxNameW = width
 		}
 	}
 
@@ -46,16 +47,20 @@ func ThemePicker(m *model.Model) string {
 		var slines []string
 		for i, name := range names[start:end] {
 			absoluteIdx := start + i
-			marker := "  "
-			if name == configuredName {
-				marker = "● "
+			focusMarker := "  "
+			if focused && absoluteIdx == cursorIdx {
+				focusMarker = "▸ "
 			}
-			paddedName := name + strings.Repeat(" ", maxNameW-len(name))
+			configuredMarker := "  "
+			if name == configuredName {
+				configuredMarker = "● "
+			}
+			paddedName := name + strings.Repeat(" ", maxNameW-lipgloss.Width(name))
 			swatch := ""
 			if p, ok := theme.GetPalette(name); ok {
 				swatch = renderSwatch(p)
 			}
-			content := marker + paddedName + "  " + swatch
+			content := focusMarker + configuredMarker + paddedName + "  " + swatch
 			if focused && absoluteIdx == cursorIdx {
 				slines = append(slines, m.Styles.ThemePickerSelected.Render(content))
 			} else {
@@ -66,7 +71,8 @@ func ThemePicker(m *model.Model) string {
 	}
 
 	var lines []string
-	lines = append(lines, modeRow, "")
+	lines = append(lines, modeRow)
+	lines = append(lines, m.Styles.Gray.Render("Terminal mode keeps your terminal colors (pass-through)."), "")
 
 	darkFocused := m.ThemePickerSection == 0
 	headerStyle := m.Styles.Gray
@@ -146,8 +152,8 @@ func Settings(m *model.Model) string {
 	maxKeyW := 0
 	for _, it := range items {
 		fk := FormatKey(it.Key)
-		if len([]rune(fk)) > maxKeyW {
-			maxKeyW = len([]rune(fk))
+		if width := lipgloss.Width(fk); width > maxKeyW {
+			maxKeyW = width
 		}
 	}
 
@@ -165,13 +171,13 @@ func Settings(m *model.Model) string {
 	for i, it := range items[start:end] {
 		absoluteIdx := start + i + 1
 		if absoluteIdx == m.SettingsIdx && m.SettingsEditMode {
-			lines = append(lines, m.Styles.ThemePickerSelected.Render("  Press a key...  →  "+string(it.Action)))
+			lines = append(lines, m.Styles.ThemePickerSelected.Render("▸ Press a key...  →  "+string(it.Action)))
 		} else {
 			fk := FormatKey(it.Key)
-			padded := fk + strings.Repeat(" ", maxKeyW-len([]rune(fk)))
+			padded := fk + strings.Repeat(" ", maxKeyW-lipgloss.Width(fk))
 			row := "  " + padded + "  →  " + string(it.Action)
 			if absoluteIdx == m.SettingsIdx {
-				lines = append(lines, m.Styles.ThemePickerSelected.Render(row))
+				lines = append(lines, m.Styles.ThemePickerSelected.Render("▸ "+padded+"  →  "+string(it.Action)))
 			} else {
 				lines = append(lines, m.Styles.ThemePickerItem.Render(row))
 			}
@@ -183,12 +189,12 @@ func Settings(m *model.Model) string {
 	}
 	lines = append(lines, "")
 	if m.SettingsEditMode {
-		lines = append(lines, m.Styles.Hint.Render("press any key to bind  esc cancel"))
+		lines = append(lines, m.Styles.Hint.Render("press any key to bind  esc restore default"))
 	} else {
 		sNav := m.Keys.BestKey(config.ActionScrollDown)
 		sEdit := m.Keys.BestKey(config.ActionOpenResult)
 		sTheme := m.Keys.BestKey(config.ActionToggleTheme)
-		action := "edit"
+		action := "rebind"
 		if m.SettingsIdx == 0 {
 			action = "change mode"
 		}

--- a/cmd/tui/render/render_test.go
+++ b/cmd/tui/render/render_test.go
@@ -31,6 +31,19 @@ func renderModel() *model.Model {
 	return m
 }
 
+func TestLocalHostRecognizesStandardLoopbackForms(t *testing.T) {
+	for _, host := range []string{"localhost", "LOCALHOST:8080", "127.0.0.1:8080", "[::1]:8080", "[::1%lo0]:8080", "::1"} {
+		if !isLocalHost(host) {
+			t.Errorf("isLocalHost(%q) = false", host)
+		}
+	}
+	for _, host := range []string{"example.com", "192.0.2.1", "[2001:db8::1]:8080"} {
+		if isLocalHost(host) {
+			t.Errorf("isLocalHost(%q) = true", host)
+		}
+	}
+}
+
 func prepareSearchRender(m *model.Model) {
 	m.Ready = true
 	m.Viewport = viewport.New(viewport.WithWidth(1), viewport.WithHeight(1))
@@ -251,6 +264,106 @@ func TestSettingsExposeTerminalAppearance(t *testing.T) {
 
 	if !strings.Contains(settings, "Appearance  Terminal (pass-through)") {
 		t.Fatalf("settings do not expose terminal appearance:\n%s", settings)
+	}
+}
+
+func TestComfortableHeaderEstablishesBrandAndWorkspaceHierarchy(t *testing.T) {
+	t.Setenv("NO_COLOR", "")
+	m := renderModel()
+	header := ansi.Strip(Header(m))
+
+	if !strings.HasPrefix(header, " hister  [Search]") {
+		t.Fatalf("comfortable header lacks brand/workspace hierarchy: %q", header)
+	}
+	if len(m.TabTargets) == 0 || m.TabTargets[0].X0 <= model.TabBarLeftPad {
+		t.Fatalf("branded header did not shift tab hit targets: %#v", m.TabTargets)
+	}
+}
+
+func TestSearchEmptyStatesExplainTheNextStep(t *testing.T) {
+	m := renderModel()
+	m.WsReady = true
+	prepareSearchRender(m)
+	initial := ansi.Strip(m.Viewport.View())
+	if !strings.Contains(initial, "Search your history") || !strings.Contains(initial, "Type above") {
+		t.Fatalf("initial search state is not actionable:\n%s", initial)
+	}
+
+	m.TextInput.SetValue("wrod")
+	m.Results = &indexer.Results{QuerySuggestion: "word"}
+	RefreshViewport(m)
+	empty := ansi.Strip(m.Viewport.View())
+	for _, want := range []string{"No results for “wrod”", "Did you mean “word”?", "Press Enter to try it"} {
+		if !strings.Contains(empty, want) {
+			t.Errorf("no-result state is missing %q:\n%s", want, empty)
+		}
+	}
+}
+
+func TestOfflineSearchStateExplainsRecovery(t *testing.T) {
+	m := renderModel()
+	m.TextInput.SetValue("kept query")
+	prepareSearchRender(m)
+	content := ansi.Strip(m.Viewport.View())
+	if !strings.Contains(content, "Search is offline") || !strings.Contains(content, "reconnecting automatically") {
+		t.Fatalf("offline state is misleading:\n%s", content)
+	}
+}
+
+func TestResultSelectionDistinguishesFocusFromRetention(t *testing.T) {
+	m := renderModel()
+	m.Results = &indexer.Results{Documents: []*document.Document{{
+		URL: "https://example.com", Title: "Selected result",
+	}}}
+	m.SelectedIdx = 0
+	m.State = model.StateInput
+	prepareSearchRender(m)
+	inactive := ansi.Strip(m.Viewport.View())
+	if !strings.Contains(inactive, "│") || strings.Contains(inactive, "┃") {
+		t.Fatalf("retained selection looks focused:\n%s", inactive)
+	}
+
+	m.State = model.StateResults
+	RefreshViewport(m)
+	active := ansi.Strip(m.Viewport.View())
+	if !strings.Contains(active, "┃") {
+		t.Fatalf("focused result lacks a strong focus marker:\n%s", active)
+	}
+}
+
+func TestSelectedResultTitleStyleResumesAfterSearchHighlight(t *testing.T) {
+	m := renderModel()
+	m.State = model.StateResults
+	highlight := lipgloss.NewStyle().Foreground(lipgloss.Color("205")).Bold(true)
+	doc := &document.Document{
+		URL:   "https://example.com",
+		Title: "Before " + highlight.Render("match") + " after",
+	}
+
+	rendered := Document(m, doc, true, 60)
+	if want := m.Styles.SelTitle.Render(" after"); !strings.Contains(rendered, want) {
+		t.Fatalf("selected title style was not restored after highlight reset:\n%q\nwant segment %q", rendered, want)
+	}
+	if got := ansi.Strip(rendered); !strings.Contains(got, "Before match after") {
+		t.Fatalf("styled title changed its text: %q", got)
+	}
+}
+
+func TestHeaderStatusMatchesTheActiveWorkspace(t *testing.T) {
+	m := renderModel()
+	m.WsReady = true
+	m.ActiveTab = model.TabHistory
+	m.HistoryItems = []model.HistoryItem{{}, {}}
+	header := ansi.Strip(Header(m))
+	if !strings.Contains(header, "2 history items") || strings.Contains(header, "results") {
+		t.Fatalf("history header reports the wrong workspace status: %q", header)
+	}
+
+	m.Notice = "Could not save rules"
+	m.NoticeKind = model.NoticeError
+	header = ansi.Strip(Header(m))
+	if !strings.Contains(header, "! Could not save rules") {
+		t.Fatalf("error notice relies on color alone: %q", header)
 	}
 }
 

--- a/cmd/tui/render/results.go
+++ b/cmd/tui/render/results.go
@@ -13,19 +13,31 @@ import (
 	smodel "github.com/asciimoo/hister/server/model"
 
 	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
 )
 
 func Results(m *model.Model) string {
 	documents := m.VisibleDocuments()
 	if m.Results == nil || (len(documents) == 0 && len(m.Results.History) == 0) {
 		m.LineOffsets = nil
+		m.SuggestionHeight = 0
 		if m.IsSearching {
 			return m.Styles.Gray.Render("  " + m.Spinner.View() + " searching…")
 		}
-		if m.TextInput.Value() != "" {
-			return m.Styles.Gray.Render("  No results found")
+		query := sanitizeTerminalLine(m.TextInput.Value())
+		if !m.WsReady {
+			return emptyState(m, "Search is offline", "Hister is reconnecting automatically. Your query will stay here.")
 		}
-		return m.Styles.Gray.Render("  " + model.SearchTips[m.TipIdx])
+		if query != "" {
+			title := "No results for “" + truncateLine(query, max(8, m.Viewport.Width()-22)) + "”"
+			detail := "Try fewer words or check the spelling."
+			if m.Results != nil && m.Results.QuerySuggestion != "" {
+				suggestion := sanitizeTerminalLine(m.Results.QuerySuggestion)
+				detail = "Did you mean “" + truncateLine(suggestion, max(8, m.Viewport.Width()-24)) + "”? Press Enter to try it."
+			}
+			return emptyState(m, title, detail)
+		}
+		return emptyState(m, "Search your history", "Type above to search indexed content and past visits.")
 	}
 	var items []string
 	var lineOffsets []int
@@ -69,7 +81,7 @@ func Results(m *model.Model) string {
 			}
 			lastDomain = d.Domain
 			domLabel := strings.TrimPrefix(d.Domain, "www.")
-			ruleW := max(0, w-len([]rune(domLabel))-3)
+			ruleW := max(0, w-lipgloss.Width(domLabel)-3)
 			domDiv := "  " + m.Styles.DomainHeader.Render(domLabel) + " " + m.Styles.Div.Render(strings.Repeat("─", ruleW))
 			items = append(items, domDiv)
 			currentLine += lipgloss.Height(domDiv) + 1
@@ -94,14 +106,14 @@ func Results(m *model.Model) string {
 		totalAvailable := max(int(m.Results.Total)+len(m.Results.History), totalItems)
 		rem := max(0, totalAvailable-m.Limit)
 		var content string
-		if currentIdx == m.SelectedIdx {
+		if currentIdx == m.SelectedIdx && resultListFocused(m) {
 			content = m.Styles.LoadMoreSelected.Render(fmt.Sprintf("[ ▼ Load 10 more (%d remaining) ]", rem))
 		} else {
 			content = m.Styles.LoadMore.Render(fmt.Sprintf("[ ▼ Load 10 more (%d remaining) ]", rem))
 		}
 		var item string
 		if currentIdx == m.SelectedIdx {
-			item = style.Render(m.Styles.SelectedItem.Render(content))
+			item = style.Render(selectedResultStyle(m).Render(content))
 		} else {
 			item = style.Render(m.Styles.Item.Render(content))
 		}
@@ -110,7 +122,7 @@ func Results(m *model.Model) string {
 
 	output := strings.Join(items, "\n\n")
 	if m.Results.QuerySuggestion != "" {
-		sugg := "  " + m.Styles.SuggLabel.Render("did you mean: ") + m.Styles.SuggTerm.Render(m.Results.QuerySuggestion)
+		sugg := "  " + m.Styles.SuggLabel.Render("did you mean: ") + m.Styles.SuggTerm.Render(sanitizeTerminalLine(m.Results.QuerySuggestion))
 		suggH := lipgloss.Height(sugg) + 1
 		for i := range lineOffsets {
 			lineOffsets[i] += suggH
@@ -124,9 +136,33 @@ func Results(m *model.Model) string {
 	return output
 }
 
+func emptyState(m *model.Model, title, detail string) string {
+	return strings.Join([]string{
+		"",
+		"  " + m.Styles.HelpHeader.Render(title),
+		"  " + m.Styles.Gray.Render(detail),
+	}, "\n")
+}
+
+func resultListFocused(m *model.Model) bool {
+	return m.State == model.StateResults ||
+		(m.State == model.StateDetails && renderResultsPaneFocused(m))
+}
+
+func renderResultsPaneFocused(m *model.Model) bool {
+	return DetailsSplit(m) && !m.DetailsFocused
+}
+
+func selectedResultStyle(m *model.Model) lipgloss.Style {
+	if resultListFocused(m) {
+		return m.Styles.SelectedItem
+	}
+	return m.Styles.SelectedItemBlur
+}
+
 func HistoryItem(m *model.Model, h *smodel.URLCount, sel bool, contentW int) string {
 	ts := m.Styles.Title
-	if sel {
+	if sel && resultListFocused(m) {
 		ts = m.Styles.SelTitle
 	}
 	const badgeW = 4
@@ -139,20 +175,20 @@ func HistoryItem(m *model.Model, h *smodel.URLCount, sel bool, contentW int) str
 	}
 
 	titleMaxW := max(1, contentW-badgeW-countW)
-	titleRendered := ts.Render(truncateLine(strings.Join(strings.Fields(h.Title), " "), titleMaxW))
+	titleRendered := renderTitle(ts, strings.Join(strings.Fields(h.Title), " "), titleMaxW)
 	titleLine := m.Styles.Hist.Render("[H] ") + rightPad(titleRendered, contentW-badgeW-countW) +
 		strings.Repeat(" ", max(0, countW-lipgloss.Width(countRendered))) + countRendered
 
 	content := titleLine + "\n" + renderURL(m.Styles, h.URL, "", contentW)
 	if sel {
-		return m.Styles.SelectedItem.Render(content)
+		return selectedResultStyle(m).Render(content)
 	}
 	return m.Styles.Item.Render(content)
 }
 
 func Document(m *model.Model, d *document.Document, sel bool, contentW int) string {
 	ts := m.Styles.Title
-	if sel {
+	if sel && resultListFocused(m) {
 		ts = m.Styles.SelTitle
 	}
 
@@ -178,7 +214,7 @@ func Document(m *model.Model, d *document.Document, sel bool, contentW int) stri
 	}
 
 	titleMaxW := max(1, contentW-timeW-domainBadgeW-labelBadgeW)
-	titleRendered := ts.Render(truncateLine(strings.Join(strings.Fields(d.Title), " "), titleMaxW))
+	titleRendered := renderTitle(ts, strings.Join(strings.Fields(d.Title), " "), titleMaxW)
 	titleLine := labelBadge + domainBadge + rightPad(titleRendered, contentW-timeW-domainBadgeW-labelBadgeW) +
 		strings.Repeat(" ", max(0, timeW-lipgloss.Width(timeRendered))) + timeRendered
 
@@ -192,9 +228,27 @@ func Document(m *model.Model, d *document.Document, sel bool, contentW int) stri
 		sb.WriteString(m.Styles.SecText.Render(snippet))
 	}
 	if sel {
-		return m.Styles.SelectedItem.Render(sb.String())
+		return selectedResultStyle(m).Render(sb.String())
 	}
 	return m.Styles.Item.Render(sb.String())
+}
+
+// renderTitle reapplies the title style after each search-highlight reset.
+// The server's TUI highlighter wraps matches in its own SGR style, whose reset
+// would otherwise also cancel the surrounding selected-title color.
+func renderTitle(style lipgloss.Style, title string, maxW int) string {
+	title = truncateLine(title, maxW)
+	// Lip Gloss emits ESC[m, while accepting ESC[0m from other SGR producers
+	// costs little and keeps the style boundary well-defined.
+	title = strings.ReplaceAll(title, "\x1b[0m", ansi.ResetStyle)
+	parts := strings.Split(title, ansi.ResetStyle)
+	var rendered strings.Builder
+	for _, part := range parts {
+		if part != "" {
+			rendered.WriteString(style.Render(part))
+		}
+	}
+	return rendered.String()
 }
 
 func Scrollbar(m *model.Model) string {

--- a/cmd/tui/render/tabs.go
+++ b/cmd/tui/render/tabs.go
@@ -19,7 +19,7 @@ func HistoryTab(m *model.Model) string {
 		return m.Styles.Gray.Render("  " + m.Spinner.View() + " loading…")
 	}
 	if len(m.HistoryItems) == 0 {
-		return m.Styles.Gray.Render("  No history items")
+		return workspaceEmptyState(m, "No history yet", "Open a search result and it will appear here.")
 	}
 	contentW := max(1, m.Width-5)
 	var lines []string
@@ -114,7 +114,7 @@ func RulesTab(m *model.Model) string {
 			if section.ID == m.RulesSection && m.RulesFormFocus == model.RulesFocusList {
 				m.WorkspaceSelectionY = formY
 			}
-			lines = append(lines, m.Styles.Gray.Render("    (none)"))
+			lines = append(lines, m.Styles.Gray.Render("    No entries yet — use the form above to add one."))
 		}
 		for i, item := range items {
 			var row string
@@ -188,7 +188,15 @@ func AddTab(m *model.Model) string {
 	lines = append(lines, submit)
 	if m.AddStatus != "" {
 		lines = append(lines, "")
-		lines = append(lines, "  "+m.Styles.Conn.Render(m.AddStatus))
+		lines = append(lines, "  "+renderStatusMessage(m, m.AddStatus, m.AddStatusKind))
 	}
 	return strings.Join(lines, "\n")
+}
+
+func workspaceEmptyState(m *model.Model, title, detail string) string {
+	return strings.Join([]string{
+		"",
+		"  " + m.Styles.HelpHeader.Render(title),
+		"  " + m.Styles.Gray.Render(detail),
+	}, "\n")
 }

--- a/cmd/tui/render/util.go
+++ b/cmd/tui/render/util.go
@@ -6,6 +6,8 @@ package render
 
 import (
 	"fmt"
+	"net"
+	"net/netip"
 	"net/url"
 	"strings"
 	"time"
@@ -90,13 +92,18 @@ func renderURL(st theme.Styles, rawURL, domain string, maxW int) string {
 	}
 
 	const sepStr = " · "
-	pathMaxW := max(0, maxW-hostW-len([]rune(sepStr)))
+	pathMaxW := max(0, maxW-hostW-lipgloss.Width(sepStr))
 	return hostPart + st.URLPath.Render(sepStr) + st.URLPath.Render(truncateLine(path, pathMaxW))
 }
 
 func isLocalHost(host string) bool {
-	h, _, _ := strings.Cut(host, ":")
-	return h == "localhost" || h == "127.0.0.1" || h == "::1"
+	h := host
+	if parsed, _, err := net.SplitHostPort(host); err == nil {
+		h = parsed
+	}
+	h = strings.Trim(h, "[]")
+	addr, err := netip.ParseAddr(h)
+	return strings.EqualFold(h, "localhost") || err == nil && addr.IsLoopback()
 }
 
 // renders a subtle full-width rule.
@@ -129,6 +136,10 @@ func sanitizeTerminalText(s string) string {
 		}
 		return r
 	}, s)
+}
+
+func sanitizeTerminalLine(s string) string {
+	return strings.Join(strings.Fields(sanitizeTerminalText(s)), " ")
 }
 
 func FormatKey(k string) string {

--- a/cmd/tui/theme/styles.go
+++ b/cmd/tui/theme/styles.go
@@ -63,6 +63,7 @@ type Styles struct {
 	// List items
 	Item             lipgloss.Style
 	SelectedItem     lipgloss.Style
+	SelectedItemBlur lipgloss.Style
 	LoadMore         lipgloss.Style
 	LoadMoreSelected lipgloss.Style
 
@@ -141,9 +142,14 @@ func BuildStyles(p Palette) Styles {
 
 		Item: lipgloss.NewStyle().PaddingLeft(2),
 		SelectedItem: lipgloss.NewStyle().
-			BorderStyle(lipgloss.NormalBorder()).
+			BorderStyle(lipgloss.ThickBorder()).
 			BorderLeft(true).
 			BorderForeground(c(p.Base0D)).
+			PaddingLeft(1),
+		SelectedItemBlur: lipgloss.NewStyle().
+			BorderStyle(lipgloss.NormalBorder()).
+			BorderLeft(true).
+			BorderForeground(c(p.Base03)).
 			PaddingLeft(1),
 		LoadMore: lipgloss.NewStyle().Foreground(c(p.Base09)).Bold(true),
 		LoadMoreSelected: lipgloss.NewStyle().

--- a/cmd/tui/tui.go
+++ b/cmd/tui/tui.go
@@ -37,6 +37,8 @@ func (a *app) View() tea.View {
 	v := tea.NewView(render.View(a.m))
 	v.AltScreen = true
 	v.MouseMode = tea.MouseModeCellMotion
+	// A nil color tells Bubble Tea to retain the terminal's configured color.
+	// Full themes opt in to painting the screen; terminal/no-color modes do not.
 	if a.m.Cfg.TUI.ColorScheme != theme.TerminalName && a.m.ThemeName != "no-color" {
 		v.BackgroundColor = a.m.BackgroundColor
 		v.ForegroundColor = a.m.ForegroundColor

--- a/cmd/tui/tui_test.go
+++ b/cmd/tui/tui_test.go
@@ -59,6 +59,8 @@ func TestNoColorViewLeavesTerminalColorsUnset(t *testing.T) {
 func TestTerminalAppearanceLeavesTerminalColorsUnset(t *testing.T) {
 	t.Setenv("NO_COLOR", "")
 	a := testApp(t)
+	a.m.Ready = true
+	a.m.Width, a.m.Height = 80, 24
 	v := a.View()
 
 	if a.m.ThemeName != theme.TerminalName {
@@ -66,6 +68,9 @@ func TestTerminalAppearanceLeavesTerminalColorsUnset(t *testing.T) {
 	}
 	if v.BackgroundColor != nil || v.ForegroundColor != nil {
 		t.Fatalf("terminal view declared screen colors: background=%v foreground=%v", v.BackgroundColor, v.ForegroundColor)
+	}
+	if v.WindowTitle != "" {
+		t.Fatalf("TUI took ownership of shell-managed window title: %q", v.WindowTitle)
 	}
 }
 

--- a/webui/website/src/content/docs/terminal-client.md
+++ b/webui/website/src/content/docs/terminal-client.md
@@ -231,7 +231,7 @@ hister search
 - **Responsive preview pane**: Read results beside the result list on wide terminals; smaller terminals switch the preview to full width
 - **Semantic search**: Toggle hybrid keyword/semantic results when semantic search is enabled
 - **Theming**: Built-in color themes with interactive picker (press `ctrl+t`)
-- **Settings overlay**: Edit keybindings interactively (press `ctrl+s`)
+- **Settings overlay**: Change appearance mode or edit keybindings interactively (press `ctrl+s`)
 - **Responsive workspaces**: Every tab scrolls and adapts to the terminal size
 - **Contextual help and feedback**: Footer shortcuts match the active tab, while notices confirm actions
 
@@ -259,7 +259,7 @@ The TUI uses the following keybindings by default:
 | `l`          | edit_label      | Edit the selected document's label                   |
 | `ctrl+d`     | delete_result   | Delete the selected item                             |
 | `ctrl+t`     | toggle_theme    | Open the interactive theme picker                    |
-| `ctrl+s`     | toggle_settings | Open the keybinding editor overlay                   |
+| `ctrl+s`     | toggle_settings | Open appearance and keybinding settings              |
 | `ctrl+o`     | toggle_sort     | Toggle domain-based sorting for search results       |
 | `ctrl+e`     | toggle_semantic | Toggle semantic search when enabled in server config |
 | `alt+1`      | tab_search      | Switch to the Search tab                             |
@@ -279,6 +279,11 @@ result list and the preview. Arrow keys or `j`/`k` then navigate the focused
 side. Clicking or scrolling either side focuses it. Press `v`, `esc`, or the
 `×` in the preview header to close it.
 
+Search input and result navigation are separate focus modes. While the search
+field is focused, printable keys edit the query and the footer only shows input
+actions. Press `down` or `tab`, or scroll/click inside the results, to focus the
+result list; result shortcuts such as `y` and `v` then become available.
+
 ### Customizing TUI
 
 TUI settings are stored in a separate `tui.yaml` file alongside your main config file. This file is automatically created with default values when you first run `hister search`.
@@ -291,7 +296,7 @@ On a typical Linux setup the path is `~/.config/hister/tui.yaml`. On other platf
 # Theme settings
 dark_theme: 'tokyonight'
 light_theme: 'catppuccin-latte'
-color_scheme: 'auto'
+color_scheme: 'terminal'
 # themes_dir: "/path/to/custom/themes"  # optional
 
 # TUI keybindings
@@ -311,6 +316,13 @@ hotkeys:
   # ... and all other TUI keybindings
 ```
 
+`terminal` is the default appearance. It leaves your terminal background and
+normal text color untouched and uses your terminal's ANSI palette for accents.
+Use `auto` to select the configured dark or light Hister theme based on the
+terminal background, or choose `dark` or `light` explicitly. Press `ctrl+s`
+and select **Appearance** to cycle these modes from Settings; `ctrl+t` opens the
+full theme picker.
+
 #### Available TUI Actions
 
 - `quit` - Exit the TUI application
@@ -323,7 +335,7 @@ hotkeys:
 - `edit_label` - Edit the selected document label
 - `delete_result` - Delete selected entry from index
 - `toggle_theme` - Open theme picker
-- `toggle_settings` - Open keybinding editor
+- `toggle_settings` - Open appearance and keybinding settings
 - `toggle_sort` - Toggle sorting mode
 - `toggle_semantic` - Toggle semantic search
 - `tab_search`/`tab_history`/`tab_rules`/`tab_add` - Switch tabs


### PR DESCRIPTION
The search view could highlight a result while the query input still owned the keyboard.
Enter could then open that result, while mouse-wheel navigation could move the selection
without moving keyboard focus

Empty responses could also leave result focus with nothing to select, including beneath
nested overlays

This aligns selection, keyboard routing, mouse interaction, and footer hints with the
control that actually owns focus

Search responses no longer steal input focus, empty results return focus to the query,
and query suggestions remain actionable. It also adds clearer empty, offline, notice,
and workspace status states and keeps previews and overlays usable on narrow terminals