### PR TITLE
Add config option to add domains to ytdlp extractor

### DIFF
--- a/server/extractor/extractors/ytdlp/ytdlp.go
+++ b/server/extractor/extractors/ytdlp/ytdlp.go
@@ -58,6 +58,7 @@ func (e *YtdlpExtractor) GetConfig() *sdk.Config {
 				"max_concurrent_jobs": defaultMaxConcurrentJobs,
 				"fetch_subtitles":     false,
 				"sub_language":        "auto",
+				"extra_domains":       [...]string{},
 			},
 		}
 	}
@@ -68,7 +69,7 @@ func (e *YtdlpExtractor) SetConfig(c *sdk.Config) error {
 	for k := range c.Options {
 		switch k {
 		case "binary", "timeout", "max_concurrent_jobs", "fetch_subtitles", "sub_language",
-			"cookies_file", "cookies_from_browser", "extra_args":
+			"cookies_file", "cookies_from_browser", "extra_args", "extra_domains":
 		default:
 			return fmt.Errorf("unknown option %q", k)
 		}
@@ -181,8 +182,14 @@ func (e *YtdlpExtractor) Match(d *sdk.Document) bool {
 			break
 		}
 	}
+
+	var extra_domains []string
+	if l, ok := e.GetConfig().Options["extra_domains"].([]string); ok && len(l) > 0 {
+		extra_domains = l
+	}
+
 	if !matched {
-		for _, sub := range knownHostSubstrings {
+		for _, sub := range append(knownHostSubstrings, extra_domains...) {
 			if strings.Contains(host, sub) {
 				matched = true
 				break

--- a/server/extractor/extractors/ytdlp/ytdlp.go
+++ b/server/extractor/extractors/ytdlp/ytdlp.go
@@ -58,7 +58,7 @@ func (e *YtdlpExtractor) GetConfig() *sdk.Config {
 				"max_concurrent_jobs": defaultMaxConcurrentJobs,
 				"fetch_subtitles":     false,
 				"sub_language":        "auto",
-				"extra_domains":       [...]string{},
+				"extra_domains":       [0]string{},
 			},
 		}
 	}
@@ -174,22 +174,27 @@ func (e *YtdlpExtractor) Match(d *sdk.Document) bool {
 	if err != nil {
 		return false
 	}
+
+	var extraDomains []string
+	if l, ok := e.GetConfig().Options["extra_domains"].([]any); ok && len(l) > 0 {
+		for _, v := range l {
+			if s, ok := v.(string); ok {
+				extraDomains = append(extraDomains, s)
+			}
+		}
+	}
+
 	host := strings.ToLower(u.Hostname())
 	matched := false
-	for _, domain := range knownDomains {
+	for _, domain := range append(knownDomains, extraDomains...) {
 		if host == domain || strings.HasSuffix(host, "."+domain) {
 			matched = true
 			break
 		}
 	}
 
-	var extra_domains []string
-	if l, ok := e.GetConfig().Options["extra_domains"].([]string); ok && len(l) > 0 {
-		extra_domains = l
-	}
-
 	if !matched {
-		for _, sub := range append(knownHostSubstrings, extra_domains...) {
+		for _, sub := range knownHostSubstrings {
 			if strings.Contains(host, sub) {
 				matched = true
 				break

--- a/server/extractor/extractors/ytdlp/ytdlp_test.go
+++ b/server/extractor/extractors/ytdlp/ytdlp_test.go
@@ -271,7 +271,7 @@ func TestMatch(t *testing.T) {
 		{"https://example.com/page", false},
 		{"https://stackoverflow.com/questions/123", false},
 		{"https://example.com/path/youtube.com/fake", false},
-		{"https://nebula.tv/videos/bigjoel-the-highs-and-lows-of-rupi-kaur", true},
+		{"https://nebula.tv/videos/some-video", true},
 	}
 
 	if err := e.SetConfig(&config.Extractor{

--- a/server/extractor/extractors/ytdlp/ytdlp_test.go
+++ b/server/extractor/extractors/ytdlp/ytdlp_test.go
@@ -271,7 +271,18 @@ func TestMatch(t *testing.T) {
 		{"https://example.com/page", false},
 		{"https://stackoverflow.com/questions/123", false},
 		{"https://example.com/path/youtube.com/fake", false},
+		{"https://nebula.tv/videos/bigjoel-the-highs-and-lows-of-rupi-kaur", true},
 	}
+
+	if err := e.SetConfig(&config.Extractor{
+		Enable: true,
+		Options: map[string]any{
+			"extra_domains": []string{"nebula.tv"},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
 	for _, tt := range tests {
 		d := &document.Document{URL: tt.url}
 		if got := e.Match(d); got != tt.want {

--- a/server/extractor/extractors/ytdlp/ytdlp_test.go
+++ b/server/extractor/extractors/ytdlp/ytdlp_test.go
@@ -277,7 +277,7 @@ func TestMatch(t *testing.T) {
 	if err := e.SetConfig(&config.Extractor{
 		Enable: true,
 		Options: map[string]any{
-			"extra_domains": []string{"nebula.tv"},
+			"extra_domains": []any{"nebula.tv"},
 		},
 	}); err != nil {
 		t.Fatal(err)

--- a/webui/website/src/content/docs/extractors.md
+++ b/webui/website/src/content/docs/extractors.md
@@ -57,6 +57,12 @@ description: 'Understand and configure the built in content handlers used for in
       defaultValue: '(none)',
       description: 'Additional yt-dlp command line flags appended verbatim to every invocation.',
     },
+    {
+      name: 'extra_domains',
+      type: 'string[]',
+      defaultValue: '(none)',
+      description: 'Additional domains to match this extractor. They should take the form "domain.tld", e.g. "vimeo.com". Check the yt-dlp repository for a full list of supported sites.'
+    }
   ];
 </script>
 
@@ -336,7 +342,7 @@ installed separately.
 
 **Matches:** a curated list of video-hosting domains (YouTube, Vimeo, Twitch,
 Dailymotion, Bilibili, and others), as well as any hostname containing common
-video-platform substrings.
+video-platform substrings. Additional domains can be matched using the `extra_domains` option.
 
 #### Options
 
@@ -358,6 +364,8 @@ extractors:
       extra_args:
         - --proxy
         - socks5://127.0.0.1:1080
+      extra_domains:
+        - vimeo.com
 ```
 
 ### `readability`


### PR DESCRIPTION
`yt-dlp` has support for [many sites](https://github.com/yt-dlp/yt-dlp/blob/master/supportedsites.md), but the list has caveats (e.g. some sites need an authenticated session to function) and updates frequently, making it unreasonable for hister's ytdlp extractor to match all of them. This PR adds an `extra_domains` config option so that the user can add more sites to the matcher on their own.

Claude Code was consulted for review but didn't get to write any of the code directly.