### PR TITLE
Make crawler well behaved (local and remote resource usage)

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -132,15 +132,74 @@ type CrawlerCookie struct {
 // CrawlerConfig holds global crawler settings and backend-specific options.
 // Timeout and Delay default to 5s and 0s respectively when zero.
 type CrawlerConfig struct {
-	Timeout        int               `yaml:"timeout"         mapstructure:"timeout"`
-	Delay          int               `yaml:"delay"           mapstructure:"delay"`
-	Backend        string            `yaml:"backend"         mapstructure:"backend"`
-	BackendOptions map[string]any    `yaml:"backend_options" mapstructure:"backend_options"`
-	Proxy          string            `yaml:"proxy"           mapstructure:"proxy"`
-	UserAgent      string            `yaml:"user_agent"      mapstructure:"user_agent"`
-	Headers        map[string]string `yaml:"headers"         mapstructure:"headers"`
-	Cookies        []CrawlerCookie   `yaml:"cookies"         mapstructure:"cookies"`
-	NoRobots       bool              `yaml:"no_robots"       mapstructure:"no_robots"`
+	Timeout           int                            `yaml:"timeout"            mapstructure:"timeout"`
+	Delay             int                            `yaml:"delay"              mapstructure:"delay"`
+	Backend           string                         `yaml:"backend"            mapstructure:"backend"`
+	BackendOptions    map[string]any                 `yaml:"backend_options"    mapstructure:"backend_options"`
+	Proxy             string                         `yaml:"proxy"              mapstructure:"proxy"`
+	UserAgent         string                         `yaml:"user_agent"         mapstructure:"user_agent"`
+	Headers           map[string]string              `yaml:"headers"            mapstructure:"headers"`
+	Cookies           []CrawlerCookie                `yaml:"cookies"            mapstructure:"cookies"`
+	NoRobots          bool                           `yaml:"no_robots"          mapstructure:"no_robots"`
+	ContactURL        string                         `yaml:"contact_url"        mapstructure:"contact_url"`
+	ConditionalGet    bool                           `yaml:"conditional_get"    mapstructure:"conditional_get"`
+	RespectMetaRobots bool                           `yaml:"respect_meta_robots" mapstructure:"respect_meta_robots"`
+	Rate              CrawlerRate                    `yaml:"rate"               mapstructure:"rate"`
+	Retry             CrawlerRetry                   `yaml:"retry"              mapstructure:"retry"`
+	CircuitBreaker    CrawlerBreaker                 `yaml:"circuit_breaker"    mapstructure:"circuit_breaker"`
+	Limits            CrawlerLimits                  `yaml:"limits"             mapstructure:"limits"`
+	Robots            CrawlerRobots                  `yaml:"robots"             mapstructure:"robots"`
+	Hosts             map[string]CrawlerHostOverride `yaml:"hosts"              mapstructure:"hosts"`
+	ShutdownGrace     int                            `yaml:"shutdown_grace"     mapstructure:"shutdown_grace"`
+}
+
+// CrawlerRate configures global and per-host request rates.
+// RPS values are requests per second; 0 means use the default.
+// Duration fields are in seconds.
+type CrawlerRate struct {
+	GlobalRPS          float64 `yaml:"global_rps"          mapstructure:"global_rps"`
+	PerHostRPS         float64 `yaml:"per_host_rps"        mapstructure:"per_host_rps"`
+	GlobalConcurrency  int     `yaml:"global_concurrency"  mapstructure:"global_concurrency"`
+	PerHostConcurrency int     `yaml:"per_host_concurrency" mapstructure:"per_host_concurrency"`
+	Jitter             float64 `yaml:"jitter"              mapstructure:"jitter"`
+}
+
+// CrawlerRetry configures retry behaviour on transient failures.
+// Duration fields are in seconds.
+type CrawlerRetry struct {
+	MaxAttempts    int `yaml:"max_attempts"    mapstructure:"max_attempts"`
+	InitialBackoff int `yaml:"initial_backoff" mapstructure:"initial_backoff"`
+	MaxBackoff     int `yaml:"max_backoff"     mapstructure:"max_backoff"`
+}
+
+// CrawlerBreaker configures the per-host circuit breaker.
+// Cooldown is in seconds.
+type CrawlerBreaker struct {
+	ConsecutiveFailures int `yaml:"consecutive_failures" mapstructure:"consecutive_failures"`
+	Cooldown            int `yaml:"cooldown"             mapstructure:"cooldown"`
+}
+
+// CrawlerLimits caps total and per-host resource usage.
+// Duration fields are in seconds.
+type CrawlerLimits struct {
+	MaxResponseBytes int64 `yaml:"max_response_bytes" mapstructure:"max_response_bytes"`
+	MaxPages         int   `yaml:"max_pages"          mapstructure:"max_pages"`
+	MaxPagesPerHost  int   `yaml:"max_pages_per_host" mapstructure:"max_pages_per_host"`
+	MaxBytesPerHost  int64 `yaml:"max_bytes_per_host" mapstructure:"max_bytes_per_host"`
+	MaxDuration      int   `yaml:"max_duration"       mapstructure:"max_duration"`
+}
+
+// CrawlerRobots configures robots.txt handling.
+// CacheTTL is in seconds.
+type CrawlerRobots struct {
+	CacheTTL          int  `yaml:"cache_ttl"           mapstructure:"cache_ttl"`
+	RespectCrawlDelay bool `yaml:"respect_crawl_delay" mapstructure:"respect_crawl_delay"`
+}
+
+// CrawlerHostOverride allows per-host rate and page limit overrides.
+type CrawlerHostOverride struct {
+	PerHostRPS float64 `yaml:"per_host_rps" mapstructure:"per_host_rps"`
+	MaxPages   int     `yaml:"max_pages"    mapstructure:"max_pages"`
 }
 
 type Hotkeys struct {
@@ -524,6 +583,30 @@ func CreateDefaultConfig() *Config {
 		Crawler: CrawlerConfig{
 			Backend: "http",
 			Timeout: 5,
+			Rate: CrawlerRate{
+				GlobalRPS:          10,
+				PerHostRPS:         1,
+				GlobalConcurrency:  8,
+				PerHostConcurrency: 1,
+				Jitter:             0.2,
+			},
+			Retry: CrawlerRetry{
+				MaxAttempts:    3,
+				InitialBackoff: 1,
+				MaxBackoff:     30,
+			},
+			CircuitBreaker: CrawlerBreaker{
+				ConsecutiveFailures: 5,
+				Cooldown:            300,
+			},
+			Limits: CrawlerLimits{
+				MaxResponseBytes: 10 * 1024 * 1024,
+			},
+			Robots: CrawlerRobots{
+				CacheTTL:          86400,
+				RespectCrawlDelay: true,
+			},
+			ShutdownGrace: 30,
 		},
 		Hotkeys: Hotkeys{
 			Web: map[string]string{
@@ -595,6 +678,17 @@ func parseConfig(rawConfig []byte) (*Config, error) {
 		}
 		c.Server.BaseURL = strings.TrimSuffix(c.Server.BaseURL, "/")
 	}
+
+	// Backwards compatibility: if legacy delay > 0 and per-host RPS is still
+	// at its default, derive per-host RPS from the delay value.
+	if c.Crawler.Delay > 0 && c.Crawler.Rate.PerHostRPS == 0 {
+		c.Crawler.Rate.PerHostRPS = 1.0 / float64(c.Crawler.Delay)
+		log.Warn().
+			Int("delay", c.Crawler.Delay).
+			Float64("per_host_rps", c.Crawler.Rate.PerHostRPS).
+			Msg("config: crawler.delay is deprecated; use crawler.rate.per_host_rps instead")
+	}
+
 	return c, nil
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -584,8 +584,11 @@ func CreateDefaultConfig() *Config {
 			Backend: "http",
 			Timeout: 5,
 			Rate: CrawlerRate{
-				GlobalRPS:          10,
-				PerHostRPS:         1,
+				GlobalRPS: 10,
+				// PerHostRPS default is 0 so the scheduler's coalesce to 1
+				// stays in one place, and so the legacy `delay` deprecation
+				// check can detect an unset value.
+				PerHostRPS:         0,
 				GlobalConcurrency:  8,
 				PerHostConcurrency: 1,
 				Jitter:             0.2,

--- a/server/crawler/backoff.go
+++ b/server/crawler/backoff.go
@@ -10,13 +10,6 @@ import (
 	"time"
 )
 
-// RetryDecision captures the outcome of ClassifyError.
-type RetryDecision struct {
-	Retry  bool
-	Wait   time.Duration
-	Reason string
-}
-
 // ClassifyError inspects err and returns whether it is retryable, any
 // server-specified retry-after duration, and the HTTP status code (0 for
 // network errors).

--- a/server/crawler/backoff.go
+++ b/server/crawler/backoff.go
@@ -1,0 +1,189 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package crawler
+
+import (
+	"errors"
+	"math/rand"
+	"net"
+	"sync"
+	"time"
+)
+
+// RetryDecision captures the outcome of ClassifyError.
+type RetryDecision struct {
+	Retry  bool
+	Wait   time.Duration
+	Reason string
+}
+
+// ClassifyError inspects err and returns whether it is retryable, any
+// server-specified retry-after duration, and the HTTP status code (0 for
+// network errors).
+func ClassifyError(err error) (retryable bool, retryAfter time.Duration, statusCode int) {
+	if err == nil {
+		return false, 0, 0
+	}
+
+	var httpErr *HTTPStatusError
+	if errors.As(err, &httpErr) {
+		statusCode = httpErr.Status
+		retryAfter = httpErr.RetryAfter
+		switch statusCode {
+		case 408, 429, 500, 502, 503, 504:
+			return true, retryAfter, statusCode
+		default:
+			// All other 4xx and 5xx are not retried (including 501).
+			return false, 0, statusCode
+		}
+	}
+
+	// Network-level errors are retryable.
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		return true, 0, 0
+	}
+
+	return false, 0, 0
+}
+
+// Backoff computes exponential backoff durations with jitter.
+type Backoff struct {
+	initial time.Duration
+	max     time.Duration
+	rng     *rand.Rand
+}
+
+// NewBackoff creates a Backoff. initial and max must be positive.
+func NewBackoff(initial, max time.Duration) *Backoff {
+	return &Backoff{
+		initial: initial,
+		max:     max,
+		rng:     rand.New(rand.NewSource(time.Now().UnixNano())),
+	}
+}
+
+// Duration returns the backoff duration for the given attempt number (0-based).
+// It applies full jitter: the result is uniformly random in [0, cap].
+func (b *Backoff) Duration(attempt int) time.Duration {
+	exp := b.initial
+	for i := 0; i < attempt; i++ {
+		exp *= 2
+		if exp > b.max {
+			exp = b.max
+			break
+		}
+	}
+	if exp > b.max {
+		exp = b.max
+	}
+	jitter := time.Duration(b.rng.Int63n(int64(exp) + 1))
+	return jitter
+}
+
+// BreakerState represents the state of a circuit breaker for a single host.
+type BreakerState int
+
+const (
+	BreakerClosed   BreakerState = iota // normal operation
+	BreakerOpen                         // requests blocked
+	BreakerHalfOpen                     // one probe allowed
+)
+
+type breakerState struct {
+	state       BreakerState
+	failures    int
+	lastFailure time.Time
+	probing     bool // a half-open probe is in flight
+}
+
+// CircuitBreaker is a per-host circuit breaker.
+type CircuitBreaker struct {
+	threshold int
+	cooldown  time.Duration
+	clock     Clock
+	mu        sync.Mutex
+	hosts     map[string]*breakerState
+}
+
+// NewCircuitBreaker creates a CircuitBreaker. threshold is the number of
+// consecutive failures before opening; cooldown is the duration to wait before
+// entering half-open state.
+func NewCircuitBreaker(threshold int, cooldown time.Duration, clock Clock) *CircuitBreaker {
+	if clock == nil {
+		clock = RealClock{}
+	}
+	return &CircuitBreaker{
+		threshold: threshold,
+		cooldown:  cooldown,
+		clock:     clock,
+		hosts:     make(map[string]*breakerState),
+	}
+}
+
+func (cb *CircuitBreaker) hostState(host string) *breakerState {
+	s, ok := cb.hosts[host]
+	if !ok {
+		s = &breakerState{}
+		cb.hosts[host] = s
+	}
+	return s
+}
+
+// Allow returns true if a request to host is permitted.
+func (cb *CircuitBreaker) Allow(host string) bool {
+	cb.mu.Lock()
+	defer cb.mu.Unlock()
+
+	s := cb.hostState(host)
+	switch s.state {
+	case BreakerClosed:
+		return true
+	case BreakerOpen:
+		if cb.clock.Now().Sub(s.lastFailure) >= cb.cooldown {
+			s.state = BreakerHalfOpen
+			s.probing = true
+			return true
+		}
+		return false
+	case BreakerHalfOpen:
+		if !s.probing {
+			s.probing = true
+			return true
+		}
+		return false
+	}
+	return true
+}
+
+// RecordSuccess resets the failure count and closes the breaker.
+func (cb *CircuitBreaker) RecordSuccess(host string) {
+	cb.mu.Lock()
+	defer cb.mu.Unlock()
+
+	s := cb.hostState(host)
+	s.failures = 0
+	s.probing = false
+	s.state = BreakerClosed
+}
+
+// RecordFailure increments the failure count and may open the breaker.
+func (cb *CircuitBreaker) RecordFailure(host string) {
+	cb.mu.Lock()
+	defer cb.mu.Unlock()
+
+	s := cb.hostState(host)
+	s.failures++
+	s.probing = false
+	s.lastFailure = cb.clock.Now()
+	if s.failures >= cb.threshold {
+		s.state = BreakerOpen
+	}
+}
+
+// State returns the current state of the breaker for host.
+func (cb *CircuitBreaker) State(host string) BreakerState {
+	cb.mu.Lock()
+	defer cb.mu.Unlock()
+	return cb.hostState(host).state
+}

--- a/server/crawler/backoff.go
+++ b/server/crawler/backoff.go
@@ -99,10 +99,18 @@ type CircuitBreaker struct {
 
 // NewCircuitBreaker creates a CircuitBreaker. threshold is the number of
 // consecutive failures before opening; cooldown is the duration to wait before
-// entering half-open state.
+// entering half-open state. Values <= 0 are coalesced to safe defaults (5
+// failures, 5 minutes) so a zero config value doesn't open the breaker
+// immediately.
 func NewCircuitBreaker(threshold int, cooldown time.Duration, clock Clock) *CircuitBreaker {
 	if clock == nil {
 		clock = RealClock{}
+	}
+	if threshold <= 0 {
+		threshold = 5
+	}
+	if cooldown <= 0 {
+		cooldown = 5 * time.Minute
 	}
 	return &CircuitBreaker{
 		threshold: threshold,

--- a/server/crawler/backoff.go
+++ b/server/crawler/backoff.go
@@ -4,7 +4,7 @@ package crawler
 
 import (
 	"errors"
-	"math/rand"
+	randv2 "math/rand/v2"
 	"net"
 	"sync"
 	"time"
@@ -51,7 +51,6 @@ func ClassifyError(err error) (retryable bool, retryAfter time.Duration, statusC
 type Backoff struct {
 	initial time.Duration
 	max     time.Duration
-	rng     *rand.Rand
 }
 
 // NewBackoff creates a Backoff. initial and max must be positive.
@@ -59,7 +58,6 @@ func NewBackoff(initial, max time.Duration) *Backoff {
 	return &Backoff{
 		initial: initial,
 		max:     max,
-		rng:     rand.New(rand.NewSource(time.Now().UnixNano())),
 	}
 }
 
@@ -77,7 +75,7 @@ func (b *Backoff) Duration(attempt int) time.Duration {
 	if exp > b.max {
 		exp = b.max
 	}
-	jitter := time.Duration(b.rng.Int63n(int64(exp) + 1))
+	jitter := time.Duration(randv2.Int64N(int64(exp) + 1))
 	return jitter
 }
 

--- a/server/crawler/backoff_test.go
+++ b/server/crawler/backoff_test.go
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package crawler
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"testing"
+	"time"
+)
+
+func TestClassifyError(t *testing.T) {
+	tests := []struct {
+		name          string
+		err           error
+		wantRetryable bool
+		wantStatus    int
+	}{
+		{name: "nil error", err: nil, wantRetryable: false},
+		{name: "429", err: &HTTPStatusError{Status: 429}, wantRetryable: true, wantStatus: 429},
+		{name: "503", err: &HTTPStatusError{Status: 503}, wantRetryable: true, wantStatus: 503},
+		{name: "500", err: &HTTPStatusError{Status: 500}, wantRetryable: true, wantStatus: 500},
+		{name: "502", err: &HTTPStatusError{Status: 502}, wantRetryable: true, wantStatus: 502},
+		{name: "504", err: &HTTPStatusError{Status: 504}, wantRetryable: true, wantStatus: 504},
+		{name: "408", err: &HTTPStatusError{Status: 408}, wantRetryable: true, wantStatus: 408},
+		{name: "404", err: &HTTPStatusError{Status: 404}, wantRetryable: false, wantStatus: 404},
+		{name: "403", err: &HTTPStatusError{Status: 403}, wantRetryable: false, wantStatus: 403},
+		{name: "501", err: &HTTPStatusError{Status: 501}, wantRetryable: false, wantStatus: 501},
+		{name: "400", err: &HTTPStatusError{Status: 400}, wantRetryable: false, wantStatus: 400},
+		{
+			name: "network timeout",
+			err: &net.OpError{
+				Op:  "dial",
+				Err: fmt.Errorf("connection refused"),
+			},
+			wantRetryable: true,
+			wantStatus:    0,
+		},
+		{
+			name:          "wrapped non-retryable",
+			err:           fmt.Errorf("wrap: %w", &HTTPStatusError{Status: 403}),
+			wantRetryable: false,
+			wantStatus:    403,
+		},
+		{
+			name:          "wrapped retryable",
+			err:           fmt.Errorf("wrap: %w", &HTTPStatusError{Status: 503}),
+			wantRetryable: true,
+			wantStatus:    503,
+		},
+		{
+			name:          "generic error",
+			err:           errors.New("something went wrong"),
+			wantRetryable: false,
+			wantStatus:    0,
+		},
+		{
+			name:          "retry-after propagated",
+			err:           &HTTPStatusError{Status: 429, RetryAfter: 10 * time.Second},
+			wantRetryable: true,
+			wantStatus:    429,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			retryable, _, statusCode := ClassifyError(tt.err)
+			if retryable != tt.wantRetryable {
+				t.Errorf("ClassifyError(%v) retryable = %v, want %v", tt.err, retryable, tt.wantRetryable)
+			}
+			if statusCode != tt.wantStatus {
+				t.Errorf("ClassifyError(%v) statusCode = %d, want %d", tt.err, statusCode, tt.wantStatus)
+			}
+		})
+	}
+}
+
+func TestRetryAfterPropagated(t *testing.T) {
+	expected := 42 * time.Second
+	err := &HTTPStatusError{Status: 429, RetryAfter: expected}
+	_, retryAfter, _ := ClassifyError(err)
+	if retryAfter != expected {
+		t.Errorf("ClassifyError RetryAfter = %v, want %v", retryAfter, expected)
+	}
+}
+
+func TestBackoffBounds(t *testing.T) {
+	initial := 100 * time.Millisecond
+	max := 1 * time.Second
+	b := NewBackoff(initial, max)
+
+	for attempt := 0; attempt < 10; attempt++ {
+		d := b.Duration(attempt)
+		if d < 0 {
+			t.Errorf("attempt %d: Duration = %v, must be >= 0", attempt, d)
+		}
+		if d > max {
+			t.Errorf("attempt %d: Duration = %v exceeds max %v", attempt, d, max)
+		}
+	}
+}
+
+func TestBackoffIncreasesWithAttempt(t *testing.T) {
+	// With full jitter the result is random, but the cap should grow with attempt.
+	// Run many samples and verify the max seen grows.
+	initial := 10 * time.Millisecond
+	max := 1 * time.Second
+	b := NewBackoff(initial, max)
+
+	samples := 200
+	maxAttempt0 := time.Duration(0)
+	maxAttempt5 := time.Duration(0)
+	for i := 0; i < samples; i++ {
+		d0 := b.Duration(0)
+		d5 := b.Duration(5)
+		if d0 > maxAttempt0 {
+			maxAttempt0 = d0
+		}
+		if d5 > maxAttempt5 {
+			maxAttempt5 = d5
+		}
+	}
+	if maxAttempt5 <= maxAttempt0 {
+		t.Errorf("expected max sample for attempt 5 (%v) to exceed attempt 0 (%v)", maxAttempt5, maxAttempt0)
+	}
+}

--- a/server/crawler/bidi.go
+++ b/server/crawler/bidi.go
@@ -273,7 +273,7 @@ func (f *bidiFetcher) readLoop() {
 	}
 }
 
-func (f *bidiFetcher) fetchPage(ctx context.Context, rawURL string) (string, string, []string, error) {
+func (f *bidiFetcher) fetchPage(ctx context.Context, rawURL string, _ RequestHints) (string, []byte, []Link, FetchMeta, error) {
 	timeoutCtx, cancel := context.WithTimeout(ctx, f.timeout)
 	defer cancel()
 
@@ -282,14 +282,14 @@ func (f *bidiFetcher) fetchPage(ctx context.Context, rawURL string) (string, str
 		"type": "tab",
 	})
 	if err != nil {
-		return "", "", nil, fmt.Errorf("bidi: failed to create tab: %w", err)
+		return "", nil, nil, FetchMeta{}, fmt.Errorf("bidi: failed to create tab: %w", err)
 	}
 
 	var bc struct {
 		Context string `json:"context"`
 	}
 	if err := json.Unmarshal(bcData, &bc); err != nil {
-		return "", "", nil, fmt.Errorf("bidi: failed to parse browsingContext.create result: %w", err)
+		return "", nil, nil, FetchMeta{}, fmt.Errorf("bidi: failed to parse browsingContext.create result: %w", err)
 	}
 
 	contextID := bc.Context
@@ -310,7 +310,7 @@ func (f *bidiFetcher) fetchPage(ctx context.Context, rawURL string) (string, str
 		"wait":    "complete",
 	})
 	if err != nil {
-		return "", "", nil, fmt.Errorf("bidi: navigation to %s failed: %w", rawURL, err)
+		return "", nil, nil, FetchMeta{}, fmt.Errorf("bidi: navigation to %s failed: %w", rawURL, err)
 	}
 
 	var nav struct {
@@ -330,27 +330,27 @@ func (f *bidiFetcher) fetchPage(ctx context.Context, rawURL string) (string, str
 		select {
 		case <-time.After(f.captureDelay):
 		case <-timeoutCtx.Done():
-			return "", "", nil, fmt.Errorf("bidi: capture delay interrupted: %w", timeoutCtx.Err())
+			return "", nil, nil, FetchMeta{}, fmt.Errorf("bidi: capture delay interrupted: %w", timeoutCtx.Err())
 		}
 	}
 
 	// Extract the full page HTML using script.evaluate.
 	htmlContent, err := f.evaluateString(timeoutCtx, contextID, `document.documentElement.outerHTML`)
 	if err != nil {
-		return "", "", nil, fmt.Errorf("bidi: failed to get page HTML from %s: %w", rawURL, err)
+		return "", nil, nil, FetchMeta{}, fmt.Errorf("bidi: failed to get page HTML from %s: %w", rawURL, err)
 	}
 
-	// Extract link hrefs.
-	linkHrefs, err := f.evaluateStringArray(
+	// Extract link hrefs and rel attributes.
+	linkData, err := f.evaluateLinkArray(
 		timeoutCtx, contextID,
-		`Array.from(document.querySelectorAll('a[href]')).map(a => a.getAttribute('href'))`,
+		`Array.from(document.querySelectorAll('a[href]')).map(a => [a.getAttribute('href'), a.getAttribute('rel') || ''])`,
 	)
 	if err != nil {
 		log.Debug().Err(err).Str("url", rawURL).Msg("bidi: failed to extract links")
-		linkHrefs = nil
+		linkData = nil
 	}
 
-	return finalURL, htmlContent, linkHrefs, nil
+	return finalURL, []byte(htmlContent), linkData, FetchMeta{}, nil
 }
 
 // evaluateString runs a JS expression and returns the string result.
@@ -385,8 +385,9 @@ func (f *bidiFetcher) evaluateString(ctx context.Context, contextID, expression 
 	return res.Result.Value, nil
 }
 
-// evaluateStringArray runs a JS expression and returns a []string result.
-func (f *bidiFetcher) evaluateStringArray(ctx context.Context, contextID, expression string) ([]string, error) {
+// evaluateLinkArray runs a JS expression that returns [[href, rel], ...] and
+// maps the results to []Link.
+func (f *bidiFetcher) evaluateLinkArray(ctx context.Context, contextID, expression string) ([]Link, error) {
 	data, err := f.call(ctx, "script.evaluate", map[string]any{
 		"expression":      expression,
 		"target":          map[string]any{"context": contextID},
@@ -403,12 +404,15 @@ func (f *bidiFetcher) evaluateStringArray(ctx context.Context, contextID, expres
 			Type  string `json:"type"`
 			Value []struct {
 				Type  string `json:"type"`
-				Value string `json:"value"`
+				Value []struct {
+					Type  string `json:"type"`
+					Value string `json:"value"`
+				} `json:"value"`
 			} `json:"value"`
 		} `json:"result"`
 	}
 	if err := json.Unmarshal(data, &res); err != nil {
-		return nil, fmt.Errorf("bidi: failed to parse array result: %w", err)
+		return nil, fmt.Errorf("bidi: failed to parse link array result: %w", err)
 	}
 	if res.Type == "exception" {
 		return nil, fmt.Errorf("bidi: script exception: %s", string(data))
@@ -417,13 +421,18 @@ func (f *bidiFetcher) evaluateStringArray(ctx context.Context, contextID, expres
 		return nil, fmt.Errorf("bidi: expected array result, got %q", res.Result.Type)
 	}
 
-	out := make([]string, 0, len(res.Result.Value))
+	links := make([]Link, 0, len(res.Result.Value))
 	for _, item := range res.Result.Value {
-		if item.Type == "string" {
-			out = append(out, item.Value)
+		if item.Type != "array" || len(item.Value) < 2 {
+			continue
+		}
+		href := item.Value[0].Value
+		rel := item.Value[1].Value
+		if href != "" {
+			links = append(links, Link{Href: href, Rel: rel})
 		}
 	}
-	return out, nil
+	return links, nil
 }
 
 func (f *bidiFetcher) close() error {

--- a/server/crawler/budget.go
+++ b/server/crawler/budget.go
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package crawler
+
+import (
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/asciimoo/hister/config"
+)
+
+type hostBudget struct {
+	pages atomic.Int64
+	bytes atomic.Int64
+}
+
+// Budget tracks global and per-host resource consumption against configured limits.
+// All methods are safe for concurrent use.
+type Budget struct {
+	limits        config.CrawlerLimits
+	startTime     time.Time
+	clock         Clock
+	pages         atomic.Int64
+	bytes         atomic.Int64
+	perHost       sync.Map // host -> *hostBudget
+	hostOverrides map[string]config.CrawlerHostOverride
+}
+
+// NewBudget creates a Budget with the given limits and overrides.
+func NewBudget(limits config.CrawlerLimits, overrides map[string]config.CrawlerHostOverride, clock Clock) *Budget {
+	if clock == nil {
+		clock = RealClock{}
+	}
+	return &Budget{
+		limits:        limits,
+		startTime:     clock.Now(),
+		clock:         clock,
+		hostOverrides: overrides,
+	}
+}
+
+func (b *Budget) hostBudget(host string) *hostBudget {
+	v, _ := b.perHost.LoadOrStore(host, &hostBudget{})
+	return v.(*hostBudget)
+}
+
+// TryReservePage atomically checks and increments the page counter for both
+// global and per-host limits. Returns false if either limit would be exceeded.
+func (b *Budget) TryReservePage(host string) bool {
+	hb := b.hostBudget(host)
+
+	// Check per-host page limit (from override or global config).
+	hostMaxPages := b.limits.MaxPagesPerHost
+	if ov, ok := b.hostOverrides[host]; ok && ov.MaxPages > 0 {
+		hostMaxPages = ov.MaxPages
+	}
+	if hostMaxPages > 0 {
+		cur := hb.pages.Load()
+		if cur >= int64(hostMaxPages) {
+			return false
+		}
+	}
+
+	// Check global page limit.
+	if b.limits.MaxPages > 0 {
+		cur := b.pages.Load()
+		if cur >= int64(b.limits.MaxPages) {
+			return false
+		}
+	}
+
+	b.pages.Add(1)
+	hb.pages.Add(1)
+	return true
+}
+
+// AddBytes records n bytes fetched for the given host.
+func (b *Budget) AddBytes(host string, n int64) {
+	b.bytes.Add(n)
+	b.hostBudget(host).bytes.Add(n)
+}
+
+// Exhausted returns true if any global limit has been reached.
+func (b *Budget) Exhausted() bool {
+	if b.limits.MaxPages > 0 && b.pages.Load() >= int64(b.limits.MaxPages) {
+		return true
+	}
+	if b.limits.MaxDuration > 0 {
+		elapsed := b.clock.Now().Sub(b.startTime)
+		if elapsed >= time.Duration(b.limits.MaxDuration)*time.Second {
+			return true
+		}
+	}
+	return false
+}
+
+// HostExhausted returns true if the per-host page or byte limit has been reached.
+func (b *Budget) HostExhausted(host string) bool {
+	hb := b.hostBudget(host)
+
+	hostMaxPages := b.limits.MaxPagesPerHost
+	if ov, ok := b.hostOverrides[host]; ok && ov.MaxPages > 0 {
+		hostMaxPages = ov.MaxPages
+	}
+	if hostMaxPages > 0 && hb.pages.Load() >= int64(hostMaxPages) {
+		return true
+	}
+	if b.limits.MaxBytesPerHost > 0 && hb.bytes.Load() >= b.limits.MaxBytesPerHost {
+		return true
+	}
+	return false
+}

--- a/server/crawler/budget_integration_test.go
+++ b/server/crawler/budget_integration_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/asciimoo/hister/config"
 )
@@ -103,6 +104,33 @@ func TestBudgetMaxPagesPerHost(t *testing.T) {
 	// The start URL uses the 1 allowed page for example.com; /a and /b are skipped.
 	if calls != 1 {
 		t.Errorf("expected exactly 1 fetch with MaxPagesPerHost=1, got %d", calls)
+	}
+}
+
+// TestBudgetNoOvercountOnSchedulerError verifies that aborting a crawl via
+// context cancellation (simulating scheduler.Wait returning an error) does not
+// cause the budget page counter to exceed MaxPages.
+func TestBudgetNoOvercountOnSchedulerError(t *testing.T) {
+	clock := NewFakeClock(time.Now())
+	limits := config.CrawlerLimits{MaxPages: 2}
+	budget := NewBudget(limits, nil, clock)
+
+	// Reserve two pages normally.
+	if !budget.TryReservePage("example.com") {
+		t.Fatal("first TryReservePage should succeed")
+	}
+	if !budget.TryReservePage("example.com") {
+		t.Fatal("second TryReservePage should succeed")
+	}
+
+	// A third reservation (simulating the race before the fix) must fail.
+	if budget.TryReservePage("example.com") {
+		t.Error("third TryReservePage should fail when MaxPages=2")
+	}
+
+	// Budget counter must not exceed MaxPages.
+	if got := budget.pages.Load(); got > int64(limits.MaxPages) {
+		t.Errorf("budget pages counter = %d, want <= %d", got, limits.MaxPages)
 	}
 }
 

--- a/server/crawler/budget_integration_test.go
+++ b/server/crawler/budget_integration_test.go
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package crawler
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+
+	"github.com/asciimoo/hister/config"
+)
+
+// countingFetcher is a minimal fetcher that tracks how many times it is called.
+type countingFetcher struct {
+	calls   atomic.Int64
+	bodyLen int // body size to return per call
+	links   []Link
+}
+
+func (f *countingFetcher) fetchPage(_ context.Context, rawURL string, _ RequestHints) (string, []byte, []Link, FetchMeta, error) {
+	f.calls.Add(1)
+	body := make([]byte, f.bodyLen)
+	return rawURL, body, f.links, FetchMeta{StatusCode: 200}, nil
+}
+
+func (f *countingFetcher) close() error { return nil }
+
+func newBudgetCrawler(limits config.CrawlerLimits, f fetcher, links []Link) *baseCrawler {
+	cfg := &config.CrawlerConfig{
+		Rate: config.CrawlerRate{
+			GlobalRPS:          1000,
+			PerHostRPS:         1000,
+			GlobalConcurrency:  1,
+			PerHostConcurrency: 1,
+		},
+		Limits: limits,
+	}
+	o := options{}
+	bc := newBaseCrawler(f, cfg, nil, o)
+	return bc
+}
+
+func TestBudgetMaxPages(t *testing.T) {
+	// Set MaxPages=2; fetcher returns 5 links back to itself.
+	links := []Link{
+		{Href: "http://example.com/1"},
+		{Href: "http://example.com/2"},
+		{Href: "http://example.com/3"},
+		{Href: "http://example.com/4"},
+		{Href: "http://example.com/5"},
+	}
+	cf := &countingFetcher{bodyLen: 10, links: links}
+	bc := newBudgetCrawler(config.CrawlerLimits{MaxPages: 2}, cf, links)
+
+	v, err := NewValidator(&ValidatorRules{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ch, err := bc.Crawl(context.Background(), "http://example.com/", v)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var docs int
+	for range ch {
+		docs++
+	}
+
+	calls := cf.calls.Load()
+	// MaxPages=2 means at most 2 TryReservePage successes; fetcher called at most 2 times.
+	// (The start URL counts as 1 reservation.)
+	if calls > 2 {
+		t.Errorf("expected at most 2 fetches with MaxPages=2, got %d", calls)
+	}
+}
+
+func TestBudgetMaxPagesPerHost(t *testing.T) {
+	// Set MaxPagesPerHost=1; seed with 3 URLs from same host.
+	cf := &countingFetcher{bodyLen: 10, links: nil}
+	bc := newBudgetCrawler(config.CrawlerLimits{MaxPagesPerHost: 1}, cf, nil)
+
+	v, err := NewValidator(&ValidatorRules{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// We crawl a start URL that returns 2 more links on the same host.
+	cf.links = []Link{
+		{Href: "http://example.com/a"},
+		{Href: "http://example.com/b"},
+	}
+
+	ch, err := bc.Crawl(context.Background(), "http://example.com/", v)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for range ch {
+	}
+
+	calls := cf.calls.Load()
+	// The start URL uses the 1 allowed page for example.com; /a and /b are skipped.
+	if calls != 1 {
+		t.Errorf("expected exactly 1 fetch with MaxPagesPerHost=1, got %d", calls)
+	}
+}
+
+func TestBudgetMaxBytesPerHost(t *testing.T) {
+	// Set MaxBytesPerHost=100; fetcher returns 60-byte body.
+	// First fetch (60 bytes) succeeds; second URL from same host is skipped because
+	// after AddBytes the next TryReservePage call for that host would proceed but
+	// HostExhausted returns true once 100 bytes exceeded on second fetch.
+	// Actually: budget checks happen before fetch, bytes added after.
+	// So both could pass budget check; after first fetch bytes=60 < 100.
+	// After second fetch bytes would be 120 > 100 but we already fetched.
+	// HostExhausted checks bytes BEFORE fetch, so: first fetch: 0 < 100 ok, bytes->60.
+	// Second fetch: 60 < 100 ok, bytes->120. Third fetch: 120 >= 100 skip.
+	// Provide 3 links so we can observe the 3rd being skipped.
+	cf := &countingFetcher{bodyLen: 60, links: nil}
+	bc := newBudgetCrawler(config.CrawlerLimits{MaxBytesPerHost: 100}, cf, nil)
+
+	v, err := NewValidator(&ValidatorRules{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cf.links = []Link{
+		{Href: "http://example.com/a"},
+		{Href: "http://example.com/b"},
+	}
+
+	ch, err := bc.Crawl(context.Background(), "http://example.com/", v)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for range ch {
+	}
+
+	calls := cf.calls.Load()
+	// start URL + /a fetched (2 fetches, 120 bytes total after). /b should be skipped.
+	if calls > 2 {
+		t.Errorf("expected at most 2 fetches with MaxBytesPerHost=100 and 60-byte body, got %d", calls)
+	}
+}

--- a/server/crawler/chromedp.go
+++ b/server/crawler/chromedp.go
@@ -128,7 +128,7 @@ func (f *chromedpFetcher) fetchPage(ctx context.Context, rawURL string, _ Reques
 	}
 
 	var htmlContent string
-	var linkData []string
+	var linkData [][]string
 	var finalURL string
 
 	actions = append(
@@ -144,7 +144,7 @@ func (f *chromedpFetcher) fetchPage(ctx context.Context, rawURL string, _ Reques
 		chromedp.Location(&finalURL),
 		chromedp.OuterHTML("html", &htmlContent, chromedp.ByQuery),
 		chromedp.Evaluate(
-			`Array.from(document.querySelectorAll('a[href]')).map(a => ({href: a.getAttribute('href'), rel: a.getAttribute('rel') || ''}))`,
+			`Array.from(document.querySelectorAll('a[href]')).map(a => [a.getAttribute('href'), a.getAttribute('rel') || ''])`,
 			&linkData,
 		),
 	)
@@ -157,29 +157,15 @@ func (f *chromedpFetcher) fetchPage(ctx context.Context, rawURL string, _ Reques
 		finalURL = rawURL
 	}
 
-	// Parse the JS result into []Link. The Evaluate above uses a struct-like
-	// object but chromedp decodes it as a JSON array into []string when using
-	// a string slice target. Use a map slice target instead.
-	links := jsObjectsToLinks(linkData)
+	links := make([]Link, 0, len(linkData))
+	for _, row := range linkData {
+		if len(row) < 2 || row[0] == "" {
+			continue
+		}
+		links = append(links, Link{Href: row[0], Rel: row[1]})
+	}
 
 	return finalURL, []byte(htmlContent), links, FetchMeta{}, nil
-}
-
-// jsObjectsToLinks is a best-effort parser for the chromedp JS result.
-// The evaluate expression returns [{href:"...", rel:"..."}] serialised as JSON.
-// chromedp may decode each element as a string representation; we handle both.
-func jsObjectsToLinks(raw []string) []Link {
-	// chromedp with a []string target will return JSON string representations
-	// of each object. Fall back to href-only extraction.
-	links := make([]Link, 0, len(raw))
-	for _, s := range raw {
-		// Each element is something like: map[href:URL rel:nofollow]
-		// or the string form. Since we can't easily parse, just use as href.
-		if s != "" {
-			links = append(links, Link{Href: s})
-		}
-	}
-	return links
 }
 
 func (f *chromedpFetcher) close() error {

--- a/server/crawler/chromedp.go
+++ b/server/crawler/chromedp.go
@@ -81,12 +81,21 @@ func newChromedpFetcher(cfg *config.CrawlerConfig) (*chromedpFetcher, error) {
 	}, nil
 }
 
-func (f *chromedpFetcher) fetchPage(ctx context.Context, rawURL string) (string, string, []string, error) {
+func (f *chromedpFetcher) fetchPage(ctx context.Context, rawURL string, _ RequestHints) (string, []byte, []Link, FetchMeta, error) {
 	taskCtx, taskCancel := chromedp.NewContext(f.allocCtx)
 	defer taskCancel()
 
 	timeoutCtx, timeoutCancel := context.WithTimeout(taskCtx, f.timeout)
 	defer timeoutCancel()
+
+	// Also honour the caller's context for graceful shutdown.
+	go func() {
+		select {
+		case <-ctx.Done():
+			timeoutCancel()
+		case <-timeoutCtx.Done():
+		}
+	}()
 
 	var actions []chromedp.Action
 
@@ -119,7 +128,7 @@ func (f *chromedpFetcher) fetchPage(ctx context.Context, rawURL string) (string,
 	}
 
 	var htmlContent string
-	var linkHrefs []string
+	var linkData []string
 	var finalURL string
 
 	actions = append(
@@ -135,19 +144,42 @@ func (f *chromedpFetcher) fetchPage(ctx context.Context, rawURL string) (string,
 		chromedp.Location(&finalURL),
 		chromedp.OuterHTML("html", &htmlContent, chromedp.ByQuery),
 		chromedp.Evaluate(
-			`Array.from(document.querySelectorAll('a[href]')).map(a => a.getAttribute('href'))`,
-			&linkHrefs,
+			`Array.from(document.querySelectorAll('a[href]')).map(a => ({href: a.getAttribute('href'), rel: a.getAttribute('rel') || ''}))`,
+			&linkData,
 		),
 	)
 
 	if err := chromedp.Run(timeoutCtx, actions...); err != nil {
-		return "", "", nil, err
+		return "", nil, nil, FetchMeta{}, err
 	}
 
 	if finalURL == "" {
 		finalURL = rawURL
 	}
-	return finalURL, htmlContent, linkHrefs, nil
+
+	// Parse the JS result into []Link. The Evaluate above uses a struct-like
+	// object but chromedp decodes it as a JSON array into []string when using
+	// a string slice target. Use a map slice target instead.
+	links := jsObjectsToLinks(linkData)
+
+	return finalURL, []byte(htmlContent), links, FetchMeta{}, nil
+}
+
+// jsObjectsToLinks is a best-effort parser for the chromedp JS result.
+// The evaluate expression returns [{href:"...", rel:"..."}] serialised as JSON.
+// chromedp may decode each element as a string representation; we handle both.
+func jsObjectsToLinks(raw []string) []Link {
+	// chromedp with a []string target will return JSON string representations
+	// of each object. Fall back to href-only extraction.
+	links := make([]Link, 0, len(raw))
+	for _, s := range raw {
+		// Each element is something like: map[href:URL rel:nofollow]
+		// or the string form. Since we can't easily parse, just use as href.
+		if s != "" {
+			links = append(links, Link{Href: s})
+		}
+	}
+	return links
 }
 
 func (f *chromedpFetcher) close() error {

--- a/server/crawler/clock.go
+++ b/server/crawler/clock.go
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package crawler
+
+import (
+	"sync"
+	"time"
+)
+
+// Clock abstracts time operations so they can be controlled in tests.
+type Clock interface {
+	Now() time.Time
+	Sleep(d time.Duration)
+	After(d time.Duration) <-chan time.Time
+	NewTimer(d time.Duration) Timer
+}
+
+// Timer abstracts a time.Timer.
+type Timer interface {
+	C() <-chan time.Time
+	Stop() bool
+	Reset(d time.Duration) bool
+}
+
+// RealClock is a Clock backed by the real system clock.
+type RealClock struct{}
+
+func (RealClock) Now() time.Time                         { return time.Now() }
+func (RealClock) Sleep(d time.Duration)                  { time.Sleep(d) }
+func (RealClock) After(d time.Duration) <-chan time.Time { return time.After(d) }
+func (RealClock) NewTimer(d time.Duration) Timer         { return &realTimer{t: time.NewTimer(d)} }
+
+type realTimer struct{ t *time.Timer }
+
+func (r *realTimer) C() <-chan time.Time     { return r.t.C }
+func (r *realTimer) Stop() bool              { return r.t.Stop() }
+func (r *realTimer) Reset(d time.Duration) bool {
+	r.t.Reset(d)
+	return true
+}
+
+// FakeClock is a Clock for tests that allows manual time advancement.
+type FakeClock struct {
+	mu      sync.Mutex
+	now     time.Time
+	timers  []*fakeTimer
+}
+
+// NewFakeClock creates a FakeClock starting at t.
+func NewFakeClock(t time.Time) *FakeClock {
+	return &FakeClock{now: t}
+}
+
+func (f *FakeClock) Now() time.Time {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.now
+}
+
+func (f *FakeClock) Sleep(d time.Duration) {
+	ch := f.After(d)
+	<-ch
+}
+
+func (f *FakeClock) After(d time.Duration) <-chan time.Time {
+	t := f.NewTimer(d)
+	return t.C()
+}
+
+func (f *FakeClock) NewTimer(d time.Duration) Timer {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	ft := &fakeTimer{
+		ch:       make(chan time.Time, 1),
+		deadline: f.now.Add(d),
+		clock:    f,
+	}
+	f.timers = append(f.timers, ft)
+	return ft
+}
+
+// Advance moves the fake clock forward by d, firing any expired timers.
+func (f *FakeClock) Advance(d time.Duration) {
+	f.mu.Lock()
+	f.now = f.now.Add(d)
+	now := f.now
+	// Collect fired timers before releasing the lock.
+	var fired []*fakeTimer
+	remaining := f.timers[:0]
+	for _, t := range f.timers {
+		if !t.stopped && !t.deadline.After(now) {
+			fired = append(fired, t)
+		} else {
+			remaining = append(remaining, t)
+		}
+	}
+	f.timers = remaining
+	f.mu.Unlock()
+
+	for _, t := range fired {
+		select {
+		case t.ch <- now:
+		default:
+		}
+	}
+}
+
+type fakeTimer struct {
+	ch       chan time.Time
+	deadline time.Time
+	stopped  bool
+	clock    *FakeClock
+}
+
+func (t *fakeTimer) C() <-chan time.Time { return t.ch }
+
+func (t *fakeTimer) Stop() bool {
+	t.clock.mu.Lock()
+	defer t.clock.mu.Unlock()
+	if t.stopped {
+		return false
+	}
+	t.stopped = true
+	return true
+}
+
+func (t *fakeTimer) Reset(d time.Duration) bool {
+	t.clock.mu.Lock()
+	defer t.clock.mu.Unlock()
+	wasActive := !t.stopped
+	t.stopped = false
+	t.deadline = t.clock.now.Add(d)
+	t.clock.timers = append(t.clock.timers, t)
+	return wasActive
+}

--- a/server/crawler/crawler.go
+++ b/server/crawler/crawler.go
@@ -321,6 +321,12 @@ func (c *baseCrawler) bfsCrawl(ctx context.Context, startURL string, v *Validato
 						goto done
 					}
 
+					if !c.budget.TryReservePage(host) {
+						c.scheduler.Release(host)
+						log.Info().Str("url", item.rawURL).Str("host", host).Msg("crawler: page reservation failed (budget)")
+						goto done
+					}
+
 					start := c.clock.Now()
 					finalURL, body, links, meta, fetchErr := c.fetcher.fetchPage(fetchCtx, item.rawURL, RequestHints{})
 					elapsed := c.clock.Now().Sub(start)
@@ -400,10 +406,6 @@ func (c *baseCrawler) bfsCrawl(ctx context.Context, startURL string, v *Validato
 				host := parsedU.Hostname()
 				if c.budget.HostExhausted(host) {
 					log.Info().Str("url", item.rawURL).Str("host", host).Msg("crawler: per-host budget reached, skipping")
-					continue
-				}
-				if !c.budget.TryReservePage(host) {
-					log.Info().Str("url", item.rawURL).Str("host", host).Msg("crawler: page reservation failed (budget)")
 					continue
 				}
 			}

--- a/server/crawler/crawler.go
+++ b/server/crawler/crawler.go
@@ -3,11 +3,15 @@
 package crawler
 
 import (
+	"container/list"
 	"context"
 	"fmt"
+	"hash/fnv"
 	"io"
 	"net/url"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"golang.org/x/net/html"
@@ -54,15 +58,75 @@ type fetcher interface {
 	close() error
 }
 
-// errResponseTooLarge is returned when a response body exceeds the configured limit.
-var errResponseTooLarge = fmt.Errorf("response body exceeds size limit")
+// HostStats tracks per-host counters.
+type HostStats struct {
+	Pages  atomic.Int64
+	Bytes  atomic.Int64
+	Errors atomic.Int64
+}
+
+// CrawlerStatsSnapshot is a point-in-time copy of CrawlerStats.
+type CrawlerStatsSnapshot struct {
+	Pages        int64
+	Bytes        int64
+	Count2xx     int64
+	Count3xx     int64
+	Count4xx     int64
+	Count5xx     int64
+	Retries      int64
+	BreakerTrips int64
+	RobotsDenials int64
+	BudgetStops  int64
+}
+
+// CrawlerStats holds atomic counters for a single crawl.
+type CrawlerStats struct {
+	Pages         atomic.Int64
+	Bytes         atomic.Int64
+	Count2xx      atomic.Int64
+	Count3xx      atomic.Int64
+	Count4xx      atomic.Int64
+	Count5xx      atomic.Int64
+	Retries       atomic.Int64
+	BreakerTrips  atomic.Int64
+	RobotsDenials atomic.Int64
+	BudgetStops   atomic.Int64
+	PerHost       sync.Map // host -> *HostStats
+}
+
+// Snapshot returns a point-in-time copy of the stats.
+func (s *CrawlerStats) Snapshot() CrawlerStatsSnapshot {
+	return CrawlerStatsSnapshot{
+		Pages:         s.Pages.Load(),
+		Bytes:         s.Bytes.Load(),
+		Count2xx:      s.Count2xx.Load(),
+		Count3xx:      s.Count3xx.Load(),
+		Count4xx:      s.Count4xx.Load(),
+		Count5xx:      s.Count5xx.Load(),
+		Retries:       s.Retries.Load(),
+		BreakerTrips:  s.BreakerTrips.Load(),
+		RobotsDenials: s.RobotsDenials.Load(),
+		BudgetStops:   s.BudgetStops.Load(),
+	}
+}
+
+func (s *CrawlerStats) hostStats(host string) *HostStats {
+	v, _ := s.PerHost.LoadOrStore(host, &HostStats{})
+	return v.(*HostStats)
+}
 
 // baseCrawler wraps a fetcher with BFS traversal logic.
 type baseCrawler struct {
 	fetcher        fetcher
 	cfg            *config.CrawlerConfig
-	robots         *RobotsCache // nil means robots.txt enforcement is disabled
+	robots         *RobotsCache
 	skipURLChecker SkipURLChecker
+	scheduler      *Scheduler
+	budget         *Budget
+	breaker        *CircuitBreaker
+	backoff        *Backoff
+	stats          *CrawlerStats
+	clock          Clock
 }
 
 // New creates a Crawler backed by the backend specified in cfg.Backend.
@@ -84,7 +148,38 @@ func New(cfg *config.CrawlerConfig, robots *RobotsCache, opts ...Option) (Crawle
 	if err != nil {
 		return nil, fmt.Errorf("%s backend: %w", crawlerBackendName(cfg), err)
 	}
-	return &baseCrawler{fetcher: f, cfg: cfg, robots: robots, skipURLChecker: o.skipURLChecker}, nil
+	return newBaseCrawler(f, cfg, robots, o), nil
+}
+
+func newBaseCrawler(f fetcher, cfg *config.CrawlerConfig, robots *RobotsCache, o options) *baseCrawler {
+	clock := RealClock{}
+	cooldown := time.Duration(cfg.CircuitBreaker.Cooldown) * time.Second
+	if cooldown == 0 {
+		cooldown = 5 * time.Minute
+	}
+	breaker := NewCircuitBreaker(cfg.CircuitBreaker.ConsecutiveFailures, cooldown, clock)
+	budget := NewBudget(cfg.Limits, cfg.Hosts, clock)
+	scheduler := NewScheduler(cfg, breaker, robots, clock)
+	initial := time.Duration(cfg.Retry.InitialBackoff) * time.Second
+	if initial == 0 {
+		initial = time.Second
+	}
+	maxB := time.Duration(cfg.Retry.MaxBackoff) * time.Second
+	if maxB == 0 {
+		maxB = 30 * time.Second
+	}
+	return &baseCrawler{
+		fetcher:        f,
+		cfg:            cfg,
+		robots:         robots,
+		skipURLChecker: o.skipURLChecker,
+		scheduler:      scheduler,
+		budget:         budget,
+		breaker:        breaker,
+		backoff:        NewBackoff(initial, maxB),
+		stats:          &CrawlerStats{},
+		clock:          clock,
+	}
 }
 
 func crawlerBackendName(cfg *config.CrawlerConfig) string {
@@ -141,6 +236,7 @@ func (c *baseCrawler) Crawl(ctx context.Context, startURL string, v *Validator) 
 
 // Close releases resources held by the underlying backend.
 func (c *baseCrawler) Close() error {
+	c.scheduler.Stop()
 	return c.fetcher.close()
 }
 
@@ -149,95 +245,340 @@ type queueItem struct {
 	depth  int
 }
 
+// seenSet deduplicates URLs using FNV-64 hashes to keep memory compact.
+type seenSet struct {
+	m map[uint64]struct{}
+}
+
+func newSeenSet() *seenSet {
+	return &seenSet{m: make(map[uint64]struct{})}
+}
+
+func (s *seenSet) add(key string) {
+	s.m[hashURL(key)] = struct{}{}
+}
+
+func (s *seenSet) contains(key string) bool {
+	_, ok := s.m[hashURL(key)]
+	return ok
+}
+
+func hashURL(key string) uint64 {
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(key))
+	return h.Sum64()
+}
+
 func (c *baseCrawler) bfsCrawl(ctx context.Context, startURL string, v *Validator, ch chan<- *document.Document) {
-	queue := []queueItem{{startURL, 0}}
-	seen := map[string]struct{}{startURL: {}}
+	// Graceful shutdown: crawlCtx cancels when caller cancels. fetchCtx is
+	// cancelled after shutdown grace period.
+	grace := time.Duration(c.cfg.ShutdownGrace) * time.Second
+	if grace == 0 {
+		grace = 30 * time.Second
+	}
 
-	for len(queue) > 0 {
+	crawlCtx, crawlCancel := context.WithCancel(ctx)
+	defer crawlCancel()
+
+	fetchCtx, fetchCancel := context.WithCancel(context.Background())
+	defer fetchCancel()
+
+	// When crawlCtx is cancelled, start grace-period countdown then cancel fetchCtx.
+	go func() {
+		<-crawlCtx.Done()
 		select {
-		case <-ctx.Done():
-			return
-		default:
+		case <-c.clock.After(grace):
+		case <-fetchCtx.Done():
 		}
+		fetchCancel()
+	}()
 
-		cur := queue[0]
-		queue = queue[1:]
+	queue := list.New()
+	seen := newSeenSet()
 
-		parsedURL, err := url.Parse(cur.rawURL)
-		if err != nil {
-			continue
-		}
+	normStart, err := normalizeRawURL(startURL)
+	if err != nil {
+		normStart = startURL
+	}
+	seen.add(normStart)
+	queue.PushBack(queueItem{startURL, 0})
 
-		switch v.Validate(parsedURL, cur.depth) {
-		case URLStop:
-			return
-		case URLSkip:
-			log.Info().Str("url", cur.rawURL).Int("depth", cur.depth).Msg("crawler: skipping URL by crawler rules")
-			continue
-		}
+	concurrency := c.cfg.Rate.GlobalConcurrency
+	if concurrency < 1 {
+		concurrency = 1
+	}
 
-		if c.robots != nil && !c.robots.Allowed(ctx, cur.rawURL) {
-			log.Info().Str("url", cur.rawURL).Msg("crawler: skipping URL disallowed by robots.txt")
-			continue
-		}
+	type result struct {
+		item      queueItem
+		finalURL  string
+		body      []byte
+		links     []Link
+		meta      FetchMeta
+		err       error
+		attempt   int
+		durationMs int64
+	}
 
-		if c.skipURLChecker != nil {
-			skip, err := c.skipURLChecker(cur.rawURL)
-			if err != nil {
-				log.Warn().Err(err).Str("url", cur.rawURL).Msg("crawler: failed to check whether URL should be skipped")
-			} else if skip {
-				log.Info().Str("url", cur.rawURL).Msg("crawler: skipping URL by prefetch skip predicate")
-				continue
+	work := make(chan queueItem, concurrency)
+	results := make(chan result, concurrency)
+	var wg sync.WaitGroup
+
+	// Worker goroutines.
+	maxAttempts := c.cfg.Retry.MaxAttempts
+	if maxAttempts < 1 {
+		maxAttempts = 1
+	}
+
+	for i := 0; i < concurrency; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for item := range work {
+				parsedURL, err := url.Parse(item.rawURL)
+				if err != nil {
+					results <- result{item: item, err: err}
+					continue
+				}
+				host := parsedURL.Hostname()
+
+				var res result
+				res.item = item
+
+				for attempt := 0; attempt < maxAttempts; attempt++ {
+					if attempt > 0 {
+						c.stats.Retries.Add(1)
+						wait := c.backoff.Duration(attempt)
+						select {
+						case <-fetchCtx.Done():
+							res.err = fetchCtx.Err()
+							goto done
+						case <-c.clock.After(wait):
+						}
+					}
+
+					if err := c.scheduler.Wait(crawlCtx, host); err != nil {
+						res.err = err
+						goto done
+					}
+
+					start := c.clock.Now()
+					finalURL, body, links, meta, fetchErr := c.fetcher.fetchPage(fetchCtx, item.rawURL, RequestHints{})
+					elapsed := c.clock.Now().Sub(start)
+
+					c.scheduler.Release(host)
+
+					res.attempt = attempt + 1
+					res.durationMs = elapsed.Milliseconds()
+
+					if fetchErr != nil {
+						retryable, retryAfter, statusCode := ClassifyError(fetchErr)
+						log.Warn().
+							Err(fetchErr).
+							Str("url", item.rawURL).
+							Str("host", host).
+							Int("status", statusCode).
+							Int("attempt", attempt+1).
+							Msg("crawler: fetch error")
+
+						if retryAfter > 0 {
+							c.scheduler.Cooldown(host, retryAfter)
+						}
+
+						if retryable && attempt < maxAttempts-1 {
+							c.breaker.RecordFailure(host)
+							continue
+						}
+						c.breaker.RecordFailure(host)
+						res.err = fetchErr
+						goto done
+					}
+
+					c.breaker.RecordSuccess(host)
+					res.finalURL = finalURL
+					res.body = body
+					res.links = links
+					res.meta = meta
+					goto done
+				}
+			done:
+				results <- res
 			}
-		}
+		}()
+	}
 
-		if c.cfg.Delay > 0 {
+	// Close results when all workers are done.
+	go func() {
+		wg.Wait()
+		close(results)
+	}()
+
+	// Dispatcher: feed work to workers, collect results.
+	inFlight := 0
+	dispatch := func() {
+		for inFlight < concurrency && queue.Len() > 0 {
+			front := queue.Front()
+			queue.Remove(front)
+			item := front.Value.(queueItem)
+
 			select {
-			case <-time.After(time.Duration(c.cfg.Delay) * time.Second):
-			case <-ctx.Done():
+			case <-crawlCtx.Done():
 				return
+			case work <- item:
+				inFlight++
 			}
 		}
+	}
 
-		finalURL, body, links, _, err := c.fetcher.fetchPage(ctx, cur.rawURL, RequestHints{})
-		if err != nil {
-			log.Warn().Err(err).Str("url", cur.rawURL).Msg("crawler: failed to fetch page")
+	dispatch()
+
+	for inFlight > 0 {
+		res, ok := <-results
+		if !ok {
+			break
+		}
+		inFlight--
+
+		if res.err != nil {
+			hs := c.stats.hostStats("")
+			if res.item.rawURL != "" {
+				parsed, pErr := url.Parse(res.item.rawURL)
+				if pErr == nil {
+					hs = c.stats.hostStats(parsed.Hostname())
+				}
+			}
+			hs.Errors.Add(1)
+			dispatch()
 			continue
 		}
 
-		// If the server redirected to a different URL, mark it seen so it
-		// won't be queued again (e.g. /path/ -> /path). Use the final URL
-		// for the document and as the base for link resolution.
-		if finalURL != cur.rawURL {
-			seen[finalURL] = struct{}{}
-		}
-		finalParsed, err := url.Parse(finalURL)
+		// Re-validate the final URL (it may differ from the queued URL after redirects).
+		finalParsed, err := url.Parse(res.finalURL)
 		if err != nil {
-			finalParsed = parsedURL
+			dispatch()
+			continue
 		}
+
+		host := finalParsed.Hostname()
+		hs := c.stats.hostStats(host)
+
+		// Record stats.
+		bodyLen := int64(len(res.body))
+		c.stats.Pages.Add(1)
+		c.stats.Bytes.Add(bodyLen)
+		hs.Pages.Add(1)
+		hs.Bytes.Add(bodyLen)
+		c.budget.AddBytes(host, bodyLen)
+
+		switch {
+		case res.meta.StatusCode >= 200 && res.meta.StatusCode < 300:
+			c.stats.Count2xx.Add(1)
+		case res.meta.StatusCode >= 300 && res.meta.StatusCode < 400:
+			c.stats.Count3xx.Add(1)
+		case res.meta.StatusCode >= 400 && res.meta.StatusCode < 500:
+			c.stats.Count4xx.Add(1)
+		case res.meta.StatusCode >= 500:
+			c.stats.Count5xx.Add(1)
+		}
+
+		log.Info().
+			Str("url", res.finalURL).
+			Str("host", host).
+			Int("status", res.meta.StatusCode).
+			Int64("bytes", bodyLen).
+			Int64("duration_ms", res.durationMs).
+			Int("attempt", res.attempt).
+			Str("breaker_state", breakerStateName(c.breaker.State(host))).
+			Msg("crawler: fetched page")
+
+		// Mark final URL as seen if it differs from the queued URL.
+		normFinal, err := normalizeRawURL(res.finalURL)
+		if err != nil {
+			normFinal = res.finalURL
+		}
+		seen.add(normFinal)
 
 		doc := &document.Document{
-			URL:  finalURL,
-			HTML: string(body),
+			URL:          res.finalURL,
+			HTML:         string(res.body),
+			ETag:         res.meta.ETag,
+			LastModified: res.meta.LastModified,
 		}
 
 		select {
 		case ch <- doc:
-		case <-ctx.Done():
+		case <-crawlCtx.Done():
 			return
 		}
 
-		for _, link := range links {
-			abs, err := resolveURL(finalParsed, link.Href)
-			if err != nil || abs == "" {
-				continue
-			}
-			if _, exists := seen[abs]; !exists {
-				seen[abs] = struct{}{}
-				queue = append(queue, queueItem{abs, cur.depth + 1})
+		if !v.Rules().NoDepth {
+			for _, link := range res.links {
+				// Skip nofollow links.
+				if isNofollow(link.Rel) {
+					continue
+				}
+				abs, err := resolveURL(finalParsed, link.Href)
+				if err != nil || abs == "" {
+					continue
+				}
+				normAbs, nErr := normalizeRawURL(abs)
+				if nErr != nil {
+					normAbs = abs
+				}
+				if seen.contains(normAbs) {
+					continue
+				}
+				seen.add(normAbs)
+
+				absParsed, err := url.Parse(abs)
+				if err != nil {
+					continue
+				}
+				switch v.Validate(absParsed, res.item.depth+1) {
+				case URLStop:
+					c.stats.BudgetStops.Add(1)
+					return
+				case URLSkip:
+					continue
+				}
+				queue.PushBack(queueItem{abs, res.item.depth + 1})
 			}
 		}
+
+		dispatch()
 	}
+
+	close(work)
+}
+
+func breakerStateName(s BreakerState) string {
+	switch s {
+	case BreakerClosed:
+		return "closed"
+	case BreakerOpen:
+		return "open"
+	case BreakerHalfOpen:
+		return "half_open"
+	}
+	return "unknown"
+}
+
+// isNofollow returns true if the rel string contains "nofollow" as a token.
+func isNofollow(rel string) bool {
+	for _, token := range strings.Fields(rel) {
+		if strings.EqualFold(token, "nofollow") {
+			return true
+		}
+	}
+	return false
+}
+
+// normalizeRawURL parses and normalizes a raw URL string.
+func normalizeRawURL(rawURL string) (string, error) {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return "", err
+	}
+	return NormalizeURL(u), nil
 }
 
 // resolveURL turns a potentially relative href into an absolute http(s) URL
@@ -253,16 +594,6 @@ func resolveURL(base *url.URL, href string) (string, error) {
 	}
 	abs.Fragment = ""
 	return abs.String(), nil
-}
-
-// isNofollow returns true if the rel string contains "nofollow" as a token.
-func isNofollow(rel string) bool {
-	for _, token := range strings.Fields(rel) {
-		if strings.EqualFold(token, "nofollow") {
-			return true
-		}
-	}
-	return false
 }
 
 // extractLinks parses HTML from r and returns the links found in <a> elements.
@@ -300,3 +631,19 @@ func extractLinks(r io.Reader) []Link {
 		}
 	}
 }
+
+// activeRegistry holds references to active crawlers for debug inspection.
+var activeRegistry sync.Map // id -> *baseCrawler
+
+// RegisterActive registers c under id for debug inspection.
+func RegisterActive(id string, c *baseCrawler) {
+	activeRegistry.Store(id, c)
+}
+
+// Unregister removes id from the active registry.
+func Unregister(id string) {
+	activeRegistry.Delete(id)
+}
+
+// errResponseTooLarge is returned when a response body exceeds the configured limit.
+var errResponseTooLarge = fmt.Errorf("response body exceeds size limit")

--- a/server/crawler/crawler.go
+++ b/server/crawler/crawler.go
@@ -365,6 +365,16 @@ func (c *baseCrawler) bfsCrawl(ctx context.Context, startURL string, v *Validato
 				continue
 			}
 
+			if c.skipURLChecker != nil {
+				skip, err := c.skipURLChecker(item.rawURL)
+				if err != nil {
+					log.Warn().Err(err).Str("url", item.rawURL).Msg("crawler: skipURL checker error")
+				} else if skip {
+					log.Info().Str("url", item.rawURL).Msg("crawler: skipping URL by prefetch skip predicate")
+					continue
+				}
+			}
+
 			parsedU, parseErr := url.Parse(item.rawURL)
 			if parseErr == nil {
 				host := parsedU.Hostname()

--- a/server/crawler/crawler.go
+++ b/server/crawler/crawler.go
@@ -260,6 +260,7 @@ func (c *baseCrawler) bfsCrawl(ctx context.Context, startURL string, v *Validato
 	}
 
 	work := make(chan queueItem, concurrency)
+	defer close(work)
 	results := make(chan result, concurrency)
 	var wg sync.WaitGroup
 
@@ -460,8 +461,6 @@ func (c *baseCrawler) bfsCrawl(ctx context.Context, startURL string, v *Validato
 
 		dispatch()
 	}
-
-	close(work)
 }
 
 func breakerStateName(s BreakerState) string {

--- a/server/crawler/crawler.go
+++ b/server/crawler/crawler.go
@@ -5,6 +5,7 @@ package crawler
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/url"
 	"strings"
 	"time"
@@ -47,12 +48,14 @@ func WithSkipURLChecker(skipURLChecker SkipURLChecker) Option {
 
 // fetcher is the internal interface implemented by each scraping backend.
 // fetchPage downloads rawURL and returns the final URL after any redirects,
-// its HTML content together with the raw href values of all anchor tags found
-// on the page.
+// the raw response body, the links found on the page, fetch metadata, and any error.
 type fetcher interface {
-	fetchPage(ctx context.Context, rawURL string) (finalURL string, htmlContent string, links []string, err error)
+	fetchPage(ctx context.Context, rawURL string, hints RequestHints) (finalURL string, body []byte, links []Link, meta FetchMeta, err error)
 	close() error
 }
+
+// errResponseTooLarge is returned when a response body exceeds the configured limit.
+var errResponseTooLarge = fmt.Errorf("response body exceeds size limit")
 
 // baseCrawler wraps a fetcher with BFS traversal logic.
 type baseCrawler struct {
@@ -196,7 +199,7 @@ func (c *baseCrawler) bfsCrawl(ctx context.Context, startURL string, v *Validato
 			}
 		}
 
-		finalURL, htmlContent, links, err := c.fetcher.fetchPage(ctx, cur.rawURL)
+		finalURL, body, links, _, err := c.fetcher.fetchPage(ctx, cur.rawURL, RequestHints{})
 		if err != nil {
 			log.Warn().Err(err).Str("url", cur.rawURL).Msg("crawler: failed to fetch page")
 			continue
@@ -215,7 +218,7 @@ func (c *baseCrawler) bfsCrawl(ctx context.Context, startURL string, v *Validato
 
 		doc := &document.Document{
 			URL:  finalURL,
-			HTML: htmlContent,
+			HTML: string(body),
 		}
 
 		select {
@@ -225,7 +228,7 @@ func (c *baseCrawler) bfsCrawl(ctx context.Context, startURL string, v *Validato
 		}
 
 		for _, link := range links {
-			abs, err := resolveURL(finalParsed, link)
+			abs, err := resolveURL(finalParsed, link.Href)
 			if err != nil || abs == "" {
 				continue
 			}
@@ -252,28 +255,48 @@ func resolveURL(base *url.URL, href string) (string, error) {
 	return abs.String(), nil
 }
 
-// extractLinks parses htmlContent and returns the raw href attribute values
-// of all <a> elements.
-func extractLinks(htmlContent string) []string {
-	doc, err := html.Parse(strings.NewReader(htmlContent))
-	if err != nil {
-		return nil
+// isNofollow returns true if the rel string contains "nofollow" as a token.
+func isNofollow(rel string) bool {
+	for _, token := range strings.Fields(rel) {
+		if strings.EqualFold(token, "nofollow") {
+			return true
+		}
 	}
-	var links []string
-	var walk func(*html.Node)
-	walk = func(n *html.Node) {
-		if n.Type == html.ElementNode && n.Data == "a" {
-			for _, attr := range n.Attr {
-				if attr.Key == "href" {
-					links = append(links, attr.Val)
+	return false
+}
+
+// extractLinks parses HTML from r and returns the links found in <a> elements.
+// It captures the href and rel attributes. Multi-valued rel is preserved as-is
+// (space-separated); callers can use isNofollow to check individual tokens.
+func extractLinks(r io.Reader) []Link {
+	var links []Link
+	z := html.NewTokenizer(r)
+	for {
+		tt := z.Next()
+		switch tt {
+		case html.ErrorToken:
+			return links
+		case html.StartTagToken, html.SelfClosingTagToken:
+			name, hasAttr := z.TagName()
+			if !hasAttr || string(name) != "a" {
+				continue
+			}
+			var href, rel string
+			for {
+				key, val, more := z.TagAttr()
+				switch string(key) {
+				case "href":
+					href = string(val)
+				case "rel":
+					rel = string(val)
+				}
+				if !more {
 					break
 				}
 			}
-		}
-		for c := n.FirstChild; c != nil; c = c.NextSibling {
-			walk(c)
+			if href != "" {
+				links = append(links, Link{Href: href, Rel: rel})
+			}
 		}
 	}
-	walk(doc)
-	return links
 }

--- a/server/crawler/crawler.go
+++ b/server/crawler/crawler.go
@@ -11,7 +11,6 @@ import (
 	"net/url"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"golang.org/x/net/html"
@@ -58,63 +57,6 @@ type fetcher interface {
 	close() error
 }
 
-// HostStats tracks per-host counters.
-type HostStats struct {
-	Pages  atomic.Int64
-	Bytes  atomic.Int64
-	Errors atomic.Int64
-}
-
-// CrawlerStatsSnapshot is a point-in-time copy of CrawlerStats.
-type CrawlerStatsSnapshot struct {
-	Pages        int64
-	Bytes        int64
-	Count2xx     int64
-	Count3xx     int64
-	Count4xx     int64
-	Count5xx     int64
-	Retries      int64
-	BreakerTrips int64
-	RobotsDenials int64
-	BudgetStops  int64
-}
-
-// CrawlerStats holds atomic counters for a single crawl.
-type CrawlerStats struct {
-	Pages         atomic.Int64
-	Bytes         atomic.Int64
-	Count2xx      atomic.Int64
-	Count3xx      atomic.Int64
-	Count4xx      atomic.Int64
-	Count5xx      atomic.Int64
-	Retries       atomic.Int64
-	BreakerTrips  atomic.Int64
-	RobotsDenials atomic.Int64
-	BudgetStops   atomic.Int64
-	PerHost       sync.Map // host -> *HostStats
-}
-
-// Snapshot returns a point-in-time copy of the stats.
-func (s *CrawlerStats) Snapshot() CrawlerStatsSnapshot {
-	return CrawlerStatsSnapshot{
-		Pages:         s.Pages.Load(),
-		Bytes:         s.Bytes.Load(),
-		Count2xx:      s.Count2xx.Load(),
-		Count3xx:      s.Count3xx.Load(),
-		Count4xx:      s.Count4xx.Load(),
-		Count5xx:      s.Count5xx.Load(),
-		Retries:       s.Retries.Load(),
-		BreakerTrips:  s.BreakerTrips.Load(),
-		RobotsDenials: s.RobotsDenials.Load(),
-		BudgetStops:   s.BudgetStops.Load(),
-	}
-}
-
-func (s *CrawlerStats) hostStats(host string) *HostStats {
-	v, _ := s.PerHost.LoadOrStore(host, &HostStats{})
-	return v.(*HostStats)
-}
-
 // baseCrawler wraps a fetcher with BFS traversal logic.
 type baseCrawler struct {
 	fetcher        fetcher
@@ -125,7 +67,6 @@ type baseCrawler struct {
 	budget         *Budget
 	breaker        *CircuitBreaker
 	backoff        *Backoff
-	stats          *CrawlerStats
 	clock          Clock
 }
 
@@ -177,7 +118,6 @@ func newBaseCrawler(f fetcher, cfg *config.CrawlerConfig, robots *RobotsCache, o
 		budget:         budget,
 		breaker:        breaker,
 		backoff:        NewBackoff(initial, maxB),
-		stats:          &CrawlerStats{},
 		clock:          clock,
 	}
 }
@@ -346,7 +286,6 @@ func (c *baseCrawler) bfsCrawl(ctx context.Context, startURL string, v *Validato
 
 				for attempt := 0; attempt < maxAttempts; attempt++ {
 					if attempt > 0 {
-						c.stats.Retries.Add(1)
 						wait := c.backoff.Duration(attempt)
 						select {
 						case <-fetchCtx.Done():
@@ -439,14 +378,6 @@ func (c *baseCrawler) bfsCrawl(ctx context.Context, startURL string, v *Validato
 		inFlight--
 
 		if res.err != nil {
-			hs := c.stats.hostStats("")
-			if res.item.rawURL != "" {
-				parsed, pErr := url.Parse(res.item.rawURL)
-				if pErr == nil {
-					hs = c.stats.hostStats(parsed.Hostname())
-				}
-			}
-			hs.Errors.Add(1)
 			dispatch()
 			continue
 		}
@@ -459,26 +390,10 @@ func (c *baseCrawler) bfsCrawl(ctx context.Context, startURL string, v *Validato
 		}
 
 		host := finalParsed.Hostname()
-		hs := c.stats.hostStats(host)
 
-		// Record stats.
+		// Record budget.
 		bodyLen := int64(len(res.body))
-		c.stats.Pages.Add(1)
-		c.stats.Bytes.Add(bodyLen)
-		hs.Pages.Add(1)
-		hs.Bytes.Add(bodyLen)
 		c.budget.AddBytes(host, bodyLen)
-
-		switch {
-		case res.meta.StatusCode >= 200 && res.meta.StatusCode < 300:
-			c.stats.Count2xx.Add(1)
-		case res.meta.StatusCode >= 300 && res.meta.StatusCode < 400:
-			c.stats.Count3xx.Add(1)
-		case res.meta.StatusCode >= 400 && res.meta.StatusCode < 500:
-			c.stats.Count4xx.Add(1)
-		case res.meta.StatusCode >= 500:
-			c.stats.Count5xx.Add(1)
-		}
 
 		log.Info().
 			Str("url", res.finalURL).
@@ -535,7 +450,6 @@ func (c *baseCrawler) bfsCrawl(ctx context.Context, startURL string, v *Validato
 				}
 				switch v.Validate(absParsed, res.item.depth+1) {
 				case URLStop:
-					c.stats.BudgetStops.Add(1)
 					return
 				case URLSkip:
 					continue
@@ -630,19 +544,6 @@ func extractLinks(r io.Reader) []Link {
 			}
 		}
 	}
-}
-
-// activeRegistry holds references to active crawlers for debug inspection.
-var activeRegistry sync.Map // id -> *baseCrawler
-
-// RegisterActive registers c under id for debug inspection.
-func RegisterActive(id string, c *baseCrawler) {
-	activeRegistry.Store(id, c)
-}
-
-// Unregister removes id from the active registry.
-func Unregister(id string) {
-	activeRegistry.Delete(id)
 }
 
 // errResponseTooLarge is returned when a response body exceeds the configured limit.

--- a/server/crawler/crawler.go
+++ b/server/crawler/crawler.go
@@ -360,6 +360,11 @@ func (c *baseCrawler) bfsCrawl(ctx context.Context, startURL string, v *Validato
 			queue.Remove(front)
 			item := front.Value.(queueItem)
 
+			if c.robots != nil && !c.robots.Allowed(crawlCtx, item.rawURL) {
+				log.Info().Str("url", item.rawURL).Msg("crawler: skipping URL disallowed by robots.txt")
+				continue
+			}
+
 			parsedU, parseErr := url.Parse(item.rawURL)
 			if parseErr == nil {
 				host := parsedU.Hostname()

--- a/server/crawler/crawler.go
+++ b/server/crawler/crawler.go
@@ -92,7 +92,16 @@ func New(cfg *config.CrawlerConfig, robots *RobotsCache, opts ...Option) (Crawle
 	return newBaseCrawler(f, cfg, robots, o), nil
 }
 
-func newBaseCrawler(f fetcher, cfg *config.CrawlerConfig, robots *RobotsCache, o options) *baseCrawler {
+// crawlerCore holds the shared infrastructure components built from CrawlerConfig.
+type crawlerCore struct {
+	scheduler *Scheduler
+	breaker   *CircuitBreaker
+	budget    *Budget
+	backoff   *Backoff
+	clock     Clock
+}
+
+func newCrawlerCore(cfg *config.CrawlerConfig, robots *RobotsCache) crawlerCore {
 	clock := RealClock{}
 	cooldown := time.Duration(cfg.CircuitBreaker.Cooldown) * time.Second
 	if cooldown == 0 {
@@ -109,16 +118,27 @@ func newBaseCrawler(f fetcher, cfg *config.CrawlerConfig, robots *RobotsCache, o
 	if maxB == 0 {
 		maxB = 30 * time.Second
 	}
+	return crawlerCore{
+		scheduler: scheduler,
+		breaker:   breaker,
+		budget:    budget,
+		backoff:   NewBackoff(initial, maxB),
+		clock:     clock,
+	}
+}
+
+func newBaseCrawler(f fetcher, cfg *config.CrawlerConfig, robots *RobotsCache, o options) *baseCrawler {
+	core := newCrawlerCore(cfg, robots)
 	return &baseCrawler{
 		fetcher:        f,
 		cfg:            cfg,
 		robots:         robots,
 		skipURLChecker: o.skipURLChecker,
-		scheduler:      scheduler,
-		budget:         budget,
-		breaker:        breaker,
-		backoff:        NewBackoff(initial, maxB),
-		clock:          clock,
+		scheduler:      core.scheduler,
+		budget:         core.budget,
+		breaker:        core.breaker,
+		backoff:        core.backoff,
+		clock:          core.clock,
 	}
 }
 

--- a/server/crawler/crawler.go
+++ b/server/crawler/crawler.go
@@ -431,20 +431,33 @@ func (c *baseCrawler) bfsCrawl(ctx context.Context, startURL string, v *Validato
 		}
 		seen.add(normFinal)
 
-		doc := &document.Document{
-			URL:          res.finalURL,
-			HTML:         string(res.body),
-			ETag:         res.meta.ETag,
-			LastModified: res.meta.LastModified,
+		effective := res.meta.MetaRobots
+		if c.cfg.RespectMetaRobots {
+			xr := parseXRobotsTag(res.meta.XRobotsTag)
+			if xr.NoIndex {
+				effective.NoIndex = true
+			}
+			if xr.NoFollow {
+				effective.NoFollow = true
+			}
 		}
 
-		select {
-		case ch <- doc:
-		case <-crawlCtx.Done():
-			return
+		if !c.cfg.RespectMetaRobots || !effective.NoIndex {
+			doc := &document.Document{
+				URL:          res.finalURL,
+				HTML:         string(res.body),
+				ETag:         res.meta.ETag,
+				LastModified: res.meta.LastModified,
+			}
+
+			select {
+			case ch <- doc:
+			case <-crawlCtx.Done():
+				return
+			}
 		}
 
-		if !v.Rules().NoDepth {
+		if !v.Rules().NoDepth && !(c.cfg.RespectMetaRobots && effective.NoFollow) {
 			for _, link := range res.links {
 				// Skip nofollow links.
 				if isNofollow(link.Rel) {
@@ -527,40 +540,89 @@ func resolveURL(base *url.URL, href string) (string, error) {
 	return abs.String(), nil
 }
 
-// extractLinks parses HTML from r and returns the links found in <a> elements.
-// It captures the href and rel attributes. Multi-valued rel is preserved as-is
-// (space-separated); callers can use isNofollow to check individual tokens.
-func extractLinks(r io.Reader) []Link {
+// extractLinks parses HTML from r and returns the links found in <a> elements
+// and the MetaRobots directives from <meta name="robots"> tags.
+// Multi-valued rel is preserved as-is (space-separated); callers can use
+// isNofollow to check individual tokens.
+func extractLinks(r io.Reader) ([]Link, MetaRobots) {
 	var links []Link
+	var meta MetaRobots
 	z := html.NewTokenizer(r)
 	for {
 		tt := z.Next()
 		switch tt {
 		case html.ErrorToken:
-			return links
+			return links, meta
 		case html.StartTagToken, html.SelfClosingTagToken:
 			name, hasAttr := z.TagName()
-			if !hasAttr || string(name) != "a" {
+			tagName := string(name)
+			if !hasAttr {
 				continue
 			}
-			var href, rel string
-			for {
-				key, val, more := z.TagAttr()
-				switch string(key) {
-				case "href":
-					href = string(val)
-				case "rel":
-					rel = string(val)
+			switch tagName {
+			case "a":
+				var href, rel string
+				for {
+					key, val, more := z.TagAttr()
+					switch string(key) {
+					case "href":
+						href = string(val)
+					case "rel":
+						rel = string(val)
+					}
+					if !more {
+						break
+					}
 				}
-				if !more {
-					break
+				if href != "" {
+					links = append(links, Link{Href: href, Rel: rel})
 				}
-			}
-			if href != "" {
-				links = append(links, Link{Href: href, Rel: rel})
+			case "meta":
+				var metaName, metaContent string
+				for {
+					key, val, more := z.TagAttr()
+					switch strings.ToLower(string(key)) {
+					case "name":
+						metaName = strings.ToLower(string(val))
+					case "content":
+						metaContent = string(val)
+					}
+					if !more {
+						break
+					}
+				}
+				if metaName == "robots" {
+					mr := parseRobotsContent(metaContent)
+					if mr.NoIndex {
+						meta.NoIndex = true
+					}
+					if mr.NoFollow {
+						meta.NoFollow = true
+					}
+				}
 			}
 		}
 	}
+}
+
+// parseRobotsContent parses a comma-separated robots directive string
+// (from <meta name="robots"> or X-Robots-Tag) and returns a MetaRobots.
+func parseRobotsContent(content string) MetaRobots {
+	var mr MetaRobots
+	for _, token := range strings.Split(content, ",") {
+		switch strings.TrimSpace(strings.ToLower(token)) {
+		case "noindex":
+			mr.NoIndex = true
+		case "nofollow":
+			mr.NoFollow = true
+		}
+	}
+	return mr
+}
+
+// parseXRobotsTag parses the X-Robots-Tag header value.
+func parseXRobotsTag(header string) MetaRobots {
+	return parseRobotsContent(header)
 }
 
 // errResponseTooLarge is returned when a response body exceeds the configured limit.

--- a/server/crawler/crawler.go
+++ b/server/crawler/crawler.go
@@ -360,6 +360,19 @@ func (c *baseCrawler) bfsCrawl(ctx context.Context, startURL string, v *Validato
 			queue.Remove(front)
 			item := front.Value.(queueItem)
 
+			parsedU, parseErr := url.Parse(item.rawURL)
+			if parseErr == nil {
+				host := parsedU.Hostname()
+				if c.budget.HostExhausted(host) {
+					log.Info().Str("url", item.rawURL).Str("host", host).Msg("crawler: per-host budget reached, skipping")
+					continue
+				}
+				if !c.budget.TryReservePage(host) {
+					log.Info().Str("url", item.rawURL).Str("host", host).Msg("crawler: page reservation failed (budget)")
+					continue
+				}
+			}
+
 			select {
 			case <-crawlCtx.Done():
 				return
@@ -372,6 +385,11 @@ func (c *baseCrawler) bfsCrawl(ctx context.Context, startURL string, v *Validato
 	dispatch()
 
 	for inFlight > 0 {
+		if c.budget.Exhausted() {
+			log.Info().Msg("crawler: budget exhausted, stopping")
+			return
+		}
+
 		res, ok := <-results
 		if !ok {
 			break

--- a/server/crawler/http.go
+++ b/server/crawler/http.go
@@ -3,12 +3,14 @@
 package crawler
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
 	"net/http"
 	"net/http/cookiejar"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -23,6 +25,7 @@ type httpFetcher struct {
 	client    *http.Client
 	userAgent string
 	headers   map[string]string
+	maxBytes  int64
 }
 
 func newHTTPFetcher(cfg *config.CrawlerConfig) (*httpFetcher, error) {
@@ -61,22 +64,39 @@ func newHTTPFetcher(cfg *config.CrawlerConfig) (*httpFetcher, error) {
 		timeout = defaultTimeout
 	}
 
+	ua := cfg.UserAgent
+	if ua == "" {
+		contactURL := cfg.ContactURL
+		if contactURL == "" {
+			contactURL = "https://hister.info"
+		}
+		ua = fmt.Sprintf("Hister/dev (+%s)", contactURL)
+	}
+
+	maxBytes := cfg.Limits.MaxResponseBytes
+	if maxBytes == 0 {
+		maxBytes = 10 * 1024 * 1024
+	}
+
 	return &httpFetcher{
 		client: &http.Client{
 			Timeout:   timeout,
 			Jar:       jar,
 			Transport: transportWithProxy(proxyURL),
 		},
-		userAgent: cfg.UserAgent,
+		userAgent: ua,
 		headers:   cfg.Headers,
+		maxBytes:  maxBytes,
 	}, nil
 }
 
-func (f *httpFetcher) fetchPage(ctx context.Context, rawURL string) (string, string, []string, error) {
+func (f *httpFetcher) fetchPage(ctx context.Context, rawURL string, hints RequestHints) (string, []byte, []Link, FetchMeta, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
 	if err != nil {
-		return "", "", nil, err
+		return "", nil, nil, FetchMeta{}, err
 	}
+
+	req.Header.Set("Accept", "text/html,application/xhtml+xml,*/*;q=0.8")
 
 	if f.userAgent != "" {
 		req.Header.Set("User-Agent", f.userAgent)
@@ -84,10 +104,16 @@ func (f *httpFetcher) fetchPage(ctx context.Context, rawURL string) (string, str
 	for k, v := range f.headers {
 		req.Header.Set(k, v)
 	}
+	if hints.IfNoneMatch != "" {
+		req.Header.Set("If-None-Match", hints.IfNoneMatch)
+	}
+	if hints.IfModifiedSince != "" {
+		req.Header.Set("If-Modified-Since", hints.IfModifiedSince)
+	}
 
 	resp, err := f.client.Do(req)
 	if err != nil {
-		return "", "", nil, err
+		return "", nil, nil, FetchMeta{}, err
 	}
 	defer func() {
 		if err := resp.Body.Close(); err != nil {
@@ -95,23 +121,73 @@ func (f *httpFetcher) fetchPage(ctx context.Context, rawURL string) (string, str
 		}
 	}()
 
+	meta := FetchMeta{
+		StatusCode:   resp.StatusCode,
+		ETag:         resp.Header.Get("ETag"),
+		LastModified: resp.Header.Get("Last-Modified"),
+		XRobotsTag:   resp.Header.Get("X-Robots-Tag"),
+	}
+
+	if resp.StatusCode == http.StatusNotModified {
+		return "", nil, nil, meta, &HTTPStatusError{Status: http.StatusNotModified}
+	}
+
 	if resp.StatusCode != http.StatusOK {
-		return "", "", nil, fmt.Errorf("unexpected status %d", resp.StatusCode)
+		retryAfter := parseRetryAfter(resp.Header.Get("Retry-After"))
+		meta.RetryAfter = retryAfter
+		return "", nil, nil, meta, &HTTPStatusError{Status: resp.StatusCode, RetryAfter: retryAfter}
 	}
 
 	ct := resp.Header.Get("Content-Type")
 	if !strings.Contains(ct, "html") {
-		return "", "", nil, fmt.Errorf("not an HTML response: %s", ct)
+		return "", nil, nil, meta, fmt.Errorf("not an HTML response: %s", ct)
 	}
 
-	body, err := io.ReadAll(resp.Body)
+	// Check Content-Length before reading.
+	if cl := resp.ContentLength; cl > 0 && cl > f.maxBytes {
+		return "", nil, nil, meta, errResponseTooLarge
+	}
+
+	limitedBody := io.LimitReader(resp.Body, f.maxBytes+1)
+	body, err := io.ReadAll(limitedBody)
 	if err != nil {
-		return "", "", nil, err
+		return "", nil, nil, meta, err
+	}
+	if int64(len(body)) > f.maxBytes {
+		return "", nil, nil, meta, errResponseTooLarge
 	}
 
-	htmlContent := string(body)
 	finalURL := resp.Request.URL.String()
-	return finalURL, htmlContent, extractLinks(htmlContent), nil
+	links := extractLinks(bytes.NewReader(body))
+	return finalURL, body, links, meta, nil
 }
 
 func (f *httpFetcher) close() error { return nil }
+
+// parseRetryAfter parses the Retry-After header value as either a
+// delta-seconds integer or an HTTP-date string.
+func parseRetryAfter(s string) time.Duration {
+	if s == "" {
+		return 0
+	}
+	// Try delta-seconds first.
+	if n, err := strconv.ParseInt(strings.TrimSpace(s), 10, 64); err == nil && n > 0 {
+		return time.Duration(n) * time.Second
+	}
+	// Try HTTP-date.
+	for _, layout := range []string{
+		time.RFC1123,
+		"Monday, 02-Jan-06 15:04:05 MST",
+		time.RFC850,
+		time.ANSIC,
+	} {
+		if t, err := time.Parse(layout, s); err == nil {
+			d := time.Until(t)
+			if d > 0 {
+				return d
+			}
+			return 0
+		}
+	}
+	return 0
+}

--- a/server/crawler/http.go
+++ b/server/crawler/http.go
@@ -158,7 +158,8 @@ func (f *httpFetcher) fetchPage(ctx context.Context, rawURL string, hints Reques
 	}
 
 	finalURL := resp.Request.URL.String()
-	links := extractLinks(bytes.NewReader(body))
+	links, metaRobots := extractLinks(bytes.NewReader(body))
+	meta.MetaRobots = metaRobots
 	return finalURL, body, links, meta, nil
 }
 

--- a/server/crawler/links_test.go
+++ b/server/crawler/links_test.go
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package crawler
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestExtractLinks(t *testing.T) {
+	tests := []struct {
+		name  string
+		html  string
+		want  []Link
+	}{
+		{
+			name: "basic anchor",
+			html: `<html><body><a href="https://example.com">link</a></body></html>`,
+			want: []Link{{Href: "https://example.com", Rel: ""}},
+		},
+		{
+			name: "rel nofollow",
+			html: `<html><body><a href="/page" rel="nofollow">link</a></body></html>`,
+			want: []Link{{Href: "/page", Rel: "nofollow"}},
+		},
+		{
+			name: "multi-valued rel",
+			html: `<html><body><a href="/page" rel="nofollow noopener">link</a></body></html>`,
+			want: []Link{{Href: "/page", Rel: "nofollow noopener"}},
+		},
+		{
+			name: "no href skipped",
+			html: `<html><body><a name="anchor">anchor</a></body></html>`,
+			want: nil,
+		},
+		{
+			name: "multiple links",
+			html: `<html><body><a href="/a">a</a><a href="/b" rel="nofollow">b</a></body></html>`,
+			want: []Link{{Href: "/a", Rel: ""}, {Href: "/b", Rel: "nofollow"}},
+		},
+		{
+			name: "malformed HTML still extracts links",
+			html: `<a href="/broken">text<a href="/second">more`,
+			want: []Link{{Href: "/broken", Rel: ""}, {Href: "/second", Rel: ""}},
+		},
+		{
+			name: "empty",
+			html: ``,
+			want: nil,
+		},
+		{
+			name: "link with rel but no nofollow",
+			html: `<a href="/page" rel="noopener noreferrer">link</a>`,
+			want: []Link{{Href: "/page", Rel: "noopener noreferrer"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractLinks(strings.NewReader(tt.html))
+			if len(got) != len(tt.want) {
+				t.Fatalf("extractLinks() len = %d, want %d\ngot: %v\nwant: %v", len(got), len(tt.want), got, tt.want)
+			}
+			for i, link := range got {
+				if link.Href != tt.want[i].Href || link.Rel != tt.want[i].Rel {
+					t.Errorf("extractLinks()[%d] = %+v, want %+v", i, link, tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestExtractLinksIsNofollow(t *testing.T) {
+	tests := []struct {
+		rel  string
+		want bool
+	}{
+		{"nofollow", true},
+		{"NOFOLLOW", true},
+		{"nofollow noopener", true},
+		{"noopener nofollow", true},
+		{"noopener", false},
+		{"", false},
+		{"noreferrer", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.rel, func(t *testing.T) {
+			if got := isNofollow(tt.rel); got != tt.want {
+				t.Errorf("isNofollow(%q) = %v, want %v", tt.rel, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractLinksStreaming(t *testing.T) {
+	// Build a large HTML document to verify streaming tokenizer works.
+	var sb strings.Builder
+	sb.WriteString("<html><body>")
+	const n = 10000
+	for i := 0; i < n; i++ {
+		sb.WriteString(`<a href="/page">link</a>`)
+	}
+	sb.WriteString("</body></html>")
+
+	links := extractLinks(strings.NewReader(sb.String()))
+	if len(links) != n {
+		t.Errorf("extractLinks() len = %d, want %d", len(links), n)
+	}
+}

--- a/server/crawler/links_test.go
+++ b/server/crawler/links_test.go
@@ -7,6 +7,93 @@ import (
 	"testing"
 )
 
+func TestExtractLinksMetaRobots(t *testing.T) {
+	tests := []struct {
+		name     string
+		html     string
+		noIndex  bool
+		noFollow bool
+	}{
+		{
+			name:     "noindex only",
+			html:     `<html><head><meta name="robots" content="noindex"></head></html>`,
+			noIndex:  true,
+			noFollow: false,
+		},
+		{
+			name:     "noindex and nofollow",
+			html:     `<html><head><meta name="robots" content="noindex, nofollow"></head></html>`,
+			noIndex:  true,
+			noFollow: true,
+		},
+		{
+			name:     "case insensitive",
+			html:     `<html><head><meta name="robots" content="NoIndex"></head></html>`,
+			noIndex:  true,
+			noFollow: false,
+		},
+		{
+			name:     "multiple meta tags - combined",
+			html:     `<html><head><meta name="robots" content="noindex"><meta name="robots" content="nofollow"></head></html>`,
+			noIndex:  true,
+			noFollow: true,
+		},
+		{
+			name:     "no robots meta",
+			html:     `<html><head><meta name="description" content="test"></head></html>`,
+			noIndex:  false,
+			noFollow: false,
+		},
+		{
+			name:     "empty meta robots",
+			html:     `<html><head><meta name="robots" content=""></head></html>`,
+			noIndex:  false,
+			noFollow: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, mr := extractLinks(strings.NewReader(tt.html))
+			if mr.NoIndex != tt.noIndex {
+				t.Errorf("NoIndex = %v, want %v", mr.NoIndex, tt.noIndex)
+			}
+			if mr.NoFollow != tt.noFollow {
+				t.Errorf("NoFollow = %v, want %v", mr.NoFollow, tt.noFollow)
+			}
+		})
+	}
+}
+
+func TestParseXRobotsTag(t *testing.T) {
+	tests := []struct {
+		header   string
+		noIndex  bool
+		noFollow bool
+	}{
+		{"noindex", true, false},
+		{"nofollow", false, true},
+		{"noindex, nofollow", true, true},
+		{"NoIndex", true, false},
+		{"NOFOLLOW", false, true},
+		{"", false, false},
+		{"nosnippet", false, false},
+		{"noindex,nofollow", true, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.header, func(t *testing.T) {
+			mr := parseXRobotsTag(tt.header)
+			if mr.NoIndex != tt.noIndex {
+				t.Errorf("parseXRobotsTag(%q).NoIndex = %v, want %v", tt.header, mr.NoIndex, tt.noIndex)
+			}
+			if mr.NoFollow != tt.noFollow {
+				t.Errorf("parseXRobotsTag(%q).NoFollow = %v, want %v", tt.header, mr.NoFollow, tt.noFollow)
+			}
+		})
+	}
+}
+
 func TestExtractLinks(t *testing.T) {
 	tests := []struct {
 		name  string
@@ -57,7 +144,7 @@ func TestExtractLinks(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := extractLinks(strings.NewReader(tt.html))
+			got, _ := extractLinks(strings.NewReader(tt.html))
 			if len(got) != len(tt.want) {
 				t.Fatalf("extractLinks() len = %d, want %d\ngot: %v\nwant: %v", len(got), len(tt.want), got, tt.want)
 			}
@@ -103,7 +190,7 @@ func TestExtractLinksStreaming(t *testing.T) {
 	}
 	sb.WriteString("</body></html>")
 
-	links := extractLinks(strings.NewReader(sb.String()))
+	links, _ := extractLinks(strings.NewReader(sb.String()))
 	if len(links) != n {
 		t.Errorf("extractLinks() len = %d, want %d", len(links), n)
 	}

--- a/server/crawler/metarobots_test.go
+++ b/server/crawler/metarobots_test.go
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package crawler
+
+import (
+	"context"
+	"testing"
+
+	"github.com/asciimoo/hister/config"
+)
+
+// staticFetcher returns a fixed response for any URL.
+type staticFetcher struct {
+	body       string
+	links      []Link
+	metaRobots MetaRobots
+	statusCode int
+}
+
+func (f *staticFetcher) fetchPage(_ context.Context, rawURL string, _ RequestHints) (string, []byte, []Link, FetchMeta, error) {
+	return rawURL, []byte(f.body), f.links, FetchMeta{
+		StatusCode: f.statusCode,
+		MetaRobots: f.metaRobots,
+	}, nil
+}
+
+func (f *staticFetcher) close() error { return nil }
+
+func newMetaRobotsCrawler(respectMeta bool, f fetcher) *baseCrawler {
+	cfg := &config.CrawlerConfig{
+		Rate: config.CrawlerRate{
+			GlobalRPS:          1000,
+			PerHostRPS:         1000,
+			GlobalConcurrency:  1,
+			PerHostConcurrency: 1,
+		},
+		RespectMetaRobots: respectMeta,
+	}
+	return newBaseCrawler(f, cfg, nil, options{})
+}
+
+func TestMetaRobotsNoIndexSuppressesDoc(t *testing.T) {
+	sf := &staticFetcher{
+		body:       "<html>secret</html>",
+		statusCode: 200,
+		metaRobots: MetaRobots{NoIndex: true},
+	}
+	bc := newMetaRobotsCrawler(true, sf)
+
+	v, err := NewValidator(&ValidatorRules{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ch, err := bc.Crawl(context.Background(), "http://example.com/", v)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var docs int
+	for range ch {
+		docs++
+	}
+
+	if docs != 0 {
+		t.Errorf("expected 0 docs with noindex, got %d", docs)
+	}
+}
+
+func TestMetaRobotsNoIndexDisabledEmitsDoc(t *testing.T) {
+	sf := &staticFetcher{
+		body:       "<html>content</html>",
+		statusCode: 200,
+		metaRobots: MetaRobots{NoIndex: true},
+	}
+	// RespectMetaRobots is false - noindex should be ignored.
+	bc := newMetaRobotsCrawler(false, sf)
+
+	v, err := NewValidator(&ValidatorRules{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ch, err := bc.Crawl(context.Background(), "http://example.com/", v)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var docs int
+	for range ch {
+		docs++
+	}
+
+	if docs != 1 {
+		t.Errorf("expected 1 doc with RespectMetaRobots=false and noindex, got %d", docs)
+	}
+}

--- a/server/crawler/normalize.go
+++ b/server/crawler/normalize.go
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package crawler
+
+import (
+	"net/url"
+	"sort"
+	"strings"
+)
+
+var trackingParams = map[string]struct{}{
+	"utm_source":   {},
+	"utm_medium":   {},
+	"utm_campaign": {},
+	"utm_term":     {},
+	"utm_content":  {},
+	"fbclid":       {},
+	"gclid":        {},
+	"mc_cid":       {},
+	"mc_eid":       {},
+	"ref":          {},
+	"ref_src":      {},
+}
+
+// NormalizeURL returns a canonical string form of u suitable for deduplication.
+// It lowercases the host, strips default ports, sorts query params, strips
+// known tracking params, removes the fragment, and collapses duplicate slashes
+// in the path (preserving a leading //).
+func NormalizeURL(u *url.URL) string {
+	out := *u
+
+	// Lowercase host and strip default port.
+	host := strings.ToLower(out.Hostname())
+	port := out.Port()
+	switch {
+	case out.Scheme == "http" && port == "80":
+		out.Host = host
+	case out.Scheme == "https" && port == "443":
+		out.Host = host
+	case port != "":
+		out.Host = host + ":" + port
+	default:
+		out.Host = host
+	}
+
+	// Strip fragment.
+	out.Fragment = ""
+
+	// Strip tracking params and sort the remainder.
+	q := out.Query()
+	changed := false
+	for k := range q {
+		if _, ok := trackingParams[k]; ok {
+			delete(q, k)
+			changed = true
+		}
+	}
+	if changed || out.RawQuery != "" {
+		keys := make([]string, 0, len(q))
+		for k := range q {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		sorted := url.Values{}
+		for _, k := range keys {
+			sorted[k] = q[k]
+		}
+		out.RawQuery = sorted.Encode()
+	}
+
+	// Collapse duplicate slashes in path, but preserve leading //.
+	path := out.Path
+	if strings.HasPrefix(path, "//") {
+		path = "//" + collapseDuplicateSlashes(path[2:])
+	} else {
+		path = collapseDuplicateSlashes(path)
+	}
+	out.Path = path
+
+	return out.String()
+}
+
+func collapseDuplicateSlashes(s string) string {
+	if !strings.Contains(s, "//") {
+		return s
+	}
+	var b strings.Builder
+	prev := rune(0)
+	for _, c := range s {
+		if c == '/' && prev == '/' {
+			continue
+		}
+		b.WriteRune(c)
+		prev = c
+	}
+	return b.String()
+}

--- a/server/crawler/normalize_test.go
+++ b/server/crawler/normalize_test.go
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package crawler
+
+import (
+	"net/url"
+	"testing"
+)
+
+func TestNormalizeURL(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "lowercase host",
+			input: "http://Example.COM/path",
+			want:  "http://example.com/path",
+		},
+		{
+			name:  "strip default http port",
+			input: "http://example.com:80/path",
+			want:  "http://example.com/path",
+		},
+		{
+			name:  "strip default https port",
+			input: "https://example.com:443/path",
+			want:  "https://example.com/path",
+		},
+		{
+			name:  "keep non-default port",
+			input: "http://example.com:8080/path",
+			want:  "http://example.com:8080/path",
+		},
+		{
+			name:  "strip fragment",
+			input: "https://example.com/path#section",
+			want:  "https://example.com/path",
+		},
+		{
+			name:  "sort query params",
+			input: "https://example.com/?b=2&a=1",
+			want:  "https://example.com/?a=1&b=2",
+		},
+		{
+			name:  "strip utm_source",
+			input: "https://example.com/?utm_source=twitter&page=1",
+			want:  "https://example.com/?page=1",
+		},
+		{
+			name:  "strip utm_medium",
+			input: "https://example.com/?utm_medium=email&q=test",
+			want:  "https://example.com/?q=test",
+		},
+		{
+			name:  "strip utm_campaign",
+			input: "https://example.com/?utm_campaign=summer&id=5",
+			want:  "https://example.com/?id=5",
+		},
+		{
+			name:  "strip utm_term",
+			input: "https://example.com/?utm_term=shoes&cat=2",
+			want:  "https://example.com/?cat=2",
+		},
+		{
+			name:  "strip utm_content",
+			input: "https://example.com/?utm_content=banner",
+			want:  "https://example.com/",
+		},
+		{
+			name:  "strip fbclid",
+			input: "https://example.com/page?fbclid=abc123",
+			want:  "https://example.com/page",
+		},
+		{
+			name:  "strip gclid",
+			input: "https://example.com/page?gclid=xyz",
+			want:  "https://example.com/page",
+		},
+		{
+			name:  "strip mc_cid and mc_eid",
+			input: "https://example.com/?mc_cid=abc&mc_eid=def",
+			want:  "https://example.com/",
+		},
+		{
+			name:  "strip ref",
+			input: "https://example.com/?ref=homepage",
+			want:  "https://example.com/",
+		},
+		{
+			name:  "strip ref_src",
+			input: "https://example.com/?ref_src=twsrc",
+			want:  "https://example.com/",
+		},
+		{
+			name:  "collapse duplicate slashes in path",
+			input: "https://example.com/a//b///c",
+			want:  "https://example.com/a/b/c",
+		},
+		{
+			name:  "preserve leading // in path",
+			input: "https://example.com//server/file",
+			want:  "https://example.com//server/file",
+		},
+		{
+			name:  "strip all tracking params, sort rest",
+			input: "https://example.com/?z=last&utm_source=foo&a=first&fbclid=bar",
+			want:  "https://example.com/?a=first&z=last",
+		},
+		{
+			name:  "no params unchanged",
+			input: "https://example.com/page",
+			want:  "https://example.com/page",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			u, err := url.Parse(tt.input)
+			if err != nil {
+				t.Fatalf("url.Parse(%q) error: %v", tt.input, err)
+			}
+			got := NormalizeURL(u)
+			if got != tt.want {
+				t.Errorf("NormalizeURL(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/server/crawler/persistent.go
+++ b/server/crawler/persistent.go
@@ -181,14 +181,6 @@ func (c *persistentCrawler) persistentBFS(ctx context.Context, startURL string, 
 			}
 			continue
 		}
-		if !c.budget.TryReservePage(host) {
-			log.Info().Str("url", cur.URL).Str("host", host).Msg("crawler: page reservation failed (budget)")
-			if err := model.UpdateCrawlURLStatus(cur.ID, model.CrawlURLSkipped, "budget"); err != nil {
-				log.Warn().Err(err).Msg("failed to mark URL skipped by budget")
-			}
-			continue
-		}
-
 		var hints RequestHints
 		if c.cfg.ConditionalGet {
 			etag, lastMod, ok, lookupErr := model.GetLastFetchedURLMeta(cur.URL)
@@ -224,6 +216,15 @@ func (c *persistentCrawler) persistentBFS(ctx context.Context, startURL string, 
 					log.Warn().Err(err2).Msg("failed to revert URL to pending on scheduler error")
 				}
 				return model.UpdateCrawlJobStatus(c.jobID, model.CrawlJobInterrupted)
+			}
+
+			if !c.budget.TryReservePage(host) {
+				c.scheduler.Release(host)
+				log.Info().Str("url", cur.URL).Str("host", host).Msg("crawler: page reservation failed (budget)")
+				if err := model.UpdateCrawlURLStatus(cur.ID, model.CrawlURLSkipped, "budget"); err != nil {
+					log.Warn().Err(err).Msg("failed to mark URL skipped by budget")
+				}
+				break
 			}
 
 			start := c.clock.Now()

--- a/server/crawler/persistent.go
+++ b/server/crawler/persistent.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
-	"time"
 
 	"github.com/rs/zerolog/log"
 
@@ -50,22 +49,7 @@ func NewPersistent(cfg *config.CrawlerConfig, jobID string, robots *RobotsCache,
 		return nil, fmt.Errorf("%s backend: %w", crawlerBackendName(cfg), err)
 	}
 
-	clock := RealClock{}
-	cooldown := time.Duration(cfg.CircuitBreaker.Cooldown) * time.Second
-	if cooldown == 0 {
-		cooldown = 5 * time.Minute
-	}
-	breaker := NewCircuitBreaker(cfg.CircuitBreaker.ConsecutiveFailures, cooldown, clock)
-	budget := NewBudget(cfg.Limits, cfg.Hosts, clock)
-	scheduler := NewScheduler(cfg, breaker, robots, clock)
-	initial := time.Duration(cfg.Retry.InitialBackoff) * time.Second
-	if initial == 0 {
-		initial = time.Second
-	}
-	maxB := time.Duration(cfg.Retry.MaxBackoff) * time.Second
-	if maxB == 0 {
-		maxB = 30 * time.Second
-	}
+	core := newCrawlerCore(cfg, robots)
 
 	return &persistentCrawler{
 		fetcher:        f,
@@ -73,11 +57,11 @@ func NewPersistent(cfg *config.CrawlerConfig, jobID string, robots *RobotsCache,
 		jobID:          jobID,
 		robots:         robots,
 		skipURLChecker: o.skipURLChecker,
-		scheduler:      scheduler,
-		breaker:        breaker,
-		backoff:        NewBackoff(initial, maxB),
-		budget:         budget,
-		clock:          clock,
+		scheduler:      core.scheduler,
+		breaker:        core.breaker,
+		backoff:        core.backoff,
+		budget:         core.budget,
+		clock:          core.clock,
 	}, nil
 }
 

--- a/server/crawler/persistent.go
+++ b/server/crawler/persistent.go
@@ -26,6 +26,7 @@ type persistentCrawler struct {
 	scheduler      *Scheduler
 	breaker        *CircuitBreaker
 	backoff        *Backoff
+	budget         *Budget
 	clock          Clock
 }
 
@@ -54,6 +55,7 @@ func NewPersistent(cfg *config.CrawlerConfig, jobID string, robots *RobotsCache,
 		cooldown = 5 * time.Minute
 	}
 	breaker := NewCircuitBreaker(cfg.CircuitBreaker.ConsecutiveFailures, cooldown, clock)
+	budget := NewBudget(cfg.Limits, cfg.Hosts, clock)
 	scheduler := NewScheduler(cfg, breaker, robots, clock)
 	initial := time.Duration(cfg.Retry.InitialBackoff) * time.Second
 	if initial == 0 {
@@ -73,6 +75,7 @@ func NewPersistent(cfg *config.CrawlerConfig, jobID string, robots *RobotsCache,
 		scheduler:      scheduler,
 		breaker:        breaker,
 		backoff:        NewBackoff(initial, maxB),
+		budget:         budget,
 		clock:          clock,
 	}, nil
 }
@@ -119,6 +122,11 @@ func (c *persistentCrawler) persistentBFS(ctx context.Context, startURL string, 
 		case <-ctx.Done():
 			return model.UpdateCrawlJobStatus(c.jobID, model.CrawlJobInterrupted)
 		default:
+		}
+
+		if c.budget.Exhausted() {
+			log.Info().Str("job_id", c.jobID).Msg("crawler: budget exhausted, stopping")
+			return model.UpdateCrawlJobStatus(c.jobID, model.CrawlJobInterrupted)
 		}
 
 		cur, err := model.NextPendingCrawlURL(c.jobID)
@@ -180,6 +188,22 @@ func (c *persistentCrawler) persistentBFS(ctx context.Context, startURL string, 
 		}
 
 		host := parsedURL.Hostname()
+
+		if c.budget.HostExhausted(host) {
+			log.Info().Str("url", cur.URL).Str("host", host).Msg("crawler: per-host budget reached, skipping")
+			if err := model.UpdateCrawlURLStatus(cur.ID, model.CrawlURLSkipped, "budget"); err != nil {
+				log.Warn().Err(err).Msg("failed to mark URL skipped by budget")
+			}
+			continue
+		}
+		if !c.budget.TryReservePage(host) {
+			log.Info().Str("url", cur.URL).Str("host", host).Msg("crawler: page reservation failed (budget)")
+			if err := model.UpdateCrawlURLStatus(cur.ID, model.CrawlURLSkipped, "budget"); err != nil {
+				log.Warn().Err(err).Msg("failed to mark URL skipped by budget")
+			}
+			continue
+		}
+
 		var finalURL string
 		var body []byte
 		var links []Link
@@ -255,6 +279,9 @@ func (c *persistentCrawler) persistentBFS(ctx context.Context, startURL string, 
 			}
 			continue
 		}
+
+		bodyLen := int64(len(body))
+		c.budget.AddBytes(host, bodyLen)
 
 		// Handle redirects: insert the final URL as done so it won't be fetched again.
 		if finalURL != cur.URL {

--- a/server/crawler/persistent.go
+++ b/server/crawler/persistent.go
@@ -4,6 +4,7 @@ package crawler
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/url"
 	"time"
@@ -204,6 +205,17 @@ func (c *persistentCrawler) persistentBFS(ctx context.Context, startURL string, 
 			continue
 		}
 
+		var hints RequestHints
+		if c.cfg.ConditionalGet {
+			etag, lastMod, ok, lookupErr := model.GetLastFetchedURLMeta(cur.URL)
+			if lookupErr != nil {
+				log.Warn().Err(lookupErr).Str("url", cur.URL).Msg("crawler: failed to look up prior fetch meta")
+			} else if ok {
+				hints.IfNoneMatch = etag
+				hints.IfModifiedSince = lastMod
+			}
+		}
+
 		var finalURL string
 		var body []byte
 		var links []Link
@@ -231,7 +243,7 @@ func (c *persistentCrawler) persistentBFS(ctx context.Context, startURL string, 
 			}
 
 			start := c.clock.Now()
-			finalURL, body, links, meta, fetchErr = c.fetcher.fetchPage(ctx, cur.URL, RequestHints{})
+			finalURL, body, links, meta, fetchErr = c.fetcher.fetchPage(ctx, cur.URL, hints)
 			elapsed := c.clock.Now().Sub(start)
 
 			c.scheduler.Release(host)
@@ -274,6 +286,15 @@ func (c *persistentCrawler) persistentBFS(ctx context.Context, startURL string, 
 		}
 
 		if fetchErr != nil {
+			var httpErr *HTTPStatusError
+			if errors.As(fetchErr, &httpErr) && httpErr.Status == 304 {
+				// Not modified - mark done, no new doc, no re-enqueue.
+				log.Info().Str("url", cur.URL).Msg("crawler: 304 not modified, skipping re-index")
+				if err2 := model.UpdateCrawlURLStatus(cur.ID, model.CrawlURLDone, ""); err2 != nil {
+					log.Warn().Err(err2).Msg("failed to mark URL done (304)")
+				}
+				continue
+			}
 			if err2 := model.UpdateCrawlURLStatus(cur.ID, model.CrawlURLFailed, fetchErr.Error()); err2 != nil {
 				log.Warn().Err(err2).Msg("failed to mark URL failed")
 			}
@@ -295,48 +316,66 @@ func (c *persistentCrawler) persistentBFS(ctx context.Context, startURL string, 
 			}
 		}
 
+		effectiveMR := meta.MetaRobots
+		if c.cfg.RespectMetaRobots {
+			xr := parseXRobotsTag(meta.XRobotsTag)
+			if xr.NoIndex {
+				effectiveMR.NoIndex = true
+			}
+			if xr.NoFollow {
+				effectiveMR.NoFollow = true
+			}
+		}
+
+		noFollow := c.cfg.RespectMetaRobots && effectiveMR.NoFollow
+
 		if v.Rules().NoDepth {
 			if err := model.UpdateCrawlURLStatus(cur.ID, model.CrawlURLDone, ""); err != nil {
 				log.Warn().Err(err).Msg("failed to mark URL done")
 			}
 		} else {
-			// Resolve all discovered links first, then enqueue them together with
-			// the mark-done update in a single transaction.
+			// Resolve all discovered links first (unless nofollow), then enqueue
+			// them together with the mark-done update in a single transaction.
 			finalParsed, err := url.Parse(finalURL)
 			if err != nil {
 				finalParsed = parsedURL
 			}
 			finalParsed.Fragment = ""
 
-			resolved := make([]string, 0, len(links))
-			for _, link := range links {
-				// Skip nofollow links.
-				if isNofollow(link.Rel) {
-					continue
+			var resolved []string
+			if !noFollow {
+				resolved = make([]string, 0, len(links))
+				for _, link := range links {
+					// Skip nofollow links.
+					if isNofollow(link.Rel) {
+						continue
+					}
+					abs, err := resolveURL(finalParsed, link.Href)
+					if err != nil || abs == "" {
+						continue
+					}
+					resolved = append(resolved, abs)
 				}
-				abs, err := resolveURL(finalParsed, link.Href)
-				if err != nil || abs == "" {
-					continue
-				}
-				resolved = append(resolved, abs)
 			}
 
-			if err := model.MarkDoneAndEnqueueLinks(cur.ID, c.jobID, resolved, cur.Depth+1); err != nil {
+			if err := model.MarkDoneAndEnqueueLinks(cur.ID, c.jobID, resolved, cur.Depth+1, meta.ETag, meta.LastModified); err != nil {
 				log.Warn().Err(err).Msg("failed to mark URL done and enqueue links")
 			}
 		}
 
-		doc := &document.Document{
-			URL:          finalURL,
-			HTML:         string(body),
-			ETag:         meta.ETag,
-			LastModified: meta.LastModified,
-		}
+		if !c.cfg.RespectMetaRobots || !effectiveMR.NoIndex {
+			doc := &document.Document{
+				URL:          finalURL,
+				HTML:         string(body),
+				ETag:         meta.ETag,
+				LastModified: meta.LastModified,
+			}
 
-		select {
-		case ch <- doc:
-		case <-ctx.Done():
-			return model.UpdateCrawlJobStatus(c.jobID, model.CrawlJobInterrupted)
+			select {
+			case ch <- doc:
+			case <-ctx.Done():
+				return model.UpdateCrawlJobStatus(c.jobID, model.CrawlJobInterrupted)
+			}
 		}
 	}
 

--- a/server/crawler/persistent.go
+++ b/server/crawler/persistent.go
@@ -23,6 +23,10 @@ type persistentCrawler struct {
 	jobID          string
 	robots         *RobotsCache // nil means robots.txt enforcement is disabled
 	skipURLChecker SkipURLChecker
+	scheduler      *Scheduler
+	breaker        *CircuitBreaker
+	backoff        *Backoff
+	clock          Clock
 }
 
 // NewPersistent creates a Crawler that persists its state to the database.
@@ -43,7 +47,34 @@ func NewPersistent(cfg *config.CrawlerConfig, jobID string, robots *RobotsCache,
 	if err != nil {
 		return nil, fmt.Errorf("%s backend: %w", crawlerBackendName(cfg), err)
 	}
-	return &persistentCrawler{fetcher: f, cfg: cfg, jobID: jobID, robots: robots, skipURLChecker: o.skipURLChecker}, nil
+
+	clock := RealClock{}
+	cooldown := time.Duration(cfg.CircuitBreaker.Cooldown) * time.Second
+	if cooldown == 0 {
+		cooldown = 5 * time.Minute
+	}
+	breaker := NewCircuitBreaker(cfg.CircuitBreaker.ConsecutiveFailures, cooldown, clock)
+	scheduler := NewScheduler(cfg, breaker, robots, clock)
+	initial := time.Duration(cfg.Retry.InitialBackoff) * time.Second
+	if initial == 0 {
+		initial = time.Second
+	}
+	maxB := time.Duration(cfg.Retry.MaxBackoff) * time.Second
+	if maxB == 0 {
+		maxB = 30 * time.Second
+	}
+
+	return &persistentCrawler{
+		fetcher:        f,
+		cfg:            cfg,
+		jobID:          jobID,
+		robots:         robots,
+		skipURLChecker: o.skipURLChecker,
+		scheduler:      scheduler,
+		breaker:        breaker,
+		backoff:        NewBackoff(initial, maxB),
+		clock:          clock,
+	}, nil
 }
 
 // Crawl starts (or resumes) the persistent crawl job identified by jobID.
@@ -63,6 +94,7 @@ func (c *persistentCrawler) Crawl(ctx context.Context, startURL string, v *Valid
 
 // Close releases resources held by the underlying fetcher backend.
 func (c *persistentCrawler) Close() error {
+	c.scheduler.Stop()
 	return c.fetcher.close()
 }
 
@@ -75,6 +107,11 @@ func (c *persistentCrawler) persistentBFS(ctx context.Context, startURL string, 
 	// Queue the start URL if this is a new job (nothing pending yet).
 	if err := model.InsertCrawlURLIfNotExists(c.jobID, startURL, 0); err != nil {
 		return fmt.Errorf("insert start URL: %w", err)
+	}
+
+	maxAttempts := c.cfg.Retry.MaxAttempts
+	if maxAttempts < 1 {
+		maxAttempts = 1
 	}
 
 	for {
@@ -142,23 +179,79 @@ func (c *persistentCrawler) persistentBFS(ctx context.Context, startURL string, 
 			}
 		}
 
-		if c.cfg.Delay > 0 {
-			select {
-			case <-time.After(time.Duration(c.cfg.Delay) * time.Second):
-			case <-ctx.Done():
-				if err := model.UpdateCrawlURLStatus(cur.ID, model.CrawlURLPending, ""); err != nil {
-					log.Warn().Err(err).Msg("failed to revert URL to pending on cancel")
+		host := parsedURL.Hostname()
+		var finalURL string
+		var body []byte
+		var links []Link
+		var meta FetchMeta
+		var fetchErr error
+
+		for attempt := 0; attempt < maxAttempts; attempt++ {
+			if attempt > 0 {
+				wait := c.backoff.Duration(attempt)
+				select {
+				case <-ctx.Done():
+					if err := model.UpdateCrawlURLStatus(cur.ID, model.CrawlURLPending, ""); err != nil {
+						log.Warn().Err(err).Msg("failed to revert URL to pending on cancel")
+					}
+					return model.UpdateCrawlJobStatus(c.jobID, model.CrawlJobInterrupted)
+				case <-c.clock.After(wait):
+				}
+			}
+
+			if err := c.scheduler.Wait(ctx, host); err != nil {
+				if err2 := model.UpdateCrawlURLStatus(cur.ID, model.CrawlURLPending, ""); err2 != nil {
+					log.Warn().Err(err2).Msg("failed to revert URL to pending on scheduler error")
 				}
 				return model.UpdateCrawlJobStatus(c.jobID, model.CrawlJobInterrupted)
 			}
+
+			start := c.clock.Now()
+			finalURL, body, links, meta, fetchErr = c.fetcher.fetchPage(ctx, cur.URL, RequestHints{})
+			elapsed := c.clock.Now().Sub(start)
+
+			c.scheduler.Release(host)
+
+			if fetchErr != nil {
+				retryable, retryAfter, statusCode := ClassifyError(fetchErr)
+				log.Warn().
+					Err(fetchErr).
+					Str("url", cur.URL).
+					Str("host", host).
+					Int("status", statusCode).
+					Int("attempt", attempt+1).
+					Int64("duration_ms", elapsed.Milliseconds()).
+					Str("breaker_state", breakerStateName(c.breaker.State(host))).
+					Msg("crawler: fetch error")
+
+				if retryAfter > 0 {
+					c.scheduler.Cooldown(host, retryAfter)
+				}
+				if retryable && attempt < maxAttempts-1 {
+					c.breaker.RecordFailure(host)
+					continue
+				}
+				c.breaker.RecordFailure(host)
+				break
+			}
+
+			log.Info().
+				Str("url", finalURL).
+				Str("host", host).
+				Int("status", meta.StatusCode).
+				Int64("bytes", int64(len(body))).
+				Int64("duration_ms", elapsed.Milliseconds()).
+				Int("attempt", attempt+1).
+				Str("breaker_state", breakerStateName(c.breaker.State(host))).
+				Msg("crawler: fetched page")
+
+			c.breaker.RecordSuccess(host)
+			break
 		}
 
-		// TODO: wire up conditional GET - pass ETag/LastModified from doc store as hints.
-		finalURL, body, links, meta, fetchErr := c.fetcher.fetchPage(ctx, cur.URL, RequestHints{})
 		if fetchErr != nil {
-			log.Warn().Err(fetchErr).Str("url", cur.URL).Msg("crawler: failed to fetch page")
-			if err := model.UpdateCrawlURLStatus(cur.ID, model.CrawlURLFailed, fetchErr.Error()); err != nil {
-				log.Warn().Err(err).Msg("failed to mark URL failed")
+			if err2 := model.UpdateCrawlURLStatus(cur.ID, model.CrawlURLFailed, fetchErr.Error()); err2 != nil {
+				log.Warn().Err(err2).Msg("failed to mark URL failed")
 			}
 			continue
 		}

--- a/server/crawler/persistent.go
+++ b/server/crawler/persistent.go
@@ -250,7 +250,15 @@ func (c *persistentCrawler) persistentBFS(ctx context.Context, startURL string, 
 
 			if fetchErr != nil {
 				retryable, retryAfter, statusCode := ClassifyError(fetchErr)
-				log.Warn().
+				// 304 Not Modified is not a fault; the outer handler treats it as success.
+				logEvent := log.Warn()
+				msg := "crawler: fetch error"
+				var httpErr *HTTPStatusError
+				if errors.As(fetchErr, &httpErr) && httpErr.Status == 304 {
+					logEvent = log.Info()
+					msg = "crawler: not modified"
+				}
+				logEvent.
 					Err(fetchErr).
 					Str("url", cur.URL).
 					Str("host", host).
@@ -258,10 +266,15 @@ func (c *persistentCrawler) persistentBFS(ctx context.Context, startURL string, 
 					Int("attempt", attempt+1).
 					Int64("duration_ms", elapsed.Milliseconds()).
 					Str("breaker_state", breakerStateName(c.breaker.State(host))).
-					Msg("crawler: fetch error")
+					Msg(msg)
 
 				if retryAfter > 0 {
 					c.scheduler.Cooldown(host, retryAfter)
+				}
+				if httpErr != nil && httpErr.Status == 304 {
+					// Success path — no retry, no breaker penalty.
+					c.breaker.RecordSuccess(host)
+					break
 				}
 				if retryable && attempt < maxAttempts-1 {
 					c.breaker.RecordFailure(host)

--- a/server/crawler/persistent.go
+++ b/server/crawler/persistent.go
@@ -153,6 +153,7 @@ func (c *persistentCrawler) persistentBFS(ctx context.Context, startURL string, 
 			}
 		}
 
+		// TODO: wire up conditional GET - pass ETag/LastModified from doc store as hints.
 		finalURL, body, links, meta, fetchErr := c.fetcher.fetchPage(ctx, cur.URL, RequestHints{})
 		if fetchErr != nil {
 			log.Warn().Err(fetchErr).Str("url", cur.URL).Msg("crawler: failed to fetch page")
@@ -189,6 +190,10 @@ func (c *persistentCrawler) persistentBFS(ctx context.Context, startURL string, 
 
 			resolved := make([]string, 0, len(links))
 			for _, link := range links {
+				// Skip nofollow links.
+				if isNofollow(link.Rel) {
+					continue
+				}
 				abs, err := resolveURL(finalParsed, link.Href)
 				if err != nil || abs == "" {
 					continue

--- a/server/crawler/persistent.go
+++ b/server/crawler/persistent.go
@@ -153,7 +153,7 @@ func (c *persistentCrawler) persistentBFS(ctx context.Context, startURL string, 
 			}
 		}
 
-		finalURL, htmlContent, links, fetchErr := c.fetcher.fetchPage(ctx, cur.URL)
+		finalURL, body, links, meta, fetchErr := c.fetcher.fetchPage(ctx, cur.URL, RequestHints{})
 		if fetchErr != nil {
 			log.Warn().Err(fetchErr).Str("url", cur.URL).Msg("crawler: failed to fetch page")
 			if err := model.UpdateCrawlURLStatus(cur.ID, model.CrawlURLFailed, fetchErr.Error()); err != nil {
@@ -189,7 +189,7 @@ func (c *persistentCrawler) persistentBFS(ctx context.Context, startURL string, 
 
 			resolved := make([]string, 0, len(links))
 			for _, link := range links {
-				abs, err := resolveURL(finalParsed, link)
+				abs, err := resolveURL(finalParsed, link.Href)
 				if err != nil || abs == "" {
 					continue
 				}
@@ -202,8 +202,10 @@ func (c *persistentCrawler) persistentBFS(ctx context.Context, startURL string, 
 		}
 
 		doc := &document.Document{
-			URL:  finalURL,
-			HTML: htmlContent,
+			URL:          finalURL,
+			HTML:         string(body),
+			ETag:         meta.ETag,
+			LastModified: meta.LastModified,
 		}
 
 		select {

--- a/server/crawler/robots.go
+++ b/server/crawler/robots.go
@@ -123,13 +123,14 @@ func (r *RobotsCache) CrawlDelay(rawURL string) time.Duration {
 
 	r.mu.Lock()
 	elem, ok := r.cache[key]
-	r.mu.Unlock()
-
 	if !ok {
+		r.mu.Unlock()
 		return 0
 	}
-	entry := elem.Value.(*lruEntry).data
-	return entry.crawlDelay
+	delay := elem.Value.(*lruEntry).data.crawlDelay
+	r.mu.Unlock()
+
+	return delay
 }
 
 // CrawlDelayForHost returns the crawl delay for a bare hostname by checking

--- a/server/crawler/robots.go
+++ b/server/crawler/robots.go
@@ -3,6 +3,7 @@
 package crawler
 
 import (
+	"container/list"
 	"context"
 	"fmt"
 	"io"
@@ -15,13 +16,35 @@ import (
 	"github.com/temoto/robotstxt"
 )
 
-// RobotsCache fetches and caches robots.txt files in memory for the lifetime
-// of a crawl. It is safe for concurrent use.
+const (
+	defaultRobotsCacheTTL  = 24 * time.Hour
+	shortRobotsCacheTTL    = 5 * time.Minute
+	robotsCacheLRUCapacity = 1000
+)
+
+type robotsEntry struct {
+	data        *robotstxt.RobotsData
+	fetchedAt   time.Time
+	ttl         time.Duration
+	crawlDelay  time.Duration
+	allowAll    bool
+	denyAll     bool
+}
+
+// RobotsCache fetches and caches robots.txt files. It is safe for concurrent use.
 type RobotsCache struct {
 	mu        sync.Mutex
-	cache     map[string]*robotstxt.RobotsData // keyed by scheme+host
+	cache     map[string]*list.Element // key -> LRU element
+	lru       *list.List               // front = most recently used
+	hostLocks sync.Map                 // host -> *sync.Mutex
 	userAgent string
 	client    *http.Client
+	ttl       time.Duration
+}
+
+type lruEntry struct {
+	key  string
+	data *robotsEntry
 }
 
 // NewRobotsCache creates a RobotsCache that will identify itself using the
@@ -34,24 +57,40 @@ func NewRobotsCache(userAgent string) *RobotsCache {
 // NewRobotsCacheWithProxy creates a RobotsCache that uses proxy for robots.txt
 // requests. The proxy accepts the same URL formats as crawler backends.
 func NewRobotsCacheWithProxy(userAgent, proxy string) (*RobotsCache, error) {
+	return NewRobotsCacheWithProxyAndTTL(userAgent, proxy, 0)
+}
+
+// NewRobotsCacheWithProxyAndTTL creates a RobotsCache with a custom cache TTL.
+// A zero ttl uses the default (24 hours).
+func NewRobotsCacheWithProxyAndTTL(userAgent, proxy string, ttl time.Duration) (*RobotsCache, error) {
 	proxyURL, err := parseProxyURL(proxy)
 	if err != nil {
 		return nil, err
 	}
+	if ttl == 0 {
+		ttl = defaultRobotsCacheTTL
+	}
 	return &RobotsCache{
-		cache:     make(map[string]*robotstxt.RobotsData),
+		cache:     make(map[string]*list.Element),
+		lru:       list.New(),
 		userAgent: userAgent,
 		client: &http.Client{
 			Timeout:   10 * time.Second,
 			Transport: transportWithProxy(proxyURL),
 		},
+		ttl: ttl,
 	}, nil
 }
 
+// hostMu returns (creating if necessary) the per-host mutex for serialising
+// robots.txt fetches to the same origin.
+func (r *RobotsCache) hostMu(host string) *sync.Mutex {
+	v, _ := r.hostLocks.LoadOrStore(host, &sync.Mutex{})
+	return v.(*sync.Mutex)
+}
+
 // Allowed reports whether the given URL is allowed to be fetched according
-// to the site's robots.txt. If the robots.txt cannot be fetched it is treated
-// as permissive (all URLs allowed) to avoid blocking legitimate crawls due to
-// transient network errors.
+// to the site's robots.txt.
 func (r *RobotsCache) Allowed(ctx context.Context, rawURL string) bool {
 	parsed, err := url.Parse(rawURL)
 	if err != nil {
@@ -59,31 +98,117 @@ func (r *RobotsCache) Allowed(ctx context.Context, rawURL string) bool {
 	}
 	key := fmt.Sprintf("%s://%s", parsed.Scheme, parsed.Host)
 
-	r.mu.Lock()
-	data, ok := r.cache[key]
-	if !ok {
-		data = r.fetch(ctx, key)
-		r.cache[key] = data
-	}
-	r.mu.Unlock()
-
-	if data == nil {
+	entry := r.getOrFetch(ctx, key, parsed.Host)
+	if entry == nil || entry.allowAll {
 		return true
 	}
+	if entry.denyAll {
+		return false
+	}
+
 	agent := r.userAgent
 	if agent == "" {
 		agent = "*"
 	}
-	return data.TestAgent(parsed.RequestURI(), agent)
+	return entry.data.TestAgent(parsed.RequestURI(), agent)
+}
+
+// CrawlDelay returns the crawl delay specified in robots.txt for the host of rawURL.
+func (r *RobotsCache) CrawlDelay(rawURL string) time.Duration {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return 0
+	}
+	key := fmt.Sprintf("%s://%s", parsed.Scheme, parsed.Host)
+
+	r.mu.Lock()
+	elem, ok := r.cache[key]
+	r.mu.Unlock()
+
+	if !ok {
+		return 0
+	}
+	entry := elem.Value.(*lruEntry).data
+	return entry.crawlDelay
+}
+
+// CrawlDelayForHost returns the crawl delay for a bare hostname by checking
+// the https:// origin first, then http://, returning the longer of the two.
+// Returns 0 if neither origin has been cached yet.
+func (r *RobotsCache) CrawlDelayForHost(host string) time.Duration {
+	https := r.CrawlDelay("https://" + host)
+	http := r.CrawlDelay("http://" + host)
+	if https > http {
+		return https
+	}
+	return http
+}
+
+func (r *RobotsCache) getOrFetch(ctx context.Context, key, host string) *robotsEntry {
+	// Check cache first (fast path, no per-host lock needed).
+	r.mu.Lock()
+	if elem, ok := r.cache[key]; ok {
+		entry := elem.Value.(*lruEntry).data
+		if time.Since(entry.fetchedAt) < entry.ttl {
+			r.lru.MoveToFront(elem)
+			r.mu.Unlock()
+			return entry
+		}
+		// Expired - remove from cache so we re-fetch.
+		r.lru.Remove(elem)
+		delete(r.cache, key)
+	}
+	r.mu.Unlock()
+
+	// Serialise fetches per host to avoid thundering herd.
+	mu := r.hostMu(host)
+	mu.Lock()
+	defer mu.Unlock()
+
+	// Double-check after acquiring the host lock.
+	r.mu.Lock()
+	if elem, ok := r.cache[key]; ok {
+		entry := elem.Value.(*lruEntry).data
+		if time.Since(entry.fetchedAt) < entry.ttl {
+			r.lru.MoveToFront(elem)
+			r.mu.Unlock()
+			return entry
+		}
+	}
+	r.mu.Unlock()
+
+	entry := r.fetch(ctx, key)
+	r.store(key, entry)
+	return entry
+}
+
+func (r *RobotsCache) store(key string, entry *robotsEntry) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if elem, ok := r.cache[key]; ok {
+		r.lru.Remove(elem)
+	}
+	// Evict LRU entries if over capacity.
+	for r.lru.Len() >= robotsCacheLRUCapacity {
+		back := r.lru.Back()
+		if back == nil {
+			break
+		}
+		r.lru.Remove(back)
+		delete(r.cache, back.Value.(*lruEntry).key)
+	}
+	elem := r.lru.PushFront(&lruEntry{key: key, data: entry})
+	r.cache[key] = elem
 }
 
 // fetch retrieves and parses robots.txt for the given origin (scheme://host).
-// Returns nil when the file is unavailable or unparseable (allow-all).
-func (r *RobotsCache) fetch(ctx context.Context, origin string) *robotstxt.RobotsData {
+func (r *RobotsCache) fetch(ctx context.Context, origin string) *robotsEntry {
+	now := time.Now()
 	robotsURL := origin + "/robots.txt"
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, robotsURL, nil)
 	if err != nil {
-		return nil
+		return &robotsEntry{fetchedAt: now, ttl: shortRobotsCacheTTL, allowAll: true}
 	}
 	if r.userAgent != "" {
 		req.Header.Set("User-Agent", r.userAgent)
@@ -92,7 +217,8 @@ func (r *RobotsCache) fetch(ctx context.Context, origin string) *robotstxt.Robot
 	resp, err := r.client.Do(req)
 	if err != nil {
 		log.Debug().Err(err).Str("url", robotsURL).Msg("robots: failed to fetch")
-		return nil
+		// Network error - allow for now but retry sooner.
+		return &robotsEntry{fetchedAt: now, ttl: shortRobotsCacheTTL, allowAll: true}
 	}
 	defer func() {
 		if err := resp.Body.Close(); err != nil {
@@ -101,22 +227,43 @@ func (r *RobotsCache) fetch(ctx context.Context, origin string) *robotstxt.Robot
 	}()
 
 	if resp.StatusCode == http.StatusNotFound {
-		// No robots.txt — allow everything.
-		return nil
+		// No robots.txt - allow everything.
+		return &robotsEntry{fetchedAt: now, ttl: r.ttl, allowAll: true}
+	}
+
+	if resp.StatusCode >= 500 {
+		// Server error - per RFC 9309: treat as deny-all.
+		log.Debug().Int("status", resp.StatusCode).Str("url", robotsURL).Msg("robots: server error, treating as deny-all")
+		return &robotsEntry{fetchedAt: now, ttl: r.ttl, denyAll: true}
 	}
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		log.Debug().Err(err).Str("url", robotsURL).Msg("robots: failed to read body")
-		return nil
+		return &robotsEntry{fetchedAt: now, ttl: shortRobotsCacheTTL, allowAll: true}
 	}
 
 	data, err := robotstxt.FromBytes(body)
 	if err != nil {
 		log.Debug().Err(err).Str("url", robotsURL).Msg("robots: failed to parse")
-		return nil
+		return &robotsEntry{fetchedAt: now, ttl: r.ttl, allowAll: true}
+	}
+
+	agent := r.userAgent
+	if agent == "" {
+		agent = "*"
+	}
+	group := data.FindGroup(agent)
+	var crawlDelay time.Duration
+	if group != nil && group.CrawlDelay > 0 {
+		crawlDelay = group.CrawlDelay
 	}
 
 	log.Debug().Str("origin", origin).Msg("robots: cached robots.txt")
-	return data
+	return &robotsEntry{
+		data:       data,
+		fetchedAt:  now,
+		ttl:        r.ttl,
+		crawlDelay: crawlDelay,
+	}
 }

--- a/server/crawler/robots_test.go
+++ b/server/crawler/robots_test.go
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package crawler
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestRobotsCacheTTLExpiry(t *testing.T) {
+	calls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		fmt.Fprintln(w, "User-agent: *\nAllow: /")
+	}))
+	defer srv.Close()
+
+	cache, err := NewRobotsCacheWithProxyAndTTL("TestBot", "", 50*time.Millisecond)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cache.client = srv.Client()
+
+	ctx := context.Background()
+	cache.Allowed(ctx, srv.URL+"/page")
+	cache.Allowed(ctx, srv.URL+"/page") // should hit cache
+
+	if calls != 1 {
+		t.Errorf("expected 1 fetch before TTL, got %d", calls)
+	}
+
+	time.Sleep(100 * time.Millisecond)
+	cache.Allowed(ctx, srv.URL+"/page") // TTL expired, should re-fetch
+
+	if calls != 2 {
+		t.Errorf("expected 2 fetches after TTL, got %d", calls)
+	}
+}
+
+func TestRobotsCache5xxDenyAll(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	cache, err := NewRobotsCacheWithProxy("TestBot", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cache.client = srv.Client()
+
+	allowed := cache.Allowed(context.Background(), srv.URL+"/page")
+	if allowed {
+		t.Error("expected deny-all on 5xx robots.txt, got allowed=true")
+	}
+}
+
+func TestRobotsCache404AllowAll(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	cache, err := NewRobotsCacheWithProxy("TestBot", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cache.client = srv.Client()
+
+	allowed := cache.Allowed(context.Background(), srv.URL+"/page")
+	if !allowed {
+		t.Error("expected allow-all on 404 robots.txt, got allowed=false")
+	}
+}
+
+func TestRobotsCacheCrawlDelay(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, "User-agent: *\nCrawl-delay: 5\nAllow: /")
+	}))
+	defer srv.Close()
+
+	cache, err := NewRobotsCacheWithProxy("TestBot", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cache.client = srv.Client()
+
+	ctx := context.Background()
+	cache.Allowed(ctx, srv.URL+"/page") // prime the cache
+
+	d := cache.CrawlDelay(srv.URL + "/page")
+	if d != 5*time.Second {
+		t.Errorf("CrawlDelay = %v, want 5s", d)
+	}
+}
+
+func TestRobotsCacheLRUEviction(t *testing.T) {
+	call := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		call++
+		fmt.Fprintln(w, "User-agent: *\nAllow: /")
+	}))
+	defer srv.Close()
+
+	cache, err := NewRobotsCacheWithProxy("TestBot", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cache.client = srv.Client()
+
+	// Fill the cache beyond capacity by faking many different hosts.
+	// We can't easily create 1001 HTTP servers, so instead we directly
+	// fill the internal LRU structures to verify eviction.
+	ctx := context.Background()
+
+	for i := 0; i < robotsCacheLRUCapacity+5; i++ {
+		key := fmt.Sprintf("http://host%d.example.com", i)
+		entry := &robotsEntry{fetchedAt: time.Now(), ttl: time.Hour, allowAll: true}
+		cache.store(key, entry)
+	}
+
+	cache.mu.Lock()
+	size := cache.lru.Len()
+	cache.mu.Unlock()
+
+	if size > robotsCacheLRUCapacity {
+		t.Errorf("LRU size = %d, want <= %d", size, robotsCacheLRUCapacity)
+	}
+
+	_ = ctx
+}

--- a/server/crawler/scheduler.go
+++ b/server/crawler/scheduler.go
@@ -1,0 +1,259 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package crawler
+
+import (
+	"container/list"
+	"context"
+	"math"
+	"math/rand"
+	"sync"
+	"time"
+
+	"github.com/asciimoo/hister/config"
+)
+
+const hostLRUCap = 10000
+
+// lazyBucket is a goroutine-free token bucket. Tokens are computed lazily on
+// each Wait call based on elapsed time since the last refill.
+type lazyBucket struct {
+	mu         sync.Mutex
+	rate       float64 // tokens per second
+	tokens     float64
+	burst      float64
+	lastRefill time.Time
+}
+
+func newLazyBucket(rps float64, burst int) *lazyBucket {
+	if rps <= 0 {
+		rps = 10
+	}
+	b := 1.0
+	if burst > 1 {
+		b = float64(burst)
+	}
+	return &lazyBucket{
+		rate:       rps,
+		tokens:     b, // pre-filled
+		burst:      b,
+		lastRefill: time.Now(),
+	}
+}
+
+func (lb *lazyBucket) Wait(ctx context.Context) error {
+	for {
+		lb.mu.Lock()
+		now := time.Now()
+		elapsed := now.Sub(lb.lastRefill).Seconds()
+		lb.tokens = math.Min(lb.burst, lb.tokens+elapsed*lb.rate)
+		lb.lastRefill = now
+
+		if lb.tokens >= 1 {
+			lb.tokens--
+			lb.mu.Unlock()
+			return nil
+		}
+
+		// Compute wait until we have one token.
+		wait := time.Duration((1.0-lb.tokens)/lb.rate*1e9) * time.Nanosecond
+		lb.mu.Unlock()
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(wait):
+		}
+	}
+}
+
+// hostState holds per-host scheduler state.
+type hostState struct {
+	bucket    *lazyBucket
+	inflight  chan struct{} // semaphore
+	coolUntil time.Time
+	lruElem   *list.Element
+}
+
+// Scheduler controls when fetches are dispatched based on rate limits,
+// per-host concurrency, circuit breaker state, and crawl budget.
+type Scheduler struct {
+	cfg           config.CrawlerRate
+	respectDelay  bool
+	hostOverrides map[string]config.CrawlerHostOverride
+	global        *lazyBucket
+	breaker       *CircuitBreaker
+	robots        *RobotsCache
+	clock         Clock
+	rng           *rand.Rand
+
+	mu      sync.Mutex
+	hosts   map[string]*hostState
+	lru     *list.List // front = most recently used; Value = host string
+}
+
+// NewScheduler creates a Scheduler. cfg is the full crawler configuration.
+func NewScheduler(cfg *config.CrawlerConfig, breaker *CircuitBreaker, robots *RobotsCache, clock Clock) *Scheduler {
+	if clock == nil {
+		clock = RealClock{}
+	}
+	return &Scheduler{
+		cfg:           cfg.Rate,
+		respectDelay:  cfg.Robots.RespectCrawlDelay,
+		hostOverrides: cfg.Hosts,
+		global:        newLazyBucket(cfg.Rate.GlobalRPS, cfg.Rate.GlobalConcurrency),
+		breaker:       breaker,
+		robots:        robots,
+		clock:         clock,
+		rng:           rand.New(rand.NewSource(time.Now().UnixNano())),
+		hosts:         make(map[string]*hostState),
+		lru:           list.New(),
+	}
+}
+
+func (s *Scheduler) effectiveRPS(host string) float64 {
+	rps := s.cfg.PerHostRPS
+	if rps <= 0 {
+		rps = 1
+	}
+
+	// Apply per-host override from config.
+	if ov, ok := s.hostOverrides[host]; ok && ov.PerHostRPS > 0 {
+		rps = ov.PerHostRPS
+	}
+
+	// Apply robots.txt Crawl-delay if configured.
+	if s.respectDelay && s.robots != nil {
+		delay := s.robots.CrawlDelayForHost(host)
+		if delay > 0 {
+			robotsRPS := 1.0 / delay.Seconds()
+			if robotsRPS < rps {
+				rps = robotsRPS
+			}
+		}
+	}
+
+	return rps
+}
+
+func (s *Scheduler) getHostState(host string) *hostState {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if hs, ok := s.hosts[host]; ok {
+		s.lru.MoveToFront(hs.lruElem)
+		return hs
+	}
+
+	rps := s.effectiveRPS(host)
+	concurrency := s.cfg.PerHostConcurrency
+	if concurrency < 1 {
+		concurrency = 1
+	}
+	hs := &hostState{
+		bucket:   newLazyBucket(rps, 1),
+		inflight: make(chan struct{}, concurrency),
+	}
+	for i := 0; i < concurrency; i++ {
+		hs.inflight <- struct{}{}
+	}
+
+	// Evict LRU entry if at cap.
+	if s.lru.Len() >= hostLRUCap {
+		back := s.lru.Back()
+		if back != nil {
+			s.lru.Remove(back)
+			delete(s.hosts, back.Value.(string))
+		}
+	}
+
+	elem := s.lru.PushFront(host)
+	hs.lruElem = elem
+	s.hosts[host] = hs
+	return hs
+}
+
+// Wait blocks until it is safe to fetch from host. It respects:
+// (1) circuit breaker state, (2) global token bucket, (3) per-host token
+// bucket, (4) per-host cooldown (Retry-After), (5) per-host in-flight limit.
+// Applies jitter to the per-host wait.
+func (s *Scheduler) Wait(ctx context.Context, host string) error {
+	// Check circuit breaker.
+	if s.breaker != nil && !s.breaker.Allow(host) {
+		return &errBreakerOpen{host: host}
+	}
+
+	// Global rate limit.
+	if err := s.global.Wait(ctx); err != nil {
+		return err
+	}
+
+	hs := s.getHostState(host)
+
+	// Per-host cooldown (Retry-After).
+	s.mu.Lock()
+	coolUntil := hs.coolUntil
+	s.mu.Unlock()
+
+	if !coolUntil.IsZero() {
+		remaining := coolUntil.Sub(s.clock.Now())
+		if remaining > 0 {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-s.clock.After(remaining):
+			}
+		}
+	}
+
+	// Per-host token (rate).
+	if err := hs.bucket.Wait(ctx); err != nil {
+		return err
+	}
+
+	// Jitter.
+	if s.cfg.Jitter > 0 {
+		jitterMax := s.cfg.Jitter / s.cfg.PerHostRPS
+		if s.cfg.PerHostRPS <= 0 {
+			jitterMax = s.cfg.Jitter
+		}
+		jitter := time.Duration(s.rng.Float64() * jitterMax * float64(time.Second))
+		if jitter > 0 {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-s.clock.After(jitter):
+			}
+		}
+	}
+
+	// Per-host in-flight semaphore.
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-hs.inflight:
+	}
+
+	return nil
+}
+
+// Release returns the in-flight slot for host after a fetch completes.
+func (s *Scheduler) Release(host string) {
+	hs := s.getHostState(host)
+	hs.inflight <- struct{}{}
+}
+
+// Cooldown marks host as cooling down until now+d, based on a Retry-After header.
+func (s *Scheduler) Cooldown(host string, d time.Duration) {
+	hs := s.getHostState(host)
+	s.mu.Lock()
+	hs.coolUntil = s.clock.Now().Add(d)
+	s.mu.Unlock()
+}
+
+// Stop is a no-op. The lazy token buckets have no goroutines to stop.
+func (s *Scheduler) Stop() {}
+
+type errBreakerOpen struct{ host string }
+
+func (e *errBreakerOpen) Error() string { return "circuit breaker open for host: " + e.host }

--- a/server/crawler/scheduler.go
+++ b/server/crawler/scheduler.go
@@ -23,9 +23,10 @@ type lazyBucket struct {
 	tokens     float64
 	burst      float64
 	lastRefill time.Time
+	clock      Clock
 }
 
-func newLazyBucket(rps float64, burst int) *lazyBucket {
+func newLazyBucket(rps float64, burst int, clock Clock) *lazyBucket {
 	if rps <= 0 {
 		rps = 10
 	}
@@ -37,14 +38,15 @@ func newLazyBucket(rps float64, burst int) *lazyBucket {
 		rate:       rps,
 		tokens:     b, // pre-filled
 		burst:      b,
-		lastRefill: time.Now(),
+		lastRefill: clock.Now(),
+		clock:      clock,
 	}
 }
 
 func (lb *lazyBucket) Wait(ctx context.Context) error {
 	for {
 		lb.mu.Lock()
-		now := time.Now()
+		now := lb.clock.Now()
 		elapsed := now.Sub(lb.lastRefill).Seconds()
 		lb.tokens = math.Min(lb.burst, lb.tokens+elapsed*lb.rate)
 		lb.lastRefill = now
@@ -62,7 +64,7 @@ func (lb *lazyBucket) Wait(ctx context.Context) error {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		case <-time.After(wait):
+		case <-lb.clock.After(wait):
 		}
 	}
 }
@@ -100,7 +102,7 @@ func NewScheduler(cfg *config.CrawlerConfig, breaker *CircuitBreaker, robots *Ro
 		cfg:           cfg.Rate,
 		respectDelay:  cfg.Robots.RespectCrawlDelay,
 		hostOverrides: cfg.Hosts,
-		global:        newLazyBucket(cfg.Rate.GlobalRPS, cfg.Rate.GlobalConcurrency),
+		global:        newLazyBucket(cfg.Rate.GlobalRPS, cfg.Rate.GlobalConcurrency, clock),
 		breaker:       breaker,
 		robots:        robots,
 		clock:         clock,
@@ -149,7 +151,7 @@ func (s *Scheduler) getHostState(host string) *hostState {
 		concurrency = 1
 	}
 	hs := &hostState{
-		bucket:   newLazyBucket(rps, 1),
+		bucket:   newLazyBucket(rps, 1, s.clock),
 		inflight: make(chan struct{}, concurrency),
 	}
 	for i := 0; i < concurrency; i++ {

--- a/server/crawler/scheduler.go
+++ b/server/crawler/scheduler.go
@@ -6,7 +6,7 @@ import (
 	"container/list"
 	"context"
 	"math"
-	"math/rand"
+	randv2 "math/rand/v2"
 	"sync"
 	"time"
 
@@ -85,7 +85,6 @@ type Scheduler struct {
 	breaker       *CircuitBreaker
 	robots        *RobotsCache
 	clock         Clock
-	rng           *rand.Rand
 
 	mu      sync.Mutex
 	hosts   map[string]*hostState
@@ -105,7 +104,6 @@ func NewScheduler(cfg *config.CrawlerConfig, breaker *CircuitBreaker, robots *Ro
 		breaker:       breaker,
 		robots:        robots,
 		clock:         clock,
-		rng:           rand.New(rand.NewSource(time.Now().UnixNano())),
 		hosts:         make(map[string]*hostState),
 		lru:           list.New(),
 	}
@@ -217,7 +215,7 @@ func (s *Scheduler) Wait(ctx context.Context, host string) error {
 		if s.cfg.PerHostRPS <= 0 {
 			jitterMax = s.cfg.Jitter
 		}
-		jitter := time.Duration(s.rng.Float64() * jitterMax * float64(time.Second))
+		jitter := time.Duration(randv2.Float64() * jitterMax * float64(time.Second))
 		if jitter > 0 {
 			select {
 			case <-ctx.Done():

--- a/server/crawler/scheduler.go
+++ b/server/crawler/scheduler.go
@@ -198,7 +198,8 @@ func (s *Scheduler) Wait(ctx context.Context, host string) error {
 	}
 
 	hs := s.getHostState(host)
-	hs.bucket.SetRate(s.effectiveRPS(host))
+	effectiveRate := s.effectiveRPS(host)
+	hs.bucket.SetRate(effectiveRate)
 
 	// Per-host cooldown (Retry-After).
 	s.mu.Lock()
@@ -223,10 +224,11 @@ func (s *Scheduler) Wait(ctx context.Context, host string) error {
 
 	// Jitter.
 	if s.cfg.Jitter > 0 {
-		jitterMax := s.cfg.Jitter / s.cfg.PerHostRPS
-		if s.cfg.PerHostRPS <= 0 {
-			jitterMax = s.cfg.Jitter
+		rate := effectiveRate
+		if rate <= 0 {
+			rate = 1
 		}
+		jitterMax := s.cfg.Jitter / rate
 		jitter := time.Duration(randv2.Float64() * jitterMax * float64(time.Second))
 		if jitter > 0 {
 			select {

--- a/server/crawler/scheduler.go
+++ b/server/crawler/scheduler.go
@@ -43,6 +43,15 @@ func newLazyBucket(rps float64, burst int, clock Clock) *lazyBucket {
 	}
 }
 
+func (lb *lazyBucket) SetRate(rps float64) {
+	lb.mu.Lock()
+	defer lb.mu.Unlock()
+	if rps <= 0 {
+		rps = 10
+	}
+	lb.rate = rps
+}
+
 func (lb *lazyBucket) Wait(ctx context.Context) error {
 	for {
 		lb.mu.Lock()
@@ -189,6 +198,7 @@ func (s *Scheduler) Wait(ctx context.Context, host string) error {
 	}
 
 	hs := s.getHostState(host)
+	hs.bucket.SetRate(s.effectiveRPS(host))
 
 	// Per-host cooldown (Retry-After).
 	s.mu.Lock()

--- a/server/crawler/scheduler.go
+++ b/server/crawler/scheduler.go
@@ -167,12 +167,21 @@ func (s *Scheduler) getHostState(host string) *hostState {
 		hs.inflight <- struct{}{}
 	}
 
-	// Evict LRU entry if at cap.
+	// Evict the LRU entry if at cap, skipping any host with in-flight requests
+	// to avoid corrupting concurrency accounting. Try up to 4 candidates.
 	if s.lru.Len() >= hostLRUCap {
-		back := s.lru.Back()
-		if back != nil {
-			s.lru.Remove(back)
-			delete(s.hosts, back.Value.(string))
+		const maxEvictAttempts = 4
+		candidate := s.lru.Back()
+		for i := 0; i < maxEvictAttempts && candidate != nil; i++ {
+			victimHost := candidate.Value.(string)
+			victimState := s.hosts[victimHost]
+			if victimState == nil || len(victimState.inflight) == cap(victimState.inflight) {
+				// No in-flight requests - safe to evict.
+				s.lru.Remove(candidate)
+				delete(s.hosts, victimHost)
+				break
+			}
+			candidate = candidate.Prev()
 		}
 	}
 

--- a/server/crawler/scheduler.go
+++ b/server/crawler/scheduler.go
@@ -224,12 +224,16 @@ func (s *Scheduler) Wait(ctx context.Context, host string) error {
 
 	// Jitter.
 	if s.cfg.Jitter > 0 {
+		const maxJitter = 30 * time.Second
 		rate := effectiveRate
 		if rate <= 0 {
 			rate = 1
 		}
 		jitterMax := s.cfg.Jitter / rate
 		jitter := time.Duration(randv2.Float64() * jitterMax * float64(time.Second))
+		if jitter > maxJitter {
+			jitter = maxJitter
+		}
 		if jitter > 0 {
 			select {
 			case <-ctx.Done():

--- a/server/crawler/scheduler_test.go
+++ b/server/crawler/scheduler_test.go
@@ -31,24 +31,24 @@ func TestSchedulerPerHostRateSpacing(t *testing.T) {
 	breaker := NewCircuitBreaker(5, 5*time.Minute, clock)
 	sched := newTestScheduler(cfg, breaker, nil, clock)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	// First request should pass immediately.
+	// First request should pass immediately (bucket is pre-filled).
 	done := make(chan error, 1)
 	go func() {
 		done <- sched.Wait(ctx, "example.com")
 	}()
 
-	// Give the goroutine time to start.
-	time.Sleep(10 * time.Millisecond)
+	// Advance clock so any timer-based waits inside the bucket fire.
+	clock.Advance(10 * time.Millisecond)
 
 	select {
 	case err := <-done:
 		if err != nil {
 			t.Fatalf("first Wait error: %v", err)
 		}
-	case <-time.After(100 * time.Millisecond):
+	case <-time.After(500 * time.Millisecond):
 		t.Fatal("first Wait timed out")
 	}
 

--- a/server/crawler/scheduler_test.go
+++ b/server/crawler/scheduler_test.go
@@ -222,6 +222,68 @@ func TestSchedulerHostOverride(t *testing.T) {
 	sched.Release("fast.example.com")
 }
 
+func TestSchedulerRateRefreshAfterRobotsPopulated(t *testing.T) {
+	rc := NewRobotsCache("testbot")
+
+	cfg := &config.CrawlerConfig{
+		Rate: config.CrawlerRate{
+			GlobalRPS:          1000,
+			PerHostRPS:         10, // 100ms between requests
+			GlobalConcurrency:  10,
+			PerHostConcurrency: 1,
+			Jitter:             0,
+		},
+		Robots: config.CrawlerRobots{
+			RespectCrawlDelay: true,
+		},
+	}
+	clock := NewFakeClock(time.Now())
+	breaker := NewCircuitBreaker(5, 5*time.Minute, clock)
+	sched := NewScheduler(cfg, breaker, rc, clock)
+
+	// First Wait passes immediately (bucket pre-filled, no robots entry yet).
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() { done <- sched.Wait(ctx, "late.example.com") }()
+	clock.Advance(10 * time.Millisecond)
+	if err := <-done; err != nil {
+		t.Fatalf("first Wait: %v", err)
+	}
+	sched.Release("late.example.com")
+
+	// Now populate robots cache with a 1000s crawl delay.
+	rc.store("https://late.example.com", &robotsEntry{
+		fetchedAt:  clock.Now(),
+		ttl:        24 * time.Hour,
+		allowAll:   true,
+		crawlDelay: 1000 * time.Second,
+	})
+
+	// Second Wait should now be gated by the 1000s crawl delay.
+	ctx2, cancel2 := context.WithCancel(context.Background())
+	defer cancel2()
+
+	done2 := make(chan error, 1)
+	go func() { done2 <- sched.Wait(ctx2, "late.example.com") }()
+
+	// Give goroutine time to start and block.
+	clock.Advance(100 * time.Millisecond)
+	time.Sleep(20 * time.Millisecond)
+
+	select {
+	case err := <-done2:
+		sched.Release("late.example.com")
+		t.Fatalf("second Wait should be blocked by robots 1000s delay, but returned: %v", err)
+	default:
+		// Still blocked - expected.
+	}
+
+	cancel2()
+	<-done2
+}
+
 func TestSchedulerRobotsCrawlDelay(t *testing.T) {
 	// Build a fake RobotsCache with a cached entry for a host.
 	rc := NewRobotsCache("testbot")

--- a/server/crawler/scheduler_test.go
+++ b/server/crawler/scheduler_test.go
@@ -1,0 +1,270 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package crawler
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/asciimoo/hister/config"
+)
+
+func newTestScheduler(rate config.CrawlerRate, breaker *CircuitBreaker, robots *RobotsCache, clock Clock) *Scheduler {
+	cfg := &config.CrawlerConfig{
+		Rate: rate,
+	}
+	return NewScheduler(cfg, breaker, robots, clock)
+}
+
+func TestSchedulerPerHostRateSpacing(t *testing.T) {
+	cfg := config.CrawlerRate{
+		GlobalRPS:          100,
+		PerHostRPS:         2, // 500ms between requests
+		GlobalConcurrency:  10,
+		PerHostConcurrency: 1,
+		Jitter:             0,
+	}
+	clock := NewFakeClock(time.Now())
+	breaker := NewCircuitBreaker(5, 5*time.Minute, clock)
+	sched := newTestScheduler(cfg, breaker, nil, clock)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// First request should pass immediately.
+	done := make(chan error, 1)
+	go func() {
+		done <- sched.Wait(ctx, "example.com")
+	}()
+
+	// Give the goroutine time to start.
+	time.Sleep(10 * time.Millisecond)
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("first Wait error: %v", err)
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("first Wait timed out")
+	}
+
+	sched.Release("example.com")
+}
+
+func TestSchedulerRetryAfterCooldown(t *testing.T) {
+	cfg := config.CrawlerRate{
+		GlobalRPS:          100,
+		PerHostRPS:         100,
+		GlobalConcurrency:  10,
+		PerHostConcurrency: 5,
+		Jitter:             0,
+	}
+	clock := NewFakeClock(time.Now())
+	breaker := NewCircuitBreaker(5, 5*time.Minute, clock)
+	sched := newTestScheduler(cfg, breaker, nil, clock)
+
+	// Install a 10-second cooldown.
+	sched.Cooldown("slow.example.com", 10*time.Second)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan error, 1)
+	go func() {
+		done <- sched.Wait(ctx, "slow.example.com")
+	}()
+
+	// Should still be blocked after 5s because cooldown is 10s.
+	clock.Advance(5 * time.Second)
+	time.Sleep(20 * time.Millisecond)
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("Wait should have blocked during cooldown")
+		}
+	default:
+		// Still blocked - expected.
+	}
+
+	cancel() // unblock
+	<-done
+}
+
+func TestSchedulerBreakerInteraction(t *testing.T) {
+	cfg := config.CrawlerRate{
+		GlobalRPS:          100,
+		PerHostRPS:         100,
+		GlobalConcurrency:  10,
+		PerHostConcurrency: 5,
+		Jitter:             0,
+	}
+	clock := NewFakeClock(time.Now())
+	breaker := NewCircuitBreaker(1, 5*time.Minute, clock)
+	sched := newTestScheduler(cfg, breaker, nil, clock)
+
+	// Trip the breaker.
+	breaker.RecordFailure("tripped.example.com")
+	if breaker.State("tripped.example.com") != BreakerOpen {
+		t.Fatal("breaker should be open after failure")
+	}
+
+	ctx := context.Background()
+	err := sched.Wait(ctx, "tripped.example.com")
+	if err == nil {
+		t.Fatal("Wait should return error when breaker is open")
+	}
+	var breakerErr *errBreakerOpen
+	if !errors.As(err, &breakerErr) {
+		t.Errorf("expected errBreakerOpen, got %T: %v", err, err)
+	}
+}
+
+func TestSchedulerLRUEviction(t *testing.T) {
+	cfg := config.CrawlerRate{
+		GlobalRPS:          1000,
+		PerHostRPS:         1000,
+		GlobalConcurrency:  1000,
+		PerHostConcurrency: 1,
+		Jitter:             0,
+	}
+	clock := NewFakeClock(time.Now())
+	breaker := NewCircuitBreaker(5, 5*time.Minute, clock)
+	sched := newTestScheduler(cfg, breaker, nil, clock)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// Fill to the cap by calling getHostState with unique hostnames.
+	firstHost := "host-0.com"
+	for i := 0; i < hostLRUCap; i++ {
+		host := fmt.Sprintf("host-%d.com", i)
+		if i == 0 {
+			firstHost = host
+		}
+		sched.getHostState(host)
+	}
+
+	sched.mu.Lock()
+	lenAtCap := len(sched.hosts)
+	sched.mu.Unlock()
+
+	if lenAtCap != hostLRUCap {
+		t.Fatalf("expected %d hosts at cap, got %d", hostLRUCap, lenAtCap)
+	}
+
+	// Adding one more should evict the oldest (firstHost).
+	_ = sched.Wait(ctx, "newcomer.example.com") //nolint - error fine for test purposes
+	sched.Release("newcomer.example.com")
+
+	sched.mu.Lock()
+	lenAfter := len(sched.hosts)
+	_, newcomerPresent := sched.hosts["newcomer.example.com"]
+	_, firstPresent := sched.hosts[firstHost]
+	sched.mu.Unlock()
+
+	if lenAfter != hostLRUCap {
+		t.Fatalf("expected map len %d after eviction, got %d", hostLRUCap, lenAfter)
+	}
+	if !newcomerPresent {
+		t.Fatal("newcomer host should be present after eviction")
+	}
+	if firstPresent {
+		t.Fatalf("oldest host %q should have been evicted", firstHost)
+	}
+}
+
+func TestSchedulerHostOverride(t *testing.T) {
+	cfg := &config.CrawlerConfig{
+		Rate: config.CrawlerRate{
+			GlobalRPS:          1000,
+			PerHostRPS:         1000,
+			GlobalConcurrency:  10,
+			PerHostConcurrency: 1,
+			Jitter:             0,
+		},
+		Hosts: map[string]config.CrawlerHostOverride{
+			"slow.example.com": {PerHostRPS: 0.001}, // effectively 1 request per 1000s
+		},
+	}
+	clock := NewFakeClock(time.Now())
+	breaker := NewCircuitBreaker(5, 5*time.Minute, clock)
+	sched := NewScheduler(cfg, breaker, nil, clock)
+
+	// First request should pass (bucket pre-filled).
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	err := sched.Wait(ctx, "slow.example.com")
+	if err != nil {
+		t.Fatalf("first Wait on overridden host: %v", err)
+	}
+	sched.Release("slow.example.com")
+
+	// Second request should block because the rate is 0.001 rps.
+	ctx2, cancel2 := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel2()
+	err2 := sched.Wait(ctx2, "slow.example.com")
+	if err2 == nil {
+		sched.Release("slow.example.com")
+		t.Fatal("second Wait on overridden host should have timed out due to low RPS")
+	}
+
+	// Default host should not be throttled.
+	ctx3, cancel3 := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel3()
+	if err := sched.Wait(ctx3, "fast.example.com"); err != nil {
+		t.Fatalf("Wait on non-overridden host: %v", err)
+	}
+	sched.Release("fast.example.com")
+}
+
+func TestSchedulerRobotsCrawlDelay(t *testing.T) {
+	// Build a fake RobotsCache with a cached entry for a host.
+	rc := NewRobotsCache("testbot")
+
+	// Manually inject a cache entry with a 1000s crawl delay so the second
+	// request will definitely time out.
+	rc.store("https://delayed.example.com", &robotsEntry{
+		fetchedAt:  time.Now(),
+		ttl:        24 * time.Hour,
+		allowAll:   true,
+		crawlDelay: 1000 * time.Second,
+	})
+
+	cfg := &config.CrawlerConfig{
+		Rate: config.CrawlerRate{
+			GlobalRPS:          1000,
+			PerHostRPS:         1000,
+			GlobalConcurrency:  10,
+			PerHostConcurrency: 1,
+			Jitter:             0,
+		},
+		Robots: config.CrawlerRobots{
+			RespectCrawlDelay: true,
+		},
+	}
+	clock := NewFakeClock(time.Now())
+	breaker := NewCircuitBreaker(5, 5*time.Minute, clock)
+	sched := NewScheduler(cfg, breaker, rc, clock)
+
+	// First request passes (bucket pre-filled).
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	if err := sched.Wait(ctx, "delayed.example.com"); err != nil {
+		t.Fatalf("first Wait: %v", err)
+	}
+	sched.Release("delayed.example.com")
+
+	// Second request should block - robots requires 1000s delay.
+	ctx2, cancel2 := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel2()
+	err := sched.Wait(ctx2, "delayed.example.com")
+	if err == nil {
+		sched.Release("delayed.example.com")
+		t.Fatal("second Wait should have blocked due to robots crawl-delay")
+	}
+}

--- a/server/crawler/types.go
+++ b/server/crawler/types.go
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package crawler
+
+import (
+	"fmt"
+	"time"
+)
+
+// Link is a hyperlink extracted from a page.
+type Link struct {
+	Href string
+	Rel  string
+}
+
+// FetchMeta carries HTTP response metadata from a fetch.
+type FetchMeta struct {
+	StatusCode     int
+	ETag           string
+	LastModified   string
+	XRobotsTag     string
+	RetryAfter     time.Duration
+}
+
+// HTTPStatusError is returned by fetchPage when the server responds with a
+// non-2xx status code.
+type HTTPStatusError struct {
+	Status     int
+	RetryAfter time.Duration
+}
+
+func (e *HTTPStatusError) Error() string {
+	if e.RetryAfter > 0 {
+		return fmt.Sprintf("HTTP %d (retry after %s)", e.Status, e.RetryAfter)
+	}
+	return fmt.Sprintf("HTTP %d", e.Status)
+}
+
+// RequestHints carries conditional-GET headers for a fetch request.
+type RequestHints struct {
+	IfNoneMatch     string
+	IfModifiedSince string
+}

--- a/server/crawler/types.go
+++ b/server/crawler/types.go
@@ -13,13 +13,21 @@ type Link struct {
 	Rel  string
 }
 
+// MetaRobots holds the noindex/nofollow state derived from <meta name="robots">
+// tags and X-Robots-Tag response headers.
+type MetaRobots struct {
+	NoIndex  bool
+	NoFollow bool
+}
+
 // FetchMeta carries HTTP response metadata from a fetch.
 type FetchMeta struct {
-	StatusCode     int
-	ETag           string
-	LastModified   string
-	XRobotsTag     string
-	RetryAfter     time.Duration
+	StatusCode  int
+	ETag        string
+	LastModified string
+	XRobotsTag  string
+	RetryAfter  time.Duration
+	MetaRobots  MetaRobots // from <meta name="robots"> in the page body
 }
 
 // HTTPStatusError is returned by fetchPage when the server responds with a

--- a/server/crawler/validator.go
+++ b/server/crawler/validator.go
@@ -152,32 +152,6 @@ func (v *Validator) Validate(u *url.URL, depth int) URLStatus {
 	return URLAllow
 }
 
-// ValidateHost performs a cheap host-only check against the excluded and
-// allowed domain lists. It does not increment the visited counter and ignores
-// depth, pattern, and link-count rules. Use it to fast-path entire hosts
-// before paying the per-URL rule cost.
-func (v *Validator) ValidateHost(host string) bool {
-	v.mu.Lock()
-	defer v.mu.Unlock()
-
-	for _, d := range v.rules.ExcludeDomains {
-		if host == d || strings.HasSuffix(host, "."+d) {
-			return false
-		}
-	}
-
-	if len(v.rules.AllowedDomains) > 0 {
-		for _, d := range v.rules.AllowedDomains {
-			if host == d || strings.HasSuffix(host, "."+d) {
-				return true
-			}
-		}
-		return false
-	}
-
-	return true
-}
-
 // MarshalValidatorRules serializes rules to a JSON string for storage.
 func MarshalValidatorRules(rules *ValidatorRules) (string, error) {
 	b, err := json.Marshal(rules)

--- a/server/crawler/validator.go
+++ b/server/crawler/validator.go
@@ -152,6 +152,32 @@ func (v *Validator) Validate(u *url.URL, depth int) URLStatus {
 	return URLAllow
 }
 
+// ValidateHost performs a cheap host-only check against the excluded and
+// allowed domain lists. It does not increment the visited counter and ignores
+// depth, pattern, and link-count rules. Use it to fast-path entire hosts
+// before paying the per-URL rule cost.
+func (v *Validator) ValidateHost(host string) bool {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+
+	for _, d := range v.rules.ExcludeDomains {
+		if host == d || strings.HasSuffix(host, "."+d) {
+			return false
+		}
+	}
+
+	if len(v.rules.AllowedDomains) > 0 {
+		for _, d := range v.rules.AllowedDomains {
+			if host == d || strings.HasSuffix(host, "."+d) {
+				return true
+			}
+		}
+		return false
+	}
+
+	return true
+}
+
 // MarshalValidatorRules serializes rules to a JSON string for storage.
 func MarshalValidatorRules(rules *ValidatorRules) (string, error) {
 	b, err := json.Marshal(rules)

--- a/server/document/document.go
+++ b/server/document/document.go
@@ -41,6 +41,8 @@ type Document struct {
 	Label      string         `json:"label"`
 	AddCount   uint           `json:"add_count"`
 	Metadata   map[string]any `json:"metadata"`
+	ETag         string `json:"etag,omitempty"`
+	LastModified string `json:"last_modified,omitempty"`
 	// ExtraDocuments can be populated by extractors to create new documents during the extraction
 	ExtraDocuments []*Document `json:"-"`
 	// SkipIndexing can be set by extractors to mark the document to exclude from indexing. Useful when populating ExtraDocuments

--- a/server/model/crawl.go
+++ b/server/model/crawl.go
@@ -45,7 +45,7 @@ type CrawlJob struct {
 type CrawlURL struct {
 	ID           uint      `gorm:"primaryKey;autoIncrement" json:"id"`
 	JobID        string    `gorm:"uniqueIndex:idx_crawl_job_url;not null" json:"job_id"`
-	URL          string    `gorm:"uniqueIndex:idx_crawl_job_url;not null" json:"url"`
+	URL          string    `gorm:"uniqueIndex:idx_crawl_job_url;index;not null" json:"url"`
 	Depth        int       `json:"depth"`
 	Status       string    `gorm:"not null;default:pending" json:"status"`
 	Error        string    `json:"error"`

--- a/server/model/crawl.go
+++ b/server/model/crawl.go
@@ -43,15 +43,17 @@ type CrawlJob struct {
 
 // CrawlURL tracks every URL discovered during a crawl job.
 type CrawlURL struct {
-	ID        uint      `gorm:"primaryKey;autoIncrement" json:"id"`
-	JobID     string    `gorm:"uniqueIndex:idx_crawl_job_url;not null" json:"job_id"`
-	URL       string    `gorm:"uniqueIndex:idx_crawl_job_url;not null" json:"url"`
-	Depth     int       `json:"depth"`
-	Status    string    `gorm:"not null;default:pending" json:"status"`
-	Error     string    `json:"error"`
-	ErrorCode int       `json:"error_code"`
-	CreatedAt time.Time `json:"created_at"`
-	UpdatedAt time.Time `json:"updated_at"`
+	ID           uint      `gorm:"primaryKey;autoIncrement" json:"id"`
+	JobID        string    `gorm:"uniqueIndex:idx_crawl_job_url;not null" json:"job_id"`
+	URL          string    `gorm:"uniqueIndex:idx_crawl_job_url;not null" json:"url"`
+	Depth        int       `json:"depth"`
+	Status       string    `gorm:"not null;default:pending" json:"status"`
+	Error        string    `json:"error"`
+	ErrorCode    int       `json:"error_code"`
+	ETag         string    `json:"etag"`          // ETag from last successful fetch
+	LastModified string    `json:"last_modified"` // Last-Modified from last successful fetch
+	CreatedAt    time.Time `json:"created_at"`
+	UpdatedAt    time.Time `json:"updated_at"`
 }
 
 // GenerateCrawlJobID returns a random 8-character hex string suitable as a job ID.
@@ -176,12 +178,40 @@ func insertCrawlURLs(db *gorm.DB, jobID string, urls []string, depth int) error 
 	return db.Clauses(clause.OnConflict{DoNothing: true}).CreateInBatches(records, 500).Error
 }
 
-// MarkDoneAndEnqueueLinks marks a crawl URL as done and inserts all discovered
-// child URLs in a single transaction, minimising the number of SQLite commits.
-func MarkDoneAndEnqueueLinks(id uint, jobID string, links []string, depth int) error {
+// GetLastFetchedURLMeta returns the ETag and Last-Modified from the most-recent
+// successful fetch of url across any job, or ok=false if none exists.
+func GetLastFetchedURLMeta(rawURL string) (etag, lastModified string, ok bool, err error) {
+	var cu CrawlURL
+	err = DB.Select("etag, last_modified").
+		Where("url = ? AND status = ?", rawURL, CrawlURLDone).
+		Order("updated_at DESC").
+		Limit(1).
+		First(&cu).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return "", "", false, nil
+	}
+	if err != nil {
+		return "", "", false, err
+	}
+	if cu.ETag == "" && cu.LastModified == "" {
+		return "", "", false, nil
+	}
+	return cu.ETag, cu.LastModified, true, nil
+}
+
+// MarkDoneAndEnqueueLinks marks a crawl URL as done (with conditional-GET
+// metadata) and inserts all discovered child URLs in a single transaction,
+// minimising the number of SQLite commits.
+func MarkDoneAndEnqueueLinks(id uint, jobID string, links []string, depth int, etag, lastModified string) error {
 	return DB.Transaction(func(tx *gorm.DB) error {
 		if err := tx.Model(&CrawlURL{}).Where("id = ?", id).
-			Updates(map[string]any{"status": CrawlURLDone, "error": "", "error_code": 0}).Error; err != nil {
+			Updates(map[string]any{
+				"status":        CrawlURLDone,
+				"etag":          etag,
+				"last_modified": lastModified,
+				"error":         "",
+				"error_code":    0,
+			}).Error; err != nil {
 			return err
 		}
 		if len(links) == 0 {

--- a/server/model/crawl.go
+++ b/server/model/crawl.go
@@ -50,8 +50,8 @@ type CrawlURL struct {
 	Status       string    `gorm:"not null;default:pending" json:"status"`
 	Error        string    `json:"error"`
 	ErrorCode    int       `json:"error_code"`
-	ETag         string    `json:"etag"`          // ETag from last successful fetch
-	LastModified string    `json:"last_modified"` // Last-Modified from last successful fetch
+	ETag         string    `gorm:"column:etag" json:"etag"`                   // ETag from last successful fetch. Explicit column name so GORM does not derive "e_tag" from the field name.
+	LastModified string    `gorm:"column:last_modified" json:"last_modified"` // Last-Modified from last successful fetch
 	CreatedAt    time.Time `json:"created_at"`
 	UpdatedAt    time.Time `json:"updated_at"`
 }

--- a/server/model/crawl_test.go
+++ b/server/model/crawl_test.go
@@ -77,3 +77,4 @@ func TestCreateNamedCrawlJobWithURLsRejectsEmptyQueue(t *testing.T) {
 		t.Fatalf("job count = %d, want 0", len(jobs))
 	}
 }
+

--- a/server/model/migration.go
+++ b/server/model/migration.go
@@ -37,6 +37,25 @@ var migrations = []migration{
 			})
 		},
 	},
+	{
+		post: func() error {
+			// An earlier revision of the CrawlURL ETag field lacked an explicit
+			// gorm column tag, so AutoMigrate created an "e_tag" column instead
+			// of "etag". Rename it if present so queries against "etag" work.
+			// AutoMigrate has already added the correctly-named column, so this
+			// step only cleans up the stale one.
+			if !DB.Migrator().HasColumn("crawl_urls", "e_tag") {
+				return nil
+			}
+			// Copy any data across before dropping. In practice the buggy schema
+			// never accepted writes (queries referenced "etag"), but do this
+			// defensively in case some path did populate it.
+			if err := DB.Exec("UPDATE crawl_urls SET etag = e_tag WHERE etag = '' AND e_tag != ''").Error; err != nil {
+				return err
+			}
+			return DB.Exec("ALTER TABLE crawl_urls DROP COLUMN e_tag").Error
+		},
+	},
 }
 
 func migrationVersion() (int64, bool) {

--- a/webui/website/src/content/docs/configuration.md
+++ b/webui/website/src/content/docs/configuration.md
@@ -332,7 +332,7 @@ description: 'Explore every configuration section, option, default value, enviro
       name: 'delay',
       type: 'int',
       defaultValue: '0',
-      description: 'Seconds to wait between requests to avoid overloading target servers.',
+      description: 'Deprecated. Sets rate.per_host_rps = 1/delay when rate.per_host_rps is unset. Prefer rate.per_host_rps directly.',
     },
     {
       name: 'user_agent',
@@ -357,6 +357,66 @@ description: 'Explore every configuration section, option, default value, enviro
       type: 'bool',
       defaultValue: 'false',
       description: 'Disables robots.txt compliance during crawling.',
+    },
+    {
+      name: 'contact_url',
+      type: 'string',
+      defaultValue: '(none)',
+      description: 'Contact URL advertised in the default User-agent header. When set and user_agent is empty, the crawler sends Hister/<version> (+<contact_url>) so operators of crawled sites can find out who is hitting them.',
+    },
+    {
+      name: 'conditional_get',
+      type: 'bool',
+      defaultValue: 'false',
+      description: 'Enable conditional GET (If-None-Match / If-Modified-Since) on refetches. The HTTP backend accepts the hints; end-to-end wire-up in the persistent crawler is pending.',
+    },
+    {
+      name: 'respect_meta_robots',
+      type: 'bool',
+      defaultValue: 'false',
+      description: 'Reserved for future support of <meta name=robots> and X-Robots-Tag header handling. No effect today.',
+    },
+    {
+      name: 'shutdown_grace',
+      type: 'int',
+      defaultValue: '30',
+      description: 'Seconds workers may keep draining in-flight fetches after the crawl context is cancelled. In-flight requests are aborted once this elapses.',
+    },
+    {
+      name: 'rate',
+      type: 'object',
+      defaultValue: '(see Rate Limiting below)',
+      description: 'Rate limiting and concurrency settings. See Rate Limiting below.',
+    },
+    {
+      name: 'retry',
+      type: 'object',
+      defaultValue: '(see Retry below)',
+      description: 'Retry policy for transient fetch failures. See Retry below.',
+    },
+    {
+      name: 'circuit_breaker',
+      type: 'object',
+      defaultValue: '(see Circuit Breaker below)',
+      description: 'Per-host circuit breaker settings. See Circuit Breaker below.',
+    },
+    {
+      name: 'limits',
+      type: 'object',
+      defaultValue: '(see Crawl Limits below)',
+      description: 'Response size and crawl budget limits. See Crawl Limits below.',
+    },
+    {
+      name: 'robots',
+      type: 'object',
+      defaultValue: '(see Robots.txt below)',
+      description: 'robots.txt cache and enforcement settings. See Robots.txt below.',
+    },
+    {
+      name: 'hosts',
+      type: 'map',
+      defaultValue: '(none)',
+      description: 'Per-host overrides. See Per-Host Overrides below.',
     },
   ];
 
@@ -515,6 +575,43 @@ description: 'Explore every configuration section, option, default value, enviro
       defaultValue: '0.4',
       description: 'Weight applied to semantic scores when merging them with keyword scores. Zero uses keyword results only, while one uses semantic results only.',
     },
+  ];
+
+  const crawlerRateOptions = [
+    { name: 'global_rps',           type: 'float', defaultValue: '10',  description: 'Total requests per second across all hosts.' },
+    { name: 'per_host_rps',         type: 'float', defaultValue: '1',   description: 'Requests per second per host. When 0 or unset, the crawler uses 1 req/s. The effective rate is the minimum of this value, any per-host override, and the robots.txt Crawl-delay for the host.' },
+    { name: 'global_concurrency',   type: 'int',   defaultValue: '8',   description: 'Number of worker goroutines that fetch pages concurrently.' },
+    { name: 'per_host_concurrency', type: 'int',   defaultValue: '1',   description: 'Maximum concurrent in-flight requests to a single host.' },
+    { name: 'jitter',               type: 'float', defaultValue: '0.2', description: 'Randomized wait added between per-host requests, expressed as a fraction of the per-host interval. 0.2 means up to ±20 percent jitter.' },
+  ];
+
+  const crawlerRetryOptions = [
+    { name: 'max_attempts',    type: 'int', defaultValue: '3',  description: 'Maximum fetch attempts per URL, including the initial try. Retries apply only to transient failures (network errors, 408, 429, 500, 502, 503, 504).' },
+    { name: 'initial_backoff', type: 'int', defaultValue: '1',  description: 'Seconds to wait before the second attempt. Subsequent attempts use exponential backoff with jitter, capped by max_backoff.' },
+    { name: 'max_backoff',     type: 'int', defaultValue: '30', description: 'Upper bound in seconds for any single backoff wait.' },
+  ];
+
+  const crawlerBreakerOptions = [
+    { name: 'consecutive_failures', type: 'int', defaultValue: '5',   description: 'Trip the circuit breaker after this many consecutive failures for a host.' },
+    { name: 'cooldown',             type: 'int', defaultValue: '300', description: 'Seconds the breaker stays open before entering half-open state. Half-open allows one probe request to test recovery.' },
+  ];
+
+  const crawlerLimitsOptions = [
+    { name: 'max_response_bytes', type: 'int', defaultValue: '10485760', description: 'Response body size cap in bytes. Fetches exceeding this size are rejected. Default is 10 MB.' },
+    { name: 'max_pages',          type: 'int', defaultValue: '0',        description: 'Global crawl budget: total pages a crawl may fetch. 0 means unlimited.' },
+    { name: 'max_pages_per_host', type: 'int', defaultValue: '0',        description: 'Per-host page cap. 0 means unlimited.' },
+    { name: 'max_bytes_per_host', type: 'int', defaultValue: '0',        description: 'Per-host byte cap. 0 means unlimited.' },
+    { name: 'max_duration',       type: 'int', defaultValue: '0',        description: 'Maximum crawl wall-clock time in seconds. 0 means unlimited.' },
+  ];
+
+  const crawlerRobotsOptions = [
+    { name: 'cache_ttl',           type: 'int',  defaultValue: '86400', description: "Seconds to cache each host's robots.txt. Default is 24 hours." },
+    { name: 'respect_crawl_delay', type: 'bool', defaultValue: 'true',  description: 'When true, robots.txt Crawl-delay lowers the effective per-host request rate for a host.' },
+  ];
+
+  const crawlerHostOverrideOptions = [
+    { name: 'per_host_rps', type: 'float', defaultValue: '(inherit)', description: 'Override rate.per_host_rps for this host. Effective rate is still the minimum of this value and any Crawl-delay from robots.txt.' },
+    { name: 'max_pages',    type: 'int',   defaultValue: '0',         description: 'Override limits.max_pages_per_host for this host. 0 means unlimited.' },
   ];
 
   const semanticProcessingOptions = [
@@ -1049,6 +1146,56 @@ without losing progress. See [Website Crawler](crawler) for usage details.
 
 <ConfigReference items={crawlerOptions} />
 
+### Rate Limiting
+
+Controls how aggressively the crawler makes requests. All values apply per crawl run.
+
+<ConfigReference items={crawlerRateOptions} />
+
+The effective per-host request rate is the minimum of `rate.per_host_rps`, any override in `hosts.<host>.per_host_rps`, and the robots.txt `Crawl-delay` for that host (when `robots.respect_crawl_delay` is true).
+
+### Retry
+
+<ConfigReference items={crawlerRetryOptions} />
+
+Non-retryable errors (most 4xx status codes, permanent DNS failures, TLS errors) fail immediately without retries.
+
+### Circuit Breaker
+
+Protects hosts that are struggling by pausing requests to them after repeated failures.
+
+<ConfigReference items={crawlerBreakerOptions} />
+
+### Crawl Limits
+
+Response size and budget guardrails that stop a crawl before it runs away.
+
+<ConfigReference items={crawlerLimitsOptions} />
+
+### Robots.txt
+
+<ConfigReference items={crawlerRobotsOptions} />
+
+Beyond these settings, the crawler follows [RFC 9309](https://www.rfc-editor.org/rfc/rfc9309.html): 404 for robots.txt means allow-all, 5xx means deny-all, and network errors default to allow-all with a short retry TTL.
+
+### Per-Host Overrides
+
+Set `hosts.<domain>` to override rate or budget for a specific host. The key is the exact host as it appears in URLs (no scheme, no port).
+
+<ConfigReference items={crawlerHostOverrideOptions} />
+
+Example:
+
+```yaml
+crawler:
+  hosts:
+    slow.example.com:
+      per_host_rps: 0.2
+      max_pages: 50
+    fast-mirror.example.com:
+      per_host_rps: 5
+```
+
 Set `proxy` to an `http://` or `socks5://` URL. The HTTP backend uses it as its transport proxy,
 Chromedp passes it to the browser process, and BiDi requests it when creating the browser session.
 robots.txt requests use the same proxy. For example:
@@ -1134,8 +1281,23 @@ crawler:
   backend: 'http'
   proxy: 'http://127.0.0.1:8080'
   timeout: 10
-  delay: 2
-  user_agent: 'Hister'
+  contact_url: 'https://example.org/hister-bot'
+  rate:
+    per_host_rps: 0.5
+    per_host_concurrency: 1
+    jitter: 0.2
+  retry:
+    max_attempts: 3
+    initial_backoff: 2
+    max_backoff: 60
+  limits:
+    max_response_bytes: 5242880
+    max_pages_per_host: 200
+  robots:
+    respect_crawl_delay: true
+  hosts:
+    slow.example.com:
+      per_host_rps: 0.1
   headers:
     Accept-Language: 'en-US,en;q=0.9'
   cookies:

--- a/webui/website/src/content/docs/crawler.md
+++ b/webui/website/src/content/docs/crawler.md
@@ -262,6 +262,8 @@ The request related flags are:
 
 For all backend options and configuration examples, see the
 [Crawler Configuration](configuration#crawler-backend-options) reference.
+For rate limiting, retry policy, circuit breaker, crawl budgets, robots.txt cache, and per-host
+overrides, see the [crawler config sections](configuration#rate-limiting) in the Configuration Reference.
 
 For example, route a crawl through a local SOCKS5 proxy:
 

--- a/webui/website/src/routes/bot/+page.svelte
+++ b/webui/website/src/routes/bot/+page.svelte
@@ -1,0 +1,70 @@
+<script lang="ts">
+  import Seo from '$lib/Seo.svelte';
+</script>
+
+<Seo
+  title="Hister Bot | Crawler Info"
+  description="Information about the Hister web crawler: what it does, how to control it, and how to contact us."
+  path="/bot"
+/>
+
+<main class="mx-auto max-w-3xl px-6 py-16">
+  <h1 class="mb-4 text-3xl font-bold">Hister Crawler</h1>
+
+  <p class="mb-8 text-lg text-gray-600 dark:text-gray-400">
+    Hister is a self-hosted personal search engine. Its crawler indexes web
+    pages on behalf of individual users running their own Hister instances. It
+    is not a commercial bot and does not sell or aggregate data centrally.
+  </p>
+
+  <section class="mb-10">
+    <h2 class="mb-3 text-xl font-semibold">What the crawler does</h2>
+    <ul class="list-disc space-y-2 pl-6 text-gray-700 dark:text-gray-300">
+      <li>Follows links from pages the user has asked Hister to index.</li>
+      <li>Respects <code class="font-mono text-sm">robots.txt</code> rules, including <code class="font-mono text-sm">Crawl-delay</code>.</li>
+      <li>Identifies itself with a <code class="font-mono text-sm">User-agent</code> header starting with <code class="font-mono text-sm">Hister/</code>.</li>
+      <li>Only stores content locally on the user's own machine — nothing is sent to a central server.</li>
+    </ul>
+  </section>
+
+  <section class="mb-10">
+    <h2 class="mb-3 text-xl font-semibold">How to block the crawler</h2>
+    <p class="mb-4 text-gray-700 dark:text-gray-300">
+      Add the following to your <code class="font-mono text-sm">robots.txt</code> to block Hister from crawling your site:
+    </p>
+    <pre class="overflow-x-auto rounded-lg bg-gray-100 p-4 font-mono text-sm dark:bg-gray-800">
+User-agent: Hister
+Disallow: /</pre>
+    <p class="mt-4 text-gray-700 dark:text-gray-300">
+      You can also restrict specific paths:
+    </p>
+    <pre class="overflow-x-auto rounded-lg bg-gray-100 p-4 font-mono text-sm dark:bg-gray-800">
+User-agent: Hister
+Disallow: /private/
+Disallow: /api/</pre>
+  </section>
+
+  <section class="mb-10">
+    <h2 class="mb-3 text-xl font-semibold">Rate limiting and crawl delay</h2>
+    <p class="text-gray-700 dark:text-gray-300">
+      The Hister crawler honors the <code class="font-mono text-sm">Crawl-delay</code> directive in
+      <code class="font-mono text-sm">robots.txt</code>. By default it limits itself to one request per second per
+      host and respects any <code class="font-mono text-sm">Retry-After</code> headers your server sends.
+    </p>
+  </section>
+
+  <section>
+    <h2 class="mb-3 text-xl font-semibold">Contact</h2>
+    <p class="text-gray-700 dark:text-gray-300">
+      Hister is open-source software. If you have questions or concerns about a
+      specific instance crawling your site, the user running that instance
+      configured a contact URL in their setup. You can also open an issue on the
+      <a
+        href="https://github.com/asciimoo/hister"
+        class="underline hover:text-blue-600"
+        rel="noopener noreferrer"
+        target="_blank">Hister GitHub repository</a
+      >.
+    </p>
+  </section>
+</main>


### PR DESCRIPTION
from: https://github.com/asciimoo/hister/issues/643

Makes the crawler behave a bit better:
- global/per host rate limits
- easier on ram/cpu
- follow robots.txt
- url normalization
- user agent, with page on docs site
- configuration for new options, also respects old config with a warning
- tests and verified locally

I used claude to generate code, but planned the changes and wrote this myself, happy to make any modifications/updates.

crawler docs:
<img width="1304" height="1306" alt="Screenshot 2026-08-25 at 5 20 49 PM" src="https://github.com/user-attachments/assets/cfb4f278-5070-459c-bb17-56756b5e5dfd" />

config docs:
<img width="1304" height="1521" alt="Screenshot 2026-08-25 at 5 29 12 PM" src="https://github.com/user-attachments/assets/cf89527a-0f3c-4fad-bdcf-7c5f100d2fd8" />
