### PR TITLE
Add a HackerNews extractor

### DIFF
--- a/server/extractor/extractor_test.go
+++ b/server/extractor/extractor_test.go
@@ -221,6 +221,7 @@ func TestDefaultRegistryOrder(t *testing.T) {
 		"GoDoc",
 		"GitHub",
 		"Lobsters",
+		"HackerNews",
 		"Wikipedia",
 		"Mastodon",
 		"Bluesky",

--- a/server/extractor/extractors/discourse/discourse.go
+++ b/server/extractor/extractors/discourse/discourse.go
@@ -16,6 +16,7 @@ import (
 	"golang.org/x/net/html"
 
 	"github.com/asciimoo/hister/server/extractor/sdk"
+	"github.com/asciimoo/hister/server/extractor/textutil"
 	"github.com/asciimoo/hister/server/extractor/urlutil"
 	"github.com/asciimoo/hister/server/sanitizer"
 )
@@ -389,21 +390,21 @@ func parsePreloadedTags(raw json.RawMessage) []string {
 
 func readTopicHeader(topic *discourseTopic, doc *goquery.Document) {
 	topic.Title = firstNonempty(
-		selectionText(doc.Find(`#topic-title h1 a`).First()),
-		selectionText(doc.Find(`h1[data-topic-id]`).First()),
+		textutil.SelectionText(doc.Find(`#topic-title h1 a`).First()),
+		textutil.SelectionText(doc.Find(`h1[data-topic-id]`).First()),
 		metaContent(doc, `meta[property="og:title"]`, `meta[name="twitter:title"]`),
 		topic.Title,
 	)
 	if topic.Category == "" {
 		topic.Category = firstNonempty(
-			selectionText(doc.Find(`#topic-title .badge-category__name`).First()),
-			selectionText(doc.Find(`#topic-title .category-name`).First()),
+			textutil.SelectionText(doc.Find(`#topic-title .badge-category__name`).First()),
+			textutil.SelectionText(doc.Find(`#topic-title .category-name`).First()),
 			metaContent(doc, `meta[property="og:article:section"]`),
 		)
 	}
 	if len(topic.Tags) == 0 {
 		doc.Find(`#topic-title .discourse-tag`).Each(func(_ int, tag *goquery.Selection) {
-			if value := selectionText(tag); value != "" {
+			if value := textutil.SelectionText(tag); value != "" {
 				topic.Tags = append(topic.Tags, value)
 			}
 		})
@@ -426,7 +427,7 @@ func parseRenderedPosts(doc *goquery.Document, base *url.URL) []discoursePost {
 		body.Find(`script, style, button, .cooked-selection-barrier, .post-menu-area`).Remove()
 		urlutil.RewriteURLs(body, base)
 		bodyHTML, _ := body.Html()
-		bodyText := selectionText(body)
+		bodyText := textutil.SelectionText(body)
 		if bodyText == "" {
 			return
 		}
@@ -849,7 +850,7 @@ func extractContentHTML(rawHTML string, base *url.URL) (string, string) {
 	body.Find("script, style, button, .cooked-selection-barrier, .post-menu-area").Remove()
 	urlutil.RewriteURLs(body, base)
 	content, _ := body.Html()
-	return selectionText(body), content
+	return textutil.SelectionText(body), content
 }
 
 func cleanStrings(values []string) []string {
@@ -896,7 +897,7 @@ func metaContent(doc *goquery.Document, selectors ...string) string {
 
 func firstSelectionText(root *goquery.Selection, selectors ...string) string {
 	for _, selector := range selectors {
-		if value := selectionText(root.Find(selector).First()); value != "" {
+		if value := textutil.SelectionText(root.Find(selector).First()); value != "" {
 			return value
 		}
 	}
@@ -914,7 +915,7 @@ func firstSelectionAttr(root *goquery.Selection, attr string, selectors ...strin
 
 func firstSelectionInt(root *goquery.Selection, selectors ...string) int {
 	for _, selector := range selectors {
-		value := selectionText(root.Find(selector).First())
+		value := textutil.SelectionText(root.Find(selector).First())
 		for field := range strings.FieldsSeq(value) {
 			if number := parseInt(strings.Trim(field, "()[]{}.,")); number > 0 {
 				return number
@@ -932,81 +933,4 @@ func parseInt(value string) int {
 func parseInt64(value string) int64 {
 	number, _ := strconv.ParseInt(strings.TrimSpace(value), 10, 64)
 	return number
-}
-
-var textBlockElements = map[string]bool{
-	"address": true, "article": true, "blockquote": true, "dd": true, "div": true,
-	"dl": true, "dt": true, "figcaption": true, "figure": true, "footer": true,
-	"h1": true, "h2": true, "h3": true, "h4": true, "h5": true, "h6": true,
-	"header": true, "li": true, "main": true, "ol": true, "p": true, "pre": true,
-	"section": true, "table": true, "td": true, "th": true, "tr": true, "ul": true,
-}
-
-func selectionText(selection *goquery.Selection) string {
-	if selection == nil || selection.Length() == 0 {
-		return ""
-	}
-	var b strings.Builder
-	for _, node := range selection.Nodes {
-		writeNodeText(&b, node)
-	}
-	return normalizeText(b.String())
-}
-
-func writeNodeText(b *strings.Builder, node *html.Node) {
-	if node.Type == html.TextNode {
-		b.WriteString(node.Data)
-		return
-	}
-	if node.Type == html.ElementNode {
-		name := strings.ToLower(node.Data)
-		if name == "script" || name == "style" || name == "svg" || name == "button" {
-			return
-		}
-		if name == "br" {
-			writeTextBreak(b)
-			return
-		}
-		if textBlockElements[name] {
-			writeTextBreak(b)
-		}
-		for child := node.FirstChild; child != nil; child = child.NextSibling {
-			writeNodeText(b, child)
-		}
-		if textBlockElements[name] {
-			writeTextBreak(b)
-		}
-		return
-	}
-	for child := node.FirstChild; child != nil; child = child.NextSibling {
-		writeNodeText(b, child)
-	}
-}
-
-func writeTextBreak(b *strings.Builder) {
-	if b.Len() > 0 && !strings.HasSuffix(b.String(), "\n") {
-		b.WriteByte('\n')
-	}
-}
-
-func normalizeText(text string) string {
-	text = strings.ReplaceAll(text, "\u00a0", " ")
-	text = strings.ReplaceAll(text, "\r\n", "\n")
-	text = strings.ReplaceAll(text, "\r", "\n")
-	lines := strings.Split(text, "\n")
-	cleaned := make([]string, 0, len(lines))
-	blank := false
-	for _, line := range lines {
-		line = strings.Join(strings.Fields(line), " ")
-		if line == "" {
-			if len(cleaned) > 0 && !blank {
-				cleaned = append(cleaned, "")
-				blank = true
-			}
-			continue
-		}
-		cleaned = append(cleaned, line)
-		blank = false
-	}
-	return strings.TrimSpace(strings.Join(cleaned, "\n"))
 }

--- a/server/extractor/extractors/hackernews/hackernews.go
+++ b/server/extractor/extractors/hackernews/hackernews.go
@@ -1,0 +1,298 @@
+// Package hackernews provides an extractor for Hacker News item pages.
+package hackernews
+
+import (
+	"fmt"
+	stdhtml "html"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/PuerkitoBio/goquery"
+
+	"github.com/asciimoo/hister/server/extractor/sdk"
+	"github.com/asciimoo/hister/server/extractor/textutil"
+	"github.com/asciimoo/hister/server/extractor/urlutil"
+	"github.com/asciimoo/hister/server/sanitizer"
+)
+
+// HackerNewsExtractor turns a news.ycombinator.com item page into searchable
+// text and a readable preview.
+//
+// Unlike the Lobsters markup, Hacker News does not nest its comments: every
+// comment is a sibling row in one flat table and its depth is carried by the
+// indent attribute on the leading td.ind cell. Reconstructing the tree
+// therefore means tracking that number across the row sequence rather than
+// recursing, which is what commentRows below does.
+type HackerNewsExtractor struct {
+	sdk.ConfigSupport
+}
+
+func (e *HackerNewsExtractor) Name() string {
+	return "HackerNews"
+}
+
+func (e *HackerNewsExtractor) Description() string {
+	return "Extracts the submission metadata, self text and full comment tree from Hacker News item pages."
+}
+
+func (e *HackerNewsExtractor) Capabilities() sdk.Capabilities {
+	return sdk.Capabilities{Extract: true, Preview: true}
+}
+
+// Match accepts item pages on news.ycombinator.com. The URL is parsed rather
+// than prefix-matched so that pagination and tracking parameters, which show
+// up on long threads, do not stop a page from being recognised.
+func (e *HackerNewsExtractor) Match(d *sdk.Document) bool {
+	u, err := url.Parse(d.URL)
+	if err != nil {
+		return false
+	}
+	host := strings.ToLower(u.Hostname())
+	if host != "news.ycombinator.com" && host != "www.news.ycombinator.com" {
+		return false
+	}
+	if strings.TrimSuffix(u.Path, "/") != "/item" {
+		return false
+	}
+	return u.Query().Get("id") != ""
+}
+
+// story collects the header fields shared by Extract and Preview.
+type story struct {
+	title  string
+	link   string
+	site   string
+	score  string
+	author string
+	age    string
+	// selfText is the body of an Ask HN or text submission, absent for link
+	// submissions.
+	selfText *goquery.Selection
+}
+
+func parseStory(doc *goquery.Document) story {
+	titleLink := doc.Find(".titleline > a").First()
+	subline := doc.Find(".subline").First()
+	return story{
+		title:    strings.TrimSpace(titleLink.Text()),
+		link:     strings.TrimSpace(titleLink.AttrOr("href", "")),
+		site:     strings.TrimSpace(doc.Find(".titleline .sitestr").First().Text()),
+		score:    strings.TrimSpace(subline.Find(".score").First().Text()),
+		author:   strings.TrimSpace(subline.Find(".hnuser").First().Text()),
+		age:      strings.TrimSpace(subline.Find(".age").First().AttrOr("title", "")),
+		selfText: doc.Find(".fatitem .toptext").First(),
+	}
+}
+
+// comment is one row of the flat comment table.
+type comment struct {
+	depth    int
+	author   string
+	age      string
+	body     string
+	bodyHTML string
+}
+
+func commentRows(doc *goquery.Document) []comment {
+	comments := make([]comment, 0)
+	doc.Find("tr.athing.comtr").Each(func(_ int, row *goquery.Selection) {
+		depth, err := strconv.Atoi(row.Find("td.ind").First().AttrOr("indent", ""))
+		if err != nil || depth < 0 {
+			depth = 0
+		}
+		text := row.Find(".commtext").First()
+		// Collapsed and flagged comments keep their row but carry no body.
+		// They are still worth a line so the thread shape survives, but an
+		// entirely empty one adds nothing to the index.
+		body := textutil.SelectionText(text)
+		author := strings.TrimSpace(row.Find(".comhead .hnuser").First().Text())
+		if body == "" && author == "" {
+			return
+		}
+		bodyHTML, err := text.Html()
+		if err != nil {
+			bodyHTML = ""
+		}
+		comments = append(comments, comment{
+			depth:    depth,
+			author:   author,
+			age:      strings.TrimSpace(row.Find(".comhead .age").First().AttrOr("title", "")),
+			body:     body,
+			bodyHTML: bodyHTML,
+		})
+	})
+	return comments
+}
+
+// Extract populates Title and Text with the submission header, any self text
+// and the whole comment tree, so the discussion is searchable and not just the
+// headline.
+func (e *HackerNewsExtractor) Extract(d *sdk.Document) sdk.ExtractResult {
+	doc, err := goquery.NewDocumentFromReader(strings.NewReader(d.HTML))
+	if err != nil {
+		return sdk.ExtractFallback(err)
+	}
+
+	s := parseStory(doc)
+	d.Title = s.title
+
+	var b strings.Builder
+	if s.title != "" {
+		b.WriteString(s.title)
+	}
+	if s.site != "" {
+		b.WriteString("\n")
+		b.WriteString(s.site)
+	}
+	byline := make([]string, 0, 3)
+	if s.score != "" {
+		byline = append(byline, s.score)
+	}
+	if s.author != "" {
+		byline = append(byline, "by "+s.author)
+	}
+	if s.age != "" {
+		byline = append(byline, "on "+s.age)
+	}
+	if len(byline) > 0 {
+		b.WriteString("\n")
+		b.WriteString(strings.Join(byline, " "))
+	}
+	if t := textutil.SelectionText(s.selfText); t != "" {
+		b.WriteString("\n\n")
+		b.WriteString(t)
+	}
+
+	// Indent each comment by its depth so parent/child relationships survive
+	// into the indexed text, matching how the Lobsters extractor renders them.
+	for _, c := range commentRows(doc) {
+		indent := strings.Repeat("  ", c.depth)
+		b.WriteString("\n\n")
+		b.WriteString(indent)
+		if c.author != "" {
+			b.WriteString(c.author)
+		}
+		if c.age != "" {
+			fmt.Fprintf(&b, " [%s]", c.age)
+		}
+		for line := range strings.SplitSeq(c.body, "\n") {
+			b.WriteString("\n")
+			if line == "" {
+				continue
+			}
+			b.WriteString(indent)
+			b.WriteString(line)
+		}
+	}
+
+	d.Text = strings.TrimSpace(b.String())
+	if d.Text == "" && d.Title == "" {
+		return sdk.ExtractFallback(fmt.Errorf("no content found"))
+	}
+	return sdk.Extracted()
+}
+
+// Preview renders the submission and its comment tree as sanitized HTML. The
+// flat indent sequence is turned back into nested lists so the preview shows
+// the reply structure rather than a wall of equal-weight comments.
+func (e *HackerNewsExtractor) Preview(d *sdk.Document) sdk.PreviewResult {
+	doc, err := goquery.NewDocumentFromReader(strings.NewReader(d.HTML))
+	if err != nil {
+		return sdk.PreviewFallback(err)
+	}
+
+	// Hacker News links internally with relative URLs (item?id=123 on Ask HN
+	// titles, polls and reply links) which the sanitizer strips because it
+	// only keeps absolute http(s) URLs. Resolving everything against the page
+	// URL up front keeps those links in the preview.
+	base, _ := url.Parse(d.URL)
+	urlutil.RewriteURLs(doc.Selection, base)
+
+	s := parseStory(doc)
+
+	var b strings.Builder
+	if s.title != "" || s.link != "" {
+		b.WriteString("<h2>")
+		if s.link != "" {
+			fmt.Fprintf(&b, `<a href="%s">%s</a>`, stdhtml.EscapeString(s.link), stdhtml.EscapeString(s.title))
+		} else {
+			b.WriteString(stdhtml.EscapeString(s.title))
+		}
+		b.WriteString("</h2>")
+	}
+
+	bylineParts := make([]string, 0, 4)
+	if s.score != "" {
+		bylineParts = append(bylineParts, stdhtml.EscapeString(s.score))
+	}
+	if s.author != "" {
+		bylineParts = append(bylineParts, fmt.Sprintf("submitted by <strong>%s</strong>", stdhtml.EscapeString(s.author)))
+	}
+	if s.age != "" {
+		bylineParts = append(bylineParts, "on "+stdhtml.EscapeString(s.age))
+	}
+	if s.site != "" {
+		bylineParts = append(bylineParts, stdhtml.EscapeString(s.site))
+	}
+	if len(bylineParts) > 0 {
+		fmt.Fprintf(&b, "<p>%s</p>", strings.Join(bylineParts, " &middot; "))
+	}
+
+	if s.selfText.Length() > 0 {
+		if inner, err := s.selfText.Html(); err == nil && strings.TrimSpace(inner) != "" {
+			b.WriteString(inner)
+		}
+	}
+
+	comments := commentRows(doc)
+	if len(comments) > 0 {
+		b.WriteString("<h2>Comments</h2>")
+		writeCommentTree(&b, comments)
+	}
+
+	return sdk.Previewed(sdk.PreviewResponse{Content: sanitizer.SanitizeHTML(b.String())})
+}
+
+// writeCommentTree converts the flat depth-tagged sequence into nested lists.
+// Depth can jump by more than one only downward in malformed markup, so the
+// close path loops while the open path steps once, which keeps the tag stack
+// balanced whatever the input.
+func writeCommentTree(b *strings.Builder, comments []comment) {
+	depth := -1
+	for _, c := range comments {
+		for depth > c.depth {
+			b.WriteString("</li></ul>")
+			depth--
+		}
+		switch {
+		case depth < c.depth:
+			for depth < c.depth {
+				b.WriteString("<ul>")
+				depth++
+			}
+		default:
+			b.WriteString("</li>")
+		}
+		b.WriteString("<li>")
+		head := make([]string, 0, 2)
+		if c.author != "" {
+			head = append(head, fmt.Sprintf("<strong>%s</strong>", stdhtml.EscapeString(c.author)))
+		}
+		if c.age != "" {
+			head = append(head, stdhtml.EscapeString(c.age))
+		}
+		if len(head) > 0 {
+			fmt.Fprintf(b, "<p>%s</p>", strings.Join(head, " &middot; "))
+		}
+		if c.bodyHTML != "" {
+			b.WriteString(c.bodyHTML)
+		} else if c.body != "" {
+			fmt.Fprintf(b, "<p>%s</p>", stdhtml.EscapeString(c.body))
+		}
+	}
+	for depth >= 0 {
+		b.WriteString("</li></ul>")
+		depth--
+	}
+}

--- a/server/extractor/extractors/hackernews/hackernews_test.go
+++ b/server/extractor/extractors/hackernews/hackernews_test.go
@@ -1,0 +1,213 @@
+package hackernews
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/asciimoo/hister/config"
+	"github.com/asciimoo/hister/server/document"
+	"github.com/asciimoo/hister/server/extractor/sdk"
+)
+
+// itemHTML mirrors the structure of a news.ycombinator.com item page: the
+// submission in a fatitem table, then one flat comment table whose rows carry
+// their depth in the indent attribute of the leading td.ind cell.
+const itemHTML = `<html><body><center><table id="hnmain"><tr><td>
+<table class="fatitem"><tbody>
+  <tr class="athing submission" id="1">
+    <td class="title"><span class="titleline"><a href="http://example.com/post">Example Post</a><span class="sitebit comhead"> (<a href="from?site=example.com"><span class="sitestr">example.com</span></a>)</span></span></td>
+  </tr>
+  <tr><td class="subtext"><span class="subline">
+    <span class="score" id="score_1">57 points</span> by <a href="user?id=alice" class="hnuser">alice</a>
+    <span class="age" title="2026-01-02T03:04:05 1767322445"><a href="item?id=1">2 hours ago</a></span>
+  </span></td></tr>
+  <tr><td class="toptext">Body of the submission.</td></tr>
+</tbody></table>
+<table class="comment-tree"><tbody>
+  <tr class="athing comtr" id="10"><td><table><tr>
+    <td class="ind" indent="0"><img src="s.gif"></td>
+    <td class="default"><div><span class="comhead"><a href="user?id=bob" class="hnuser">bob</a>
+      <span class="age" title="2026-01-02T04:00:00 1767326400"><a href="item?id=10">1 hour ago</a></span></span></div>
+      <div class="comment"><div class="commtext c00">Top level remark.<p>Second paragraph, see <a href="item?id=8863">this thread</a>.</p></div></div></td>
+  </tr></table></td></tr>
+  <tr class="athing comtr" id="11"><td><table><tr>
+    <td class="ind" indent="1"><img src="s.gif"></td>
+    <td class="default"><div><span class="comhead"><a href="user?id=carol" class="hnuser">carol</a>
+      <span class="age" title="2026-01-02T05:00:00 1767330000"><a href="item?id=11">30 minutes ago</a></span></span></div>
+      <div class="comment"><div class="commtext c00">Nested reply.</div></div></td>
+  </tr></table></td></tr>
+  <tr class="athing comtr" id="12"><td><table><tr>
+    <td class="ind" indent="0"><img src="s.gif"></td>
+    <td class="default"><div><span class="comhead"><a href="user?id=dan" class="hnuser">dan</a>
+      <span class="age" title="2026-01-02T06:00:00 1767333600"><a href="item?id=12">10 minutes ago</a></span></span></div>
+      <div class="comment"><div class="commtext c00">Back to top level.</div></div></td>
+  </tr></table></td></tr>
+</tbody></table>
+</td></tr></table></center></body></html>`
+
+func TestSetConfigRejectsUnknownOptions(t *testing.T) {
+	err := (&HackerNewsExtractor{}).SetConfig(&config.Extractor{
+		Enable:  true,
+		Options: map[string]any{"unknown": true},
+	})
+	if err == nil {
+		t.Fatal("SetConfig accepted an unknown option")
+	}
+}
+
+func TestMatchOnlyAcceptsItemPages(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+		want bool
+	}{
+		{name: "item", url: "https://news.ycombinator.com/item?id=1", want: true},
+		{name: "item with extra params", url: "https://news.ycombinator.com/item?id=1&p=2", want: true},
+		{name: "trailing slash", url: "https://news.ycombinator.com/item/?id=9", want: true},
+		{name: "plain http", url: "http://news.ycombinator.com/item?id=9", want: true},
+		{name: "www host", url: "https://www.news.ycombinator.com/item?id=9", want: true},
+		{name: "front page", url: "https://news.ycombinator.com/", want: false},
+		{name: "newest listing", url: "https://news.ycombinator.com/newest", want: false},
+		{name: "item without id", url: "https://news.ycombinator.com/item", want: false},
+		{name: "user profile", url: "https://news.ycombinator.com/user?id=alice", want: false},
+		{name: "lookalike host", url: "https://news.ycombinator.com.example/item?id=1", want: false},
+		{name: "unrelated host", url: "https://example.com/item?id=1", want: false},
+	}
+
+	extractor := &HackerNewsExtractor{}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := extractor.Match(&document.Document{URL: test.url}); got != test.want {
+				t.Errorf("Match(%q) = %v, want %v", test.url, got, test.want)
+			}
+		})
+	}
+}
+
+func TestExtractCollectsSubmissionAndComments(t *testing.T) {
+	d := &sdk.Document{URL: "https://news.ycombinator.com/item?id=1", HTML: itemHTML}
+	if res := (&HackerNewsExtractor{}).Extract(d); res.Err() != nil {
+		t.Fatalf("Extract returned %v", res.Err())
+	}
+
+	if d.Title != "Example Post" {
+		t.Errorf("Title = %q, want %q", d.Title, "Example Post")
+	}
+	for _, want := range []string{
+		"example.com",
+		"57 points",
+		"by alice",
+		"Body of the submission.",
+		"Top level remark.",
+		"Nested reply.",
+		"Back to top level.",
+		"bob",
+		"carol",
+	} {
+		if !strings.Contains(d.Text, want) {
+			t.Errorf("Text is missing %q\ngot:\n%s", want, d.Text)
+		}
+	}
+}
+
+func TestExtractIndentsRepliesByDepth(t *testing.T) {
+	d := &sdk.Document{URL: "https://news.ycombinator.com/item?id=1", HTML: itemHTML}
+	if res := (&HackerNewsExtractor{}).Extract(d); res.Err() != nil {
+		t.Fatalf("Extract returned %v", res.Err())
+	}
+
+	// The reply sits one level deep, so it must carry more leading whitespace
+	// than the top level comments around it.
+	for line := range strings.SplitSeq(d.Text, "\n") {
+		trimmed := strings.TrimSpace(line)
+		indent := len(line) - len(trimmed)
+		switch trimmed {
+		case "Top level remark.", "Back to top level.":
+			if indent != 0 {
+				t.Errorf("%q indented by %d, want 0", trimmed, indent)
+			}
+		case "Nested reply.":
+			if indent == 0 {
+				t.Errorf("%q was not indented", trimmed)
+			}
+		}
+	}
+}
+
+func TestExtractKeepsParagraphBoundaries(t *testing.T) {
+	d := &sdk.Document{URL: "https://news.ycombinator.com/item?id=1", HTML: itemHTML}
+	if res := (&HackerNewsExtractor{}).Extract(d); res.Err() != nil {
+		t.Fatalf("Extract returned %v", res.Err())
+	}
+
+	// bob's comment has two paragraphs; each must land on its own line rather
+	// than running together the way goquery's Text() would leave them.
+	if strings.Contains(d.Text, "remark.Second") {
+		t.Errorf("paragraphs ran together:\n%s", d.Text)
+	}
+	if !strings.Contains(d.Text, "Top level remark.\n") {
+		t.Errorf("first paragraph does not end its line:\n%s", d.Text)
+	}
+	if !strings.Contains(d.Text, "Second paragraph, see this thread.") {
+		t.Errorf("second paragraph is missing:\n%s", d.Text)
+	}
+}
+
+func TestExtractFallsBackWithoutContent(t *testing.T) {
+	d := &sdk.Document{URL: "https://news.ycombinator.com/item?id=1", HTML: "<html><body></body></html>"}
+	if res := (&HackerNewsExtractor{}).Extract(d); res.Err() == nil {
+		t.Error("Extract accepted a page with no submission")
+	}
+}
+
+func TestPreviewNestsCommentsAndBalancesTags(t *testing.T) {
+	d := &sdk.Document{URL: "https://news.ycombinator.com/item?id=1", HTML: itemHTML}
+	res := (&HackerNewsExtractor{}).Preview(d)
+	if res.Err() != nil {
+		t.Fatalf("Preview returned %v", res.Err())
+	}
+	html := res.Response().Content
+
+	if open, closed := strings.Count(html, "<ul>"), strings.Count(html, "</ul>"); open != closed {
+		t.Errorf("unbalanced ul: %d open, %d closed\n%s", open, closed, html)
+	}
+	if open, closed := strings.Count(html, "<li>"), strings.Count(html, "</li>"); open != closed {
+		t.Errorf("unbalanced li: %d open, %d closed\n%s", open, closed, html)
+	}
+	// Two depths in the fixture must produce two levels of nesting.
+	if got := strings.Count(html, "<ul>"); got != 2 {
+		t.Errorf("got %d ul, want 2 (one per depth)\n%s", got, html)
+	}
+	if !strings.Contains(html, "Example Post") {
+		t.Errorf("preview is missing the title\n%s", html)
+	}
+}
+
+func TestPreviewResolvesRelativeLinks(t *testing.T) {
+	d := &sdk.Document{URL: "https://news.ycombinator.com/item?id=1", HTML: itemHTML}
+	res := (&HackerNewsExtractor{}).Preview(d)
+	if res.Err() != nil {
+		t.Fatalf("Preview returned %v", res.Err())
+	}
+	html := res.Response().Content
+
+	// The relative item?id=8863 link in bob's comment must survive
+	// sanitization, which drops URLs that are not absolute http(s).
+	if !strings.Contains(html, `href="https://news.ycombinator.com/item?id=8863"`) {
+		t.Errorf("relative comment link was not resolved\n%s", html)
+	}
+}
+
+func TestPreviewResolvesRelativeTitleLink(t *testing.T) {
+	// Ask HN and poll submissions link their own title to the relative
+	// item?id=N URL.
+	html := strings.Replace(itemHTML, `href="http://example.com/post"`, `href="item?id=1"`, 1)
+	d := &sdk.Document{URL: "https://news.ycombinator.com/item?id=1", HTML: html}
+	res := (&HackerNewsExtractor{}).Preview(d)
+	if res.Err() != nil {
+		t.Fatalf("Preview returned %v", res.Err())
+	}
+	if !strings.Contains(res.Response().Content, `href="https://news.ycombinator.com/item?id=1"`) {
+		t.Errorf("relative title link was not resolved\n%s", res.Response().Content)
+	}
+}

--- a/server/extractor/extractors/reddit/reddit.go
+++ b/server/extractor/extractors/reddit/reddit.go
@@ -10,9 +10,9 @@ import (
 	"strings"
 
 	"github.com/PuerkitoBio/goquery"
-	"golang.org/x/net/html"
 
 	"github.com/asciimoo/hister/server/extractor/sdk"
+	"github.com/asciimoo/hister/server/extractor/textutil"
 	"github.com/asciimoo/hister/server/extractor/urlutil"
 	"github.com/asciimoo/hister/server/sanitizer"
 )
@@ -251,7 +251,7 @@ func parsePostElement(post *redditPost, root *goquery.Selection, doc *goquery.Do
 		firstAttr(root, "post-title", "data-title"),
 		firstSelectionText(root, `h1[slot="title"]`, `[data-testid="post-title"]`, `[itemprop="headline"]`, `p.title a.title`, "h1"),
 		firstPageMeta(doc, `meta[property="og:title"]`, `meta[name="twitter:title"]`),
-		selectionText(doc.Find("title").First()),
+		textutil.SelectionText(doc.Find("title").First()),
 	)
 	post.Author = firstValue(
 		firstAttr(root, "author", "data-author"),
@@ -277,7 +277,7 @@ func parsePostElement(post *redditPost, root *goquery.Selection, doc *goquery.Do
 
 	body := firstBodySelection(root)
 	if body != nil {
-		post.BodyText = selectionText(body)
+		post.BodyText = textutil.SelectionText(body)
 		urlutil.RewriteURLs(body, base)
 		post.BodyHTML, _ = body.Html()
 	}
@@ -311,7 +311,7 @@ func firstBodySelection(root *goquery.Selection) *goquery.Selection {
 	for _, selector := range selectors {
 		var found *goquery.Selection
 		root.Find(selector).EachWithBreak(func(_ int, s *goquery.Selection) bool {
-			if selectionText(s) == "" && s.Find("img, video, audio").Length() == 0 {
+			if textutil.SelectionText(s) == "" && s.Find("img, video, audio").Length() == 0 {
 				return true
 			}
 			found = s
@@ -454,7 +454,7 @@ func parseComment(root *goquery.Selection, rootSelector string, base *url.URL) (
 	}
 	body := commentBody(root)
 	if body != nil {
-		comment.Text = selectionText(body)
+		comment.Text = textutil.SelectionText(body)
 		urlutil.RewriteURLs(body, base)
 		comment.HTML, _ = body.Html()
 	} else {
@@ -493,7 +493,7 @@ func fallbackCommentText(root *goquery.Selection, rootSelector string) string {
 	clone := root.Clone()
 	clone.Find(rootSelector).Remove()
 	clone.Find("button, script, style, svg, shreddit-comment-action-row, [slot=actionRow], [slot=commentMeta], [slot=commentAvatar]").Remove()
-	return selectionText(clone)
+	return textutil.SelectionText(clone)
 }
 
 func commentID(root *goquery.Selection) string {
@@ -655,7 +655,7 @@ func firstSelectionText(s *goquery.Selection, selectors ...string) string {
 		return ""
 	}
 	for _, selector := range selectors {
-		if value := selectionText(s.Find(selector).First()); value != "" {
+		if value := textutil.SelectionText(s.Find(selector).First()); value != "" {
 			return value
 		}
 	}
@@ -685,83 +685,6 @@ func firstPageMeta(s selectionFinder, selectors ...string) string {
 		}
 	}
 	return ""
-}
-
-var textBlockElements = map[string]bool{
-	"address": true, "article": true, "blockquote": true, "dd": true, "div": true,
-	"dl": true, "dt": true, "figcaption": true, "figure": true, "footer": true,
-	"h1": true, "h2": true, "h3": true, "h4": true, "h5": true, "h6": true,
-	"header": true, "li": true, "main": true, "ol": true, "p": true, "pre": true,
-	"section": true, "table": true, "td": true, "th": true, "tr": true, "ul": true,
-}
-
-func selectionText(s *goquery.Selection) string {
-	if s == nil || s.Length() == 0 {
-		return ""
-	}
-	var b strings.Builder
-	for _, node := range s.Nodes {
-		writeNodeText(&b, node)
-	}
-	return normalizeText(b.String())
-}
-
-func writeNodeText(b *strings.Builder, node *html.Node) {
-	if node.Type == html.TextNode {
-		b.WriteString(node.Data)
-		return
-	}
-	if node.Type == html.ElementNode {
-		name := strings.ToLower(node.Data)
-		if name == "script" || name == "style" || name == "svg" || name == "button" {
-			return
-		}
-		if name == "br" {
-			writeTextBreak(b)
-			return
-		}
-		if textBlockElements[name] {
-			writeTextBreak(b)
-		}
-		for child := node.FirstChild; child != nil; child = child.NextSibling {
-			writeNodeText(b, child)
-		}
-		if textBlockElements[name] {
-			writeTextBreak(b)
-		}
-		return
-	}
-	for child := node.FirstChild; child != nil; child = child.NextSibling {
-		writeNodeText(b, child)
-	}
-}
-
-func writeTextBreak(b *strings.Builder) {
-	if b.Len() > 0 && !strings.HasSuffix(b.String(), "\n") {
-		b.WriteByte('\n')
-	}
-}
-
-func normalizeText(text string) string {
-	text = strings.ReplaceAll(text, "\u00a0", " ")
-	text = strings.ReplaceAll(text, "\r\n", "\n")
-	text = strings.ReplaceAll(text, "\r", "\n")
-	lines := strings.Split(text, "\n")
-	clean := make([]string, 0, len(lines))
-	blank := false
-	for _, line := range lines {
-		line = strings.Join(strings.Fields(line), " ")
-		if line == "" {
-			if len(clean) > 0 && !blank {
-				clean = append(clean, "")
-				blank = true
-			}
-			continue
-		}
-		clean = append(clean, line)
-		blank = false
-	}
-	return strings.TrimSpace(strings.Join(clean, "\n"))
 }
 
 func paragraphHTML(text string) string {

--- a/server/extractor/live_cases.yaml
+++ b/server/extractor/live_cases.yaml
@@ -193,6 +193,25 @@ cases:
         type: Issue
         repo: asciimoo/hister
 
+  - name: hackernews_item_archive_http
+    url: https://web.archive.org/web/20260821112419/https://news.ycombinator.com/item?id=8863
+    document_url: https://news.ycombinator.com/item?id=8863
+    backend: http
+    extractor: HackerNews
+    timeout: 20
+    run_chain: false
+    expect:
+      title_contains:
+        - Dropbox - Throw away your USB drive
+      text_contains:
+        - 104 points
+        - by dhouston
+        - curlftpfs
+      min_text_length: 1000
+      preview_contains:
+        - Comments
+        - dhouston
+      min_preview_length: 1000
   - name: lobsters_story_archive_http
     url: https://web.archive.org/web/20260210164115/https://lobste.rs/s/ogr30w/how_i_cut_my_google_search_dependence_half
     document_url: https://lobste.rs/s/ogr30w/how_i_cut_my_google_search_dependence_half

--- a/server/extractor/registry.go
+++ b/server/extractor/registry.go
@@ -14,6 +14,7 @@ import (
 	"github.com/asciimoo/hister/server/extractor/extractors/embeddedvideo"
 	"github.com/asciimoo/hister/server/extractor/extractors/github"
 	"github.com/asciimoo/hister/server/extractor/extractors/godoc"
+	"github.com/asciimoo/hister/server/extractor/extractors/hackernews"
 	"github.com/asciimoo/hister/server/extractor/extractors/jsonld"
 	"github.com/asciimoo/hister/server/extractor/extractors/lobsters"
 	"github.com/asciimoo/hister/server/extractor/extractors/markdown"
@@ -63,6 +64,7 @@ func DefaultExtractors() []Extractor {
 		&godoc.GoDocExtractor{},
 		&github.GitHubExtractor{},
 		&lobsters.LobstersExtractor{},
+		&hackernews.HackerNewsExtractor{},
 		&wikipedia.WikipediaExtractor{},
 		&mastodon.MastodonExtractor{},
 		&bluesky.BlueskyExtractor{},

--- a/server/extractor/textutil/textutil.go
+++ b/server/extractor/textutil/textutil.go
@@ -1,0 +1,95 @@
+// Package textutil provides shared helpers for flattening HTML to plain text
+// while keeping the block structure of the original markup.
+package textutil
+
+import (
+	"strings"
+
+	"github.com/PuerkitoBio/goquery"
+	"golang.org/x/net/html"
+)
+
+// textBlockElements are the elements whose boundaries become line breaks when
+// markup is flattened to text.
+var textBlockElements = map[string]bool{
+	"address": true, "article": true, "blockquote": true, "dd": true, "div": true,
+	"dl": true, "dt": true, "figcaption": true, "figure": true, "footer": true,
+	"h1": true, "h2": true, "h3": true, "h4": true, "h5": true, "h6": true,
+	"header": true, "li": true, "main": true, "ol": true, "p": true, "pre": true,
+	"section": true, "table": true, "td": true, "th": true, "tr": true, "ul": true,
+}
+
+// SelectionText flattens a selection to plain text. Unlike goquery's Text(),
+// which concatenates text nodes with no separator and therefore runs the
+// paragraphs of multi-paragraph content together, block elements and <br>
+// become line breaks so the shape of the original content survives.
+func SelectionText(selection *goquery.Selection) string {
+	if selection == nil || selection.Length() == 0 {
+		return ""
+	}
+	var b strings.Builder
+	for _, node := range selection.Nodes {
+		writeNodeText(&b, node)
+	}
+	return normalizeText(b.String())
+}
+
+func writeNodeText(b *strings.Builder, node *html.Node) {
+	if node.Type == html.TextNode {
+		b.WriteString(node.Data)
+		return
+	}
+	if node.Type == html.ElementNode {
+		name := strings.ToLower(node.Data)
+		if name == "script" || name == "style" || name == "svg" || name == "button" {
+			return
+		}
+		if name == "br" {
+			writeTextBreak(b)
+			return
+		}
+		if textBlockElements[name] {
+			writeTextBreak(b)
+		}
+		for child := node.FirstChild; child != nil; child = child.NextSibling {
+			writeNodeText(b, child)
+		}
+		if textBlockElements[name] {
+			writeTextBreak(b)
+		}
+		return
+	}
+	for child := node.FirstChild; child != nil; child = child.NextSibling {
+		writeNodeText(b, child)
+	}
+}
+
+func writeTextBreak(b *strings.Builder) {
+	if b.Len() > 0 && !strings.HasSuffix(b.String(), "\n") {
+		b.WriteByte('\n')
+	}
+}
+
+// normalizeText collapses runs of whitespace within lines and runs of blank
+// lines down to one, and trims the result.
+func normalizeText(text string) string {
+	text = strings.ReplaceAll(text, "\u00a0", " ")
+	text = strings.ReplaceAll(text, "\r\n", "\n")
+	text = strings.ReplaceAll(text, "\r", "\n")
+	lines := strings.Split(text, "\n")
+	cleaned := make([]string, 0, len(lines))
+	blank := false
+	for _, line := range lines {
+		line = strings.Join(strings.Fields(line), " ")
+		if line == "" {
+			if len(cleaned) > 0 && !blank {
+				cleaned = append(cleaned, "")
+				blank = true
+			}
+			continue
+		}
+		cleaned = append(cleaned, line)
+		blank = false
+	}
+	return strings.TrimSpace(strings.Join(cleaned, "\n"))
+}

--- a/webui/website/src/content/docs/extractors.md
+++ b/webui/website/src/content/docs/extractors.md
@@ -247,6 +247,17 @@ parent–child comment hierarchy.
 
 **Matches:** `https://lobste.rs/s/…`
 
+### `hackernews`
+
+Extracts the full content of a Hacker News item page, including the submission
+metadata (title, target site, score, author, submission date), the optional self
+text of an Ask HN or text post, and the complete comment tree. Hacker News
+renders comments as one flat table and records depth in the `indent` attribute
+of each row, so both the indexed text and the preview rebuild the parent–child
+hierarchy from it.
+
+**Matches:** `https://news.ycombinator.com/item?id=…`
+
 ### `wikipedia`
 
 Extracts article content from Wikipedia. Indexed text includes the article


### PR DESCRIPTION
Hacker News item pages currently fall through to the generic readability extractor, which keeps the submission text but flattens the discussion.

Unlike the Lobsters markup, Hacker News does not nest its comments: every comment is a sibling row in a single flat table and its depth is carried by the indent attribute on the leading td.ind cell. The extractor rebuilds the tree from that sequence, so both the indexed text and the preview preserve the parent-child hierarchy rather than presenting every comment at the same level.

Match parses the URL instead of prefix-matching it, so pagination and tracking parameters on long threads do not stop a page from being recognised, while lookalike hosts and listing pages are rejected.

Verified against an archived copy of item 8863, which yields the expected title, score, author and a 28k character comment tree.