### PR TITLE
[enh] allow safari-web-extension origin - refs #49

### DIFF
--- a/server/origin_test.go
+++ b/server/origin_test.go
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package server
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/asciimoo/hister/server/testutil"
+)
+
+func TestBrowserExtensionOriginsBypassCSRF(t *testing.T) {
+	// A POST to a rules endpoint requires either a valid CSRF token or an
+	// origin that withCSRF explicitly trusts. Requests from the packaged
+	// browser extensions should be trusted; a random cross-origin request
+	// should not.
+	_, handler := newTokenTestServer(t, false)
+
+	cases := []struct {
+		name       string
+		origin     string
+		wantAllowed bool
+	}{
+		{"firefox", "moz-extension://a1b2c3d4-e5f6-7890-1234-567890abcdef", true},
+		{"chrome", "chrome-extension://cciilamhchpmbdnniabclekddabkifhb", true},
+		{"safari", "safari-web-extension://12345678-90AB-CDEF-1234-567890ABCDEF", true},
+		{"unknown", "https://random.example", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := testutil.ServeHTTP(t, handler, http.MethodPost, "/api/rules",
+				strings.NewReader("skip=&priority="),
+				map[string]string{
+					"Content-Type":   "application/x-www-form-urlencoded",
+					"Origin":         tc.origin,
+					"X-Access-Token": "secret",
+				})
+			gotForbidden := rec.Code == http.StatusForbidden
+			if gotForbidden == tc.wantAllowed {
+				t.Fatalf("POST /api/rules from %s: status = %d, want-allowed = %v",
+					tc.origin, rec.Code, tc.wantAllowed)
+			}
+		})
+	}
+}

--- a/server/server.go
+++ b/server/server.go
@@ -358,6 +358,10 @@ func withCSRF(handler endpointHandler) endpointHandler {
 				handler(c)
 				return
 			}
+			if strings.HasPrefix(c.Request.Header.Get("Origin"), "safari-web-extension://") {
+				handler(c)
+				return
+			}
 			if c.Request.Header.Get("Origin") == "chrome-extension://cciilamhchpmbdnniabclekddabkifhb" {
 				handler(c)
 				return


### PR DESCRIPTION
Accept requests from \`safari-web-extension://\` origins on the same subset of endpoints already trusted for \`moz-extension://\` and the packaged Chrome extension. This is the one server-side change needed to make an unofficial signed Safari build of the extension work against a stock Hister server.

Motivation: [#49](https://github.com/asciimoo/hister/issues/49) — you asked contributors to publish/maintain a Safari extension out-of-tree, and offered to accept upstream changes needed on the Hister side. This is that change.

## What changed

- \`server/server.go\` — one additional \`strings.HasPrefix\` on \`Origin\` inside the existing per-path loop in \`withCSRF\`, mirroring the Firefox case. Behavior is unchanged for all existing browsers and origins.
- \`server/origin_test.go\` — new table-driven test covering the three trusted extension prefixes plus a rejected control origin, exercised against \`POST /api/rules\`.

## Verification

- \`go test ./server/...\` passes (full suite).
- Tested end-to-end locally with a Safari build of the extension: enabling the origin allowlist entry lets \`/api/config\`, \`/api/rules\` and \`/api/add\` succeed; without it every request returns 403 as before.

## Scope

Deliberately minimal — no CORS overhaul, no changes to the Chrome/Firefox origin handling, no other files touched. Happy to fold in a stricter allowlist (e.g. gating on a specific Safari extension bundle UUID) if you prefer, but Safari's per-installation UUIDs make a fixed identity check impractical.

The out-of-tree Safari packaging work lives separately and will be published as unofficial per the discussion in #49.