### PR TITLE
Allow safari-web-extension:// origin in CSRF allowlist

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -358,6 +358,10 @@ func withCSRF(handler endpointHandler) endpointHandler {
 				handler(c)
 				return
 			}
+			if strings.HasPrefix(c.Request.Header.Get("Origin"), "safari-web-extension://") {
+				handler(c)
+				return
+			}
 			if c.Request.Header.Get("Origin") == "chrome-extension://cciilamhchpmbdnniabclekddabkifhb" {
 				handler(c)
 				return


### PR DESCRIPTION
I'm using the Safari extension from #108. The CSRF check didn't let it through by default, so this PR adds a check for the Safari specific origin, similar to how Chrome and Safari are handled. 

The extension now works (and I'm aware of all the hoops I'll have to jump through to use it unless it's signed). 