### PR TITLE
fix: keep vectors after reindex errors

### DIFF
--- a/server/indexer/embedding_queue.go
+++ b/server/indexer/embedding_queue.go
@@ -85,11 +85,18 @@ func (i *Indexer) startEmbeddingQueue(workers int) error {
 }
 
 func (i *Indexer) stopEmbeddingQueue() {
-	if i.embeddingQueue == nil {
+	i.reindexMu.RLock()
+	queue := i.embeddingQueue
+	i.reindexMu.RUnlock()
+	if queue == nil {
 		return
 	}
-	i.embeddingQueue.Close()
-	i.embeddingQueue = nil
+	queue.Close()
+	i.reindexMu.Lock()
+	if i.embeddingQueue == queue {
+		i.embeddingQueue = nil
+	}
+	i.reindexMu.Unlock()
 }
 
 func (i *Indexer) enqueueEmbedding(docID string) error {

--- a/server/indexer/indexer.go
+++ b/server/indexer/indexer.go
@@ -51,11 +51,14 @@ type Indexer struct {
 	indexers          map[string]bleve.Index // default and language specific indexers
 	indexesMu         sync.RWMutex           // protects idx, indexers, and indexesClosed
 	indexCreationMu   sync.Mutex             // serializes index creation, close, and adoption
+	lifecycleMu       sync.Mutex             // serializes Reindex and Close
+	reindexMu         sync.RWMutex           // serializes reindex publication with mutations
 	indexesClosed     bool
 	dir               string
 	data              *dataStore
 	langDetector      document.LanguageDetector
 	reindexInProgress atomic.Bool
+	reindexGeneration atomic.Uint64
 	embedder          *vectorstore.Embedder
 	vectorStore       vectorstore.VectorStore
 	embedCtx          context.Context
@@ -63,6 +66,7 @@ type Indexer struct {
 	embeddingQueue    *embeddingQueue
 	embeddingWorkers  int
 	disablePreviews   bool
+	detectLanguages   bool
 	keepStopwords     bool
 	directories       []*config.Directory
 	maxFileSize       int64
@@ -270,13 +274,16 @@ func (s storedDocumentState) embeddingTextChanged(text string) bool {
 }
 
 type MultiBatch struct {
-	indexer             *Indexer
-	batches             map[string]*indexBatch
-	orphanedHTMLKeys    []string
-	orphanedFaviconKeys []string
-	embeddingIDs        map[string]struct{}
-	deletedIDs          map[string]struct{}
-	incrementAddCount   bool
+	indexer              *Indexer
+	batches              map[string]*indexBatch
+	orphanedHTMLKeys     []string
+	orphanedFaviconKeys  []string
+	embeddingIDs         map[string]struct{}
+	deletedIDs           map[string]struct{}
+	incrementAddCount    bool
+	failOnEmbeddingError bool
+	generation           uint64
+	mutationLocked       bool
 }
 
 func (i *Indexer) searchIndexes(req *bleve.SearchRequest) (*bleve.SearchResult, error) {
@@ -425,12 +432,13 @@ func initializeIndexer(basePath string, detectLanguages, keepStopwords bool, emb
 		indexers: map[string]bleve.Index{
 			defaultIndexerName: idx,
 		},
-		dir:           basePath,
-		keepStopwords: keepStopwords,
-		embedCtx:      embedCtx,
-		embedCancel:   embedCancel,
-		data:          newDataStore(filepath.Join(basePath, dataDirName)),
-		maxFileSize:   defaultMaxFileSize,
+		dir:             basePath,
+		detectLanguages: detectLanguages,
+		keepStopwords:   keepStopwords,
+		embedCtx:        embedCtx,
+		embedCancel:     embedCancel,
+		data:            newDataStore(filepath.Join(basePath, dataDirName)),
+		maxFileSize:     defaultMaxFileSize,
 	}
 	initialized := false
 	defer func() {
@@ -583,6 +591,48 @@ func (i *Indexer) Reindex(rules *config.Rules, skipSensitiveChecks bool, detectL
 	return i.ReindexContext(context.Background(), rules, skipSensitiveChecks, detectLanguages, keepStopwords, dirs)
 }
 
+func publishReindexIndexes(basePath, tmpBasePath string, oldIndexes, newIndexes map[string]bleve.Index) (func() error, error) {
+	backupPath := filepath.Join(tmpBasePath, "old")
+	if err := os.MkdirAll(backupPath, os.ModePerm); err != nil {
+		return nil, fmt.Errorf("create reindex backup path: %w", err)
+	}
+	movedOld := make([]string, 0, len(oldIndexes))
+	movedNew := make([]string, 0, len(newIndexes))
+	restored := false
+	restore := func() error {
+		if restored {
+			return nil
+		}
+		restored = true
+		var restoreErrs []error
+		for n := len(movedNew) - 1; n >= 0; n-- {
+			if err := os.RemoveAll(filepath.Join(basePath, movedNew[n])); err != nil {
+				restoreErrs = append(restoreErrs, fmt.Errorf("remove replacement index %s: %w", movedNew[n], err))
+			}
+		}
+		for n := len(movedOld) - 1; n >= 0; n-- {
+			name := movedOld[n]
+			if err := os.Rename(filepath.Join(backupPath, name), filepath.Join(basePath, name)); err != nil {
+				restoreErrs = append(restoreErrs, fmt.Errorf("restore index %s: %w", name, err))
+			}
+		}
+		return errors.Join(restoreErrs...)
+	}
+	for name := range oldIndexes {
+		if err := os.Rename(filepath.Join(basePath, name), filepath.Join(backupPath, name)); err != nil {
+			return restore, fmt.Errorf("move index %s to reindex backup: %w", name, err)
+		}
+		movedOld = append(movedOld, name)
+	}
+	for name := range newIndexes {
+		if err := os.Rename(filepath.Join(tmpBasePath, name), filepath.Join(basePath, name)); err != nil {
+			return restore, fmt.Errorf("publish replacement index %s: %w", name, err)
+		}
+		movedNew = append(movedNew, name)
+	}
+	return restore, nil
+}
+
 // ReindexContext rebuilds indexes while honoring caller cancellation.
 func (i *Indexer) ReindexContext(ctx context.Context, rules *config.Rules, skipSensitiveChecks bool, detectLanguages, keepStopwords bool, dirs []*config.Directory) error {
 	return i.reindex(ctx, i.dir, rules, skipSensitiveChecks, detectLanguages, keepStopwords, dirs)
@@ -592,6 +642,11 @@ func (idx *Indexer) reindex(ctx context.Context, basePath string, rules *config.
 	if err := ctx.Err(); err != nil {
 		return err
 	}
+	// TODO store new documents in both indexes while running reindex to guarantee not losing any data.
+	if !idx.reindexInProgress.CompareAndSwap(false, true) {
+		return errors.New("Reindex is already running")
+	}
+	defer idx.reindexInProgress.Store(false)
 	var embeddingFingerprint string
 	if idx.vectorStore != nil && idx.embedder != nil {
 		embeddingFingerprint = idx.semanticConfig.EmbeddingFingerprint()
@@ -603,20 +658,25 @@ func (idx *Indexer) reindex(ctx context.Context, basePath string, rules *config.
 		}
 		embeddingFingerprint = metadata.EmbeddingFingerprint
 	}
-	// TODO store new documents in both indexes while running reindex to guarantee not losing any data.
-	if !idx.reindexInProgress.CompareAndSwap(false, true) {
-		return errors.New("Reindex is already running")
-	}
+	idx.lifecycleMu.Lock()
+	idx.reindexGeneration.Add(1)
 	workers := idx.embeddingWorkers
 	queueStopped := false
+	if idx.embeddingQueue != nil {
+		idx.stopEmbeddingQueue()
+		queueStopped = true
+	}
+	idx.reindexMu.Lock()
 	oldIndexClosed := false
 	defer func() {
-		idx.reindexInProgress.Store(false)
 		if retErr != nil && queueStopped && !oldIndexClosed && idx.embeddingQueue == nil {
 			if err := idx.startEmbeddingQueue(workers); err != nil {
 				retErr = errors.Join(retErr, fmt.Errorf("restart embedding queue: %w", err))
 			}
 		}
+		idx.reindexGeneration.Add(1)
+		idx.reindexMu.Unlock()
+		idx.lifecycleMu.Unlock()
 	}()
 	tmpBasePath := filepath.Join(basePath, "reindex")
 	if _, err := os.Stat(tmpBasePath); err == nil {
@@ -642,34 +702,46 @@ func (idx *Indexer) reindex(ctx context.Context, basePath string, rules *config.
 	// content-addressed files written during reindex are immediately usable
 	// after the rename step. No data directory rename is needed.
 	tmpIdx.data = idx.data
-	if idx.embeddingQueue != nil {
-		idx.stopEmbeddingQueue()
-		queueStopped = true
-	}
-
-	// Carry the vector store and embedder into the temporary indexer so that
-	// MultiBatch.Add() re-embeds every surviving document.  The vector store is
-	// rebuilt in-place (no temp-dir / rename dance is needed because it is a
-	// separate file from the Bleve indexes).
+	// Carry the embedder into the temporary indexer and write vectors to an
+	// isolated store. The live vectors remain searchable until the replacement
+	// indexes and all embeddings are ready.
 	vs := idx.vectorStore
 	embedder := idx.embedder
-	if vs != nil && embedder != nil {
-		if err := vs.Clear(); err != nil {
-			log.Warn().Err(err).Msg("failed to clear vector store before reindex")
-		} else {
-			tmpIdx.vectorStore = vs
-			tmpIdx.embedder = embedder
-		}
-	}
+	var stagedVS vectorstore.ReindexStore
+	var rollbackPublication func() error
 	abortReindex := func(err error) error {
+		if stagedVS != nil {
+			if rerr := stagedVS.Rollback(); rerr != nil {
+				err = errors.Join(err, fmt.Errorf("rollback vector store reindex: %w", rerr))
+			}
+			stagedVS = nil
+		}
+		if rollbackPublication != nil {
+			if rerr := rollbackPublication(); rerr != nil {
+				err = errors.Join(err, fmt.Errorf("restore replacement indexes: %w", rerr))
+			}
+			rollbackPublication = nil
+		}
 		// The live indexer still owns the shared vector store when reindexing
-		// aborts. Do not let closing the temporary indexer close that store.
+		// aborts. Do not let closing the temporary indexer close either store.
 		tmpIdx.vectorStore = nil
 		tmpIdx.Close()
+		if idx.vectorStore == nil && vs != nil {
+			idx.vectorStore = vs
+		}
 		if rerr := os.RemoveAll(tmpBasePath); rerr != nil {
 			log.Warn().Err(rerr).Msg("failed to clean up temp index path")
 		}
 		return err
+	}
+	if vs != nil && embedder != nil {
+		var err error
+		stagedVS, err = vs.BeginReindex()
+		if err != nil {
+			return abortReindex(fmt.Errorf("begin vector store reindex: %w", err))
+		}
+		tmpIdx.vectorStore = stagedVS
+		tmpIdx.embedder = embedder
 	}
 	q := query.NewMatchAllQuery()
 	var total uint64
@@ -701,11 +773,15 @@ func (idx *Indexer) reindex(ctx context.Context, basePath string, rules *config.
 				req.SetSearchAfter(sortKey)
 			}
 			res, err := subIdx.Search(req)
-			if err != nil || len(res.Hits) < 1 {
+			if err != nil {
+				return abortReindex(fmt.Errorf("search reindex source %s: %w", subIdxName, err))
+			}
+			if len(res.Hits) < 1 {
 				break
 			}
 			n := len(res.Hits)
 			b := newMultiBatch(tmpIdx)
+			b.failOnEmbeddingError = stagedVS != nil
 			for _, h := range res.Hits {
 				d := idx.resFromHit(h, resultIncludeAll)
 				if d.Type == document.Local {
@@ -777,34 +853,76 @@ func (idx *Indexer) reindex(ctx context.Context, basePath string, rules *config.
 	}
 	closeExtraSources()
 	idx.vectorStore = nil // prevent Close() from closing the store we're still using
-	idx.Close()
+	idx.closeIndexes()
 	oldIndexClosed = true
 	tmpIdx.vectorStore = nil // already referenced by vs; prevent double-close
 	tmpIdx.Close()
-	for n := range sourceIndexes {
-		idxPath := filepath.Join(basePath, n)
-		if err := os.RemoveAll(idxPath); err != nil {
-			return err
+	recoverOld := func(reindexErr error) error {
+		restoreFailed := false
+		if stagedVS != nil {
+			if rerr := stagedVS.Rollback(); rerr != nil {
+				reindexErr = errors.Join(reindexErr, fmt.Errorf("rollback vector store reindex: %w", rerr))
+			}
+			stagedVS = nil
 		}
-	}
-	var renameError error
-	for n := range tmpIdx.indexes() {
-		idxPath := filepath.Join(basePath, n)
-		tmpIdxPath := filepath.Join(tmpBasePath, n)
-		if err := os.Rename(tmpIdxPath, idxPath); err != nil {
-			renameError = err
+		if rollbackPublication != nil {
+			if rerr := rollbackPublication(); rerr != nil {
+				restoreFailed = true
+				reindexErr = errors.Join(reindexErr, fmt.Errorf("restore replacement indexes: %w", rerr))
+			}
+			rollbackPublication = nil
 		}
+		if restoreFailed {
+			return reindexErr
+		}
+		recovered, rerr := initializeIndexer(basePath, idx.detectLanguages, idx.keepStopwords, embeddingFingerprint)
+		if rerr != nil {
+			return errors.Join(reindexErr, fmt.Errorf("restore original indexer: %w", rerr))
+		}
+		recovered.maxFileSize = idx.maxFileSize
+		recovered.sensitivePattern = idx.sensitivePattern
+		recovered.semanticConfig = idx.semanticConfig
+		idx.adopt(recovered)
+		oldIndexClosed = false
+		idx.disablePreviews = tmpIdx.disablePreviews
+		idx.directories = dirs
+		if vs != nil && embedder != nil {
+			idx.vectorStore = vs
+			idx.embedder = embedder
+			if workers > 0 {
+				if rerr := idx.startEmbeddingQueue(workers); rerr != nil {
+					reindexErr = errors.Join(reindexErr, fmt.Errorf("restart embedding queue: %w", rerr))
+				} else {
+					queueStopped = false
+				}
+			}
+		}
+		if rerr := os.RemoveAll(tmpBasePath); rerr != nil {
+			return errors.Join(reindexErr, fmt.Errorf("clean up reindex path: %w", rerr))
+		}
+		return reindexErr
 	}
-	if renameError != nil {
-		return errors.New("failed to rename tmp indexes during the reindex, resolve the issue manually")
+	rollbackPublication, err = publishReindexIndexes(basePath, tmpBasePath, sourceIndexes, tmpIdx.indexes())
+	if err != nil {
+		return recoverOld(err)
 	}
 	replacement, err := initializeIndexer(basePath, detectLanguages, keepStopwords, embeddingFingerprint)
 	if err != nil {
-		return err
+		return recoverOld(err)
 	}
 	replacement.maxFileSize = idx.maxFileSize
 	replacement.sensitivePattern = idx.sensitivePattern
 	replacement.semanticConfig = idx.semanticConfig
+	if stagedVS != nil {
+		if err := stagedVS.Commit(); err != nil {
+			commitErr := fmt.Errorf("commit vector store reindex: %w", err)
+			replacement.Close()
+			return recoverOld(commitErr)
+		}
+		vs = stagedVS
+		stagedVS = nil
+	}
+	rollbackPublication = nil
 	idx.adopt(replacement)
 	// Restore settings that are not part of the index state.
 	idx.disablePreviews = tmpIdx.disablePreviews
@@ -945,6 +1063,14 @@ func documentEmbeddingContext(d *document.Document) vectorstore.DocumentContext 
 // can retry them. Synchronous callers may ignore the error and continue Bleve
 // indexing.
 func embedDocumentChunks(ctx context.Context, idx *Indexer, d *document.Document) error {
+	return embedDocumentChunksWithLock(ctx, idx, d, true)
+}
+
+func embedDocumentChunksLocked(ctx context.Context, idx *Indexer, d *document.Document) error {
+	return embedDocumentChunksWithLock(ctx, idx, d, false)
+}
+
+func embedDocumentChunksWithLock(ctx context.Context, idx *Indexer, d *document.Document, lockVectorStore bool) error {
 	start := time.Now()
 	chunks, err := idx.embedder.ChunkAndEmbed(ctx, d.Text, documentEmbeddingContext(d))
 	if err != nil {
@@ -957,6 +1083,10 @@ func embedDocumentChunks(ctx context.Context, idx *Indexer, d *document.Document
 	}
 	if len(chunks) == 0 {
 		return nil
+	}
+	if lockVectorStore {
+		idx.reindexMu.RLock()
+		defer idx.reindexMu.RUnlock()
 	}
 	if err := idx.vectorStore.PutChunks(d.ID(), d.UserID, chunks); err != nil {
 		log.Warn().Err(err).Str("url", d.URL).Msg("vector store write failed")
@@ -1062,6 +1192,8 @@ func (i *Indexer) AddDocument(d *document.Document) error {
 // AddDocumentContext indexes a document while honoring caller cancellation
 // during document processing.
 func (i *Indexer) AddDocumentContext(ctx context.Context, d *document.Document) error {
+	i.reindexMu.RLock()
+	defer i.reindexMu.RUnlock()
 	return i.addDocument(ctx, d, true, i.applyDocumentWrite)
 }
 
@@ -1346,6 +1478,8 @@ func (i *Indexer) prepareForStorage(d *document.Document) error {
 
 // Saves a document without any processing
 func (i *Indexer) Save(d *document.Document) error {
+	i.reindexMu.RLock()
+	defer i.reindexMu.RUnlock()
 	return i.save(d)
 }
 
@@ -1401,7 +1535,15 @@ func (i *Indexer) addIndexer(name, lang string) error {
 }
 
 func (i *Indexer) Close() {
+	i.lifecycleMu.Lock()
+	defer i.lifecycleMu.Unlock()
 	i.stopEmbeddingQueue()
+	i.reindexMu.Lock()
+	defer i.reindexMu.Unlock()
+	i.closeIndexes()
+}
+
+func (i *Indexer) closeIndexes() {
 	if i.embedCancel != nil {
 		i.embedCancel()
 	}
@@ -1448,6 +1590,7 @@ func (i *Indexer) adopt(replacement *Indexer) {
 	i.embeddingQueue = replacement.embeddingQueue
 	i.embeddingWorkers = replacement.embeddingWorkers
 	i.disablePreviews = replacement.disablePreviews
+	i.detectLanguages = replacement.detectLanguages
 	i.keepStopwords = replacement.keepStopwords
 	i.directories = replacement.directories
 	i.maxFileSize = replacement.maxFileSize
@@ -1468,6 +1611,7 @@ func newMultiBatch(idx *Indexer) *MultiBatch {
 		embeddingIDs:      make(map[string]struct{}),
 		deletedIDs:        make(map[string]struct{}),
 		incrementAddCount: false,
+		generation:        idx.reindexGeneration.Load(),
 	}
 }
 
@@ -1487,6 +1631,18 @@ func (b *MultiBatch) Add(d *document.Document) error {
 // AddContext stages a document while honoring caller cancellation during
 // document processing.
 func (b *MultiBatch) AddContext(ctx context.Context, d *document.Document) error {
+	if b.generation != b.indexer.reindexGeneration.Load() {
+		return errors.New("reindex is in progress")
+	}
+	b.indexer.reindexMu.RLock()
+	defer b.indexer.reindexMu.RUnlock()
+	if b.generation != b.indexer.reindexGeneration.Load() {
+		return errors.New("reindex is in progress")
+	}
+	b.mutationLocked = true
+	defer func() {
+		b.mutationLocked = false
+	}()
 	if err := b.indexer.validateFileDocument(d); err != nil {
 		return err
 	}
@@ -1499,7 +1655,13 @@ func (b *MultiBatch) applyDocumentWrite(d *document.Document, plan documentWrite
 		if b.indexer.embeddingWorkers > 0 {
 			b.embeddingIDs[d.ID()] = struct{}{}
 		} else {
-			_ = embedDocumentChunks(b.indexer.embedCtx, b.indexer, d)
+			embed := embedDocumentChunks
+			if b.mutationLocked {
+				embed = embedDocumentChunksLocked
+			}
+			if err := embed(b.indexer.embedCtx, b.indexer, d); err != nil && b.failOnEmbeddingError {
+				return fmt.Errorf("embed document %s: %w", d.ID(), err)
+			}
 		}
 	}
 	for _, idx := range plan.staleIndexes {
@@ -1522,6 +1684,15 @@ func (b *MultiBatch) applyDocumentWrite(d *document.Document, plan documentWrite
 }
 
 func (b *MultiBatch) Delete(id string) {
+	b.indexer.reindexMu.RLock()
+	defer b.indexer.reindexMu.RUnlock()
+	b.deleteLocked(id)
+}
+
+func (b *MultiBatch) deleteLocked(id string) {
+	if b.generation != b.indexer.reindexGeneration.Load() {
+		return
+	}
 	oldHTMLKeys, oldFaviconKeys := b.indexer.getDocKeysByID(id)
 	delete(b.embeddingIDs, id)
 	b.deletedIDs[id] = struct{}{}
@@ -1533,6 +1704,15 @@ func (b *MultiBatch) Delete(id string) {
 }
 
 func (b *MultiBatch) Save() error {
+	b.indexer.reindexMu.RLock()
+	defer b.indexer.reindexMu.RUnlock()
+	return b.saveLocked()
+}
+
+func (b *MultiBatch) saveLocked() error {
+	if b.generation != b.indexer.reindexGeneration.Load() {
+		return errors.New("reindex is in progress")
+	}
 	for _, entry := range b.batches {
 		if err := entry.index.Batch(entry.batch); err != nil {
 			return err
@@ -1558,6 +1738,8 @@ func (b *MultiBatch) Save() error {
 }
 
 func (i *Indexer) Delete(id string) error {
+	i.reindexMu.RLock()
+	defer i.reindexMu.RUnlock()
 	htmlKeys, faviconKeys := i.getDocKeysByID(id)
 	for _, idx := range i.indexes() {
 		if err := idx.Delete(id); err != nil {
@@ -1582,6 +1764,8 @@ func (i *Indexer) Delete(id string) error {
 }
 
 func (i *Indexer) DeleteByQuery(text string, userID *uint, onDelete func(url string, userID uint)) (int, error) {
+	i.reindexMu.RLock()
+	defer i.reindexMu.RUnlock()
 	q, err := documentMutationQuery(text, userID)
 	if err != nil {
 		return 0, err
@@ -1608,9 +1792,9 @@ func (i *Indexer) DeleteByQuery(text string, userID *uint, onDelete func(url str
 		}
 		batch := newMultiBatch(i)
 		for _, h := range res.Hits {
-			batch.Delete(h.ID)
+			batch.deleteLocked(h.ID)
 		}
-		if err := batch.Save(); err != nil {
+		if err := batch.saveLocked(); err != nil {
 			return count, err
 		}
 		if onDelete != nil {
@@ -1740,6 +1924,7 @@ func (i *Indexer) search(semanticConfig config.SemanticSearch, q *Query) (*Resul
 
 	// Run semantic search if enabled and the embedding infrastructure is available.
 	semanticText := querybuilder.RemoveStandaloneWildcards(expression.Text)
+	i.reindexMu.RLock()
 	if q.SemanticEnabled && i.embedder != nil && i.vectorStore != nil &&
 		strings.TrimSpace(semanticText) != "" {
 		r.SemanticEnabled = true
@@ -1804,6 +1989,7 @@ func (i *Indexer) search(semanticConfig config.SemanticSearch, q *Query) (*Resul
 			}
 		}
 	}
+	i.reindexMu.RUnlock()
 
 	// Bump the total to reflect semantic matches that are not in the
 	// keyword results.

--- a/server/indexer/metadata_test.go
+++ b/server/indexer/metadata_test.go
@@ -31,6 +31,12 @@ func (*metadataVectorStore) Clear() error { return nil }
 
 func (*metadataVectorStore) Close() error { return nil }
 
+func (s *metadataVectorStore) BeginReindex() (vectorstore.ReindexStore, error) { return s, nil }
+
+func (*metadataVectorStore) Commit() error { return nil }
+
+func (*metadataVectorStore) Rollback() error { return nil }
+
 func requireIndexMetadata(t *testing.T, idx bleve.Index, want indexMetadata) {
 	t.Helper()
 	got, complete, err := readIndexMetadata(idx)

--- a/server/indexer/reindex_test.go
+++ b/server/indexer/reindex_test.go
@@ -1,0 +1,396 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package indexer
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/asciimoo/hister/config"
+	"github.com/asciimoo/hister/server/document"
+	"github.com/asciimoo/hister/server/testutil"
+	"github.com/asciimoo/hister/server/vectorstore"
+)
+
+type commitFailingVectorStore struct {
+	vectorstore.VectorStore
+	err error
+}
+
+func (s *commitFailingVectorStore) BeginReindex() (vectorstore.ReindexStore, error) {
+	staged, err := s.VectorStore.BeginReindex()
+	if err != nil {
+		return nil, err
+	}
+	return &commitFailingReindexStore{ReindexStore: staged, err: s.err}, nil
+}
+
+type commitFailingReindexStore struct {
+	vectorstore.ReindexStore
+	err error
+}
+
+func (s *commitFailingReindexStore) Commit() error {
+	return s.err
+}
+
+func TestConcurrentReindexReturnsAlreadyRunning(t *testing.T) {
+	cfg := testutil.Config(t)
+	idx, err := initializeIndexer(cfg.FullPath(""), false, false, "")
+	if err != nil {
+		t.Fatalf("initializeIndexer returned an error: %v", err)
+	}
+
+	idx.lifecycleMu.Lock()
+	lifecycleLocked := true
+	defer func() {
+		if lifecycleLocked {
+			idx.lifecycleMu.Unlock()
+		}
+		idx.Close()
+	}()
+
+	firstDone := make(chan error, 1)
+	go func() {
+		firstDone <- idx.ReindexContext(context.Background(), &config.Rules{}, false, false, false, nil)
+	}()
+	deadline := time.Now().Add(time.Second)
+	for !idx.reindexInProgress.Load() && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if !idx.reindexInProgress.Load() {
+		t.Fatal("first reindex did not claim the in-progress flag")
+	}
+
+	if err := idx.ReindexContext(context.Background(), &config.Rules{}, false, false, false, nil); err == nil || err.Error() != "Reindex is already running" {
+		t.Fatalf("second ReindexContext error = %v, want already running", err)
+	}
+
+	idx.lifecycleMu.Unlock()
+	lifecycleLocked = false
+	if err := <-firstDone; err != nil {
+		t.Fatalf("first ReindexContext returned an error: %v", err)
+	}
+}
+
+func TestReindexAlreadyRunningDoesNotReadMetadata(t *testing.T) {
+	cfg := testutil.Config(t)
+	idx, err := initializeIndexer(cfg.FullPath(""), false, false, "")
+	if err != nil {
+		t.Fatalf("initializeIndexer returned an error: %v", err)
+	}
+	idx.Close()
+	idx.reindexInProgress.Store(true)
+
+	err = idx.ReindexContext(context.Background(), &config.Rules{}, false, false, false, nil)
+	if err == nil || err.Error() != "Reindex is already running" {
+		t.Fatalf("ReindexContext error = %v, want already running without reading closed metadata", err)
+	}
+}
+
+func TestStopEmbeddingQueueWaitsForMutationLock(t *testing.T) {
+	_, cancel := context.WithCancel(context.Background())
+	idx := &Indexer{embeddingQueue: &embeddingQueue{cancel: cancel}}
+
+	idx.reindexMu.RLock()
+	mutationLocked := true
+	defer func() {
+		if mutationLocked {
+			idx.reindexMu.RUnlock()
+		}
+	}()
+	started := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		close(started)
+		idx.stopEmbeddingQueue()
+		close(done)
+	}()
+	<-started
+
+	select {
+	case <-done:
+		t.Fatal("embedding queue stopped while a mutation held reindexMu")
+	case <-time.After(50 * time.Millisecond):
+	}
+	if idx.embeddingQueue == nil {
+		t.Fatal("embedding queue was detached before the mutation completed")
+	}
+
+	idx.reindexMu.RUnlock()
+	mutationLocked = false
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("embedding queue did not stop after the mutation completed")
+	}
+}
+
+func TestStopEmbeddingQueueStaysAttachedUntilWorkersStop(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	workerCanceled := make(chan struct{})
+	releaseWorker := make(chan struct{})
+	queue := &embeddingQueue{ctx: ctx, cancel: cancel}
+	queue.wg.Go(func() {
+		<-ctx.Done()
+		close(workerCanceled)
+		<-releaseWorker
+	})
+	idx := &Indexer{embeddingQueue: queue}
+	done := make(chan struct{})
+	go func() {
+		idx.stopEmbeddingQueue()
+		close(done)
+	}()
+
+	select {
+	case <-workerCanceled:
+	case <-time.After(time.Second):
+		t.Fatal("embedding queue workers were not canceled")
+	}
+	if idx.embeddingQueue != queue {
+		t.Fatal("embedding queue was detached before its workers stopped")
+	}
+
+	close(releaseWorker)
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("embedding queue did not detach after its workers stopped")
+	}
+	if idx.embeddingQueue != nil {
+		t.Fatal("embedding queue remained attached after its workers stopped")
+	}
+}
+
+func TestReindexVectorCommitFailureRestoresKeywordAndVectorIndexes(t *testing.T) {
+	cfg := testutil.Config(t)
+	cfg.SemanticSearch.EmbeddingEndpoint = "http://127.0.0.1:0"
+	cfg.SemanticSearch.EmbeddingModel = "test-model"
+	cfg.SemanticSearch.Dimensions = 2
+
+	idx, err := initializeIndexer(cfg.FullPath(""), false, false, "")
+	if err != nil {
+		t.Fatalf("initializeIndexer returned an error: %v", err)
+	}
+	defer idx.Close()
+
+	store, err := vectorstore.New(cfg)
+	if err != nil {
+		t.Fatalf("vectorstore.New returned an error: %v", err)
+	}
+	if err := store.Init(); err != nil {
+		_ = store.Close()
+		t.Fatalf("vector store Init returned an error: %v", err)
+	}
+	commitErr := errors.New("forced vector commit failure")
+	idx.vectorStore = &commitFailingVectorStore{VectorStore: store, err: commitErr}
+	idx.embedder = vectorstore.NewEmbedder(&cfg.SemanticSearch)
+
+	doc := &document.Document{
+		URL:       "https://example.com/reindex-commit-failure",
+		Title:     "Reindex commit failure",
+		Text:      "Both live indexes must survive a failed vector commit.",
+		Language:  document.UnknownLanguage,
+		Processed: true,
+		AddCount:  1,
+	}
+	if err := idx.save(doc); err != nil {
+		t.Fatalf("seed indexed document: %v", err)
+	}
+	if err := store.PutChunks(doc.ID(), 0, []vectorstore.Chunk{
+		{Index: 0, Text: "old", Embedding: []float32{1, 0}},
+	}); err != nil {
+		t.Fatalf("seed live vector: %v", err)
+	}
+
+	rules := &config.Rules{Skip: &config.Rule{ReStrs: []string{doc.URL}}}
+	reindexErr := idx.ReindexContext(context.Background(), rules, false, false, false, nil)
+	if !errors.Is(reindexErr, commitErr) {
+		t.Fatalf("ReindexContext error = %v, want %v", reindexErr, commitErr)
+	}
+	if idx.GetByURLAndUser(doc.URL, 0) == nil {
+		t.Fatal("keyword index published the replacement after vector commit failure")
+	}
+	results, err := idx.vectorStore.Search([]float32{1, 0}, 10, 0.99, 0)
+	if err != nil {
+		t.Fatalf("search live vectors: %v", err)
+	}
+	if len(results) != 1 || results[0].DocID != doc.ID() {
+		t.Fatalf("live vector search returned %#v, want document %q", results, doc.ID())
+	}
+}
+
+func TestReindexEmbeddingFailurePreservesLiveVectors(t *testing.T) {
+	var requests atomic.Int32
+	embeddingServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		http.Error(w, "embedding service unavailable", http.StatusServiceUnavailable)
+	}))
+	defer embeddingServer.Close()
+
+	cfg := testutil.Config(t)
+	cfg.SemanticSearch.EmbeddingEndpoint = embeddingServer.URL
+	cfg.SemanticSearch.EmbeddingModel = "test-model"
+	cfg.SemanticSearch.Dimensions = 2
+	cfg.SemanticSearch.MaxContextLength = 32
+	cfg.SemanticSearch.MaxEmbeddingBatchSize = 1
+
+	idx, err := initializeIndexer(cfg.FullPath(""), false, false, "")
+	if err != nil {
+		t.Fatalf("initializeIndexer returned an error: %v", err)
+	}
+	defer idx.Close()
+
+	store, err := vectorstore.New(cfg)
+	if err != nil {
+		t.Fatalf("vectorstore.New returned an error: %v", err)
+	}
+	if err := store.Init(); err != nil {
+		_ = store.Close()
+		t.Fatalf("vector store Init returned an error: %v", err)
+	}
+	idx.vectorStore = store
+	idx.embedder = vectorstore.NewEmbedder(&cfg.SemanticSearch)
+
+	doc := &document.Document{
+		URL:       "https://example.com/reindex-embedding-failure",
+		Title:     "Reindex failure",
+		Text:      "The live vector must survive a failed reindex.",
+		Language:  document.UnknownLanguage,
+		Processed: true,
+		AddCount:  1,
+	}
+	if err := idx.save(doc); err != nil {
+		t.Fatalf("seed indexed document: %v", err)
+	}
+	if err := store.PutChunks(doc.ID(), 0, []vectorstore.Chunk{
+		{Index: 0, Text: "old", Embedding: []float32{1, 0}},
+	}); err != nil {
+		t.Fatalf("seed live vector: %v", err)
+	}
+
+	reindexErr := idx.ReindexContext(context.Background(), &config.Rules{}, false, false, false, nil)
+	if reindexErr == nil {
+		t.Error("ReindexContext succeeded despite embedding failure")
+	}
+	if requests.Load() == 0 {
+		t.Fatal("reindex did not call the embedding endpoint")
+	}
+
+	results, err := idx.vectorStore.Search([]float32{1, 0}, 10, 0.99, 0)
+	if err != nil {
+		t.Fatalf("search live vectors: %v", err)
+	}
+	if len(results) != 1 || results[0].DocID != doc.ID() {
+		t.Fatalf("live vector search returned %#v, want document %q", results, doc.ID())
+	}
+}
+
+func TestReindexCancellationPreservesLiveVectors(t *testing.T) {
+	requestStarted := make(chan struct{})
+	releaseEmbedding := make(chan struct{})
+	var startOnce sync.Once
+	var releaseOnce sync.Once
+	embeddingServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		startOnce.Do(func() { close(requestStarted) })
+		<-releaseEmbedding
+
+		var request struct {
+			Input []string `json:"input"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		data := make([]map[string]any, len(request.Input))
+		for i := range data {
+			data[i] = map[string]any{"embedding": []float64{1, 0}}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"data": data})
+	}))
+	release := func() { releaseOnce.Do(func() { close(releaseEmbedding) }) }
+	defer func() {
+		release()
+		embeddingServer.Close()
+	}()
+
+	cfg := testutil.Config(t)
+	cfg.SemanticSearch.EmbeddingEndpoint = embeddingServer.URL
+	cfg.SemanticSearch.EmbeddingModel = "test-model"
+	cfg.SemanticSearch.Dimensions = 2
+	cfg.SemanticSearch.MaxContextLength = 32
+
+	idx, err := initializeIndexer(cfg.FullPath(""), false, false, "")
+	if err != nil {
+		t.Fatalf("initializeIndexer returned an error: %v", err)
+	}
+	defer idx.Close()
+
+	store, err := vectorstore.New(cfg)
+	if err != nil {
+		t.Fatalf("vectorstore.New returned an error: %v", err)
+	}
+	if err := store.Init(); err != nil {
+		_ = store.Close()
+		t.Fatalf("vector store Init returned an error: %v", err)
+	}
+	idx.vectorStore = store
+	idx.embedder = vectorstore.NewEmbedder(&cfg.SemanticSearch)
+
+	doc := &document.Document{
+		URL:       "https://example.com/reindex-cancellation",
+		Title:     "Reindex cancellation",
+		Text:      "The live vector must survive cancellation during reindex.",
+		Language:  document.UnknownLanguage,
+		Processed: true,
+		AddCount:  1,
+	}
+	if err := idx.save(doc); err != nil {
+		t.Fatalf("seed indexed document: %v", err)
+	}
+	if err := store.PutChunks(doc.ID(), 0, []vectorstore.Chunk{
+		{Index: 0, Text: "old", Embedding: []float32{1, 0}},
+	}); err != nil {
+		t.Fatalf("seed live vector: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	reindexDone := make(chan error, 1)
+	go func() {
+		reindexDone <- idx.ReindexContext(ctx, &config.Rules{}, false, false, false, nil)
+	}()
+	select {
+	case <-requestStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("reindex did not call the embedding endpoint")
+	}
+	cancel()
+	release()
+
+	select {
+	case err := <-reindexDone:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("ReindexContext error = %v, want context.Canceled", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("ReindexContext did not return after cancellation")
+	}
+
+	results, err := idx.vectorStore.Search([]float32{1, 0}, 10, 0.99, 0)
+	if err != nil {
+		t.Fatalf("search live vectors: %v", err)
+	}
+	if len(results) != 1 || results[0].DocID != doc.ID() {
+		t.Fatalf("live vector search returned %#v, want document %q", results, doc.ID())
+	}
+}

--- a/server/indexer/update.go
+++ b/server/indexer/update.go
@@ -145,6 +145,8 @@ func (i *Indexer) UpdateByQuery(
 	changes servertypes.DocumentChanges,
 	dryRun bool,
 ) (servertypes.UpdateDocumentsResult, error) {
+	i.reindexMu.RLock()
+	defer i.reindexMu.RUnlock()
 	result := servertypes.UpdateDocumentsResult{}
 	if err := normalizeDocumentChanges(&changes); err != nil {
 		return result, err
@@ -201,28 +203,38 @@ func (i *Indexer) UpdateByQuery(
 	for start := 0; start < len(pending); start += updatePageSize {
 		end := min(start+updatePageSize, len(pending))
 		batch := newMultiBatch(i)
-		for _, update := range pending[start:end] {
-			d := update.document
-			state := i.getStoredDocumentState(d.ID())
-			plan, err := i.prepareStorageWrite(d, state)
-			if err != nil {
-				return result, fmt.Errorf("prepare update for %s: %w", d.URL, err)
+		pageErr := func() error {
+			if batch.generation != i.reindexGeneration.Load() {
+				return errors.New("reindex is in progress")
 			}
-			plan.needsEmbedding = update.embeddingContextDirty && i.embedder != nil && i.vectorStore != nil
-			if err := batch.applyDocumentWrite(d, plan); err != nil {
-				return result, fmt.Errorf("stage update for %s: %w", d.URL, err)
+			batch.mutationLocked = true
+			defer func() {
+				batch.mutationLocked = false
+			}()
+			for _, update := range pending[start:end] {
+				d := update.document
+				state := i.getStoredDocumentState(d.ID())
+				plan, err := i.prepareStorageWrite(d, state)
+				if err != nil {
+					return fmt.Errorf("prepare update for %s: %w", d.URL, err)
+				}
+				plan.needsEmbedding = update.embeddingContextDirty && i.embedder != nil && i.vectorStore != nil
+				if err := batch.applyDocumentWrite(d, plan); err != nil {
+					return fmt.Errorf("stage update for %s: %w", d.URL, err)
+				}
+				if update.originalID != d.ID() {
+					batch.deleteLocked(update.originalID)
+					result.OwnershipChanges = append(result.OwnershipChanges, servertypes.DocumentOwnershipChange{
+						URL:        d.URL,
+						FromUserID: update.originalUserID,
+						ToUserID:   d.UserID,
+					})
+				}
 			}
-			if update.originalID != d.ID() {
-				batch.Delete(update.originalID)
-				result.OwnershipChanges = append(result.OwnershipChanges, servertypes.DocumentOwnershipChange{
-					URL:        d.URL,
-					FromUserID: update.originalUserID,
-					ToUserID:   d.UserID,
-				})
-			}
-		}
-		if err := batch.Save(); err != nil {
-			return result, fmt.Errorf("save document updates: %w", err)
+			return batch.saveLocked()
+		}()
+		if pageErr != nil {
+			return result, fmt.Errorf("save document updates: %w", pageErr)
 		}
 	}
 	return result, nil

--- a/server/vectorstore/postgres.go
+++ b/server/vectorstore/postgres.go
@@ -4,6 +4,7 @@ package vectorstore
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -14,9 +15,17 @@ import (
 )
 
 type pgVectorStore struct {
-	db         *sql.DB
-	dimensions int
+	db          *sql.DB
+	dimensions  int
+	tableName   string
+	indexPrefix string
+	staging     bool
+	ownsDB      bool
 }
+
+const (
+	pgEmbeddingsTable = "embeddings"
+)
 
 func newPostgres(cfg *config.Config) (VectorStore, error) {
 	_, dsn := cfg.DatabaseConnection()
@@ -25,9 +34,16 @@ func newPostgres(cfg *config.Config) (VectorStore, error) {
 		return nil, fmt.Errorf("open postgres for vectors: %w", err)
 	}
 	return &pgVectorStore{
-		db:         db,
-		dimensions: cfg.SemanticSearch.Dimensions,
+		db:          db,
+		dimensions:  cfg.SemanticSearch.Dimensions,
+		tableName:   pgEmbeddingsTable,
+		indexPrefix: pgEmbeddingsTable,
+		ownsDB:      true,
 	}, nil
+}
+
+func pgIdentifier(name string) string {
+	return `"` + strings.ReplaceAll(name, `"`, `""`) + `"`
 }
 
 func (p *pgVectorStore) Init() error {
@@ -36,31 +52,63 @@ func (p *pgVectorStore) Init() error {
 	}
 	log.Info().Msg("pgvector extension enabled")
 
-	stmt := fmt.Sprintf(`CREATE TABLE IF NOT EXISTS embeddings (
+	if err := p.initSchema(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (p *pgVectorStore) initSchema() error {
+	stmt := fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s (
 		chunk_key TEXT PRIMARY KEY,
 		doc_id TEXT NOT NULL,
 		chunk_idx INTEGER NOT NULL DEFAULT 0,
 		user_id INTEGER NOT NULL DEFAULT 0,
 		chunk_text TEXT NOT NULL DEFAULT '',
 		embedding vector(%d)
-	)`, p.dimensions)
+	)`, pgIdentifier(p.tableName), p.dimensions)
 	if _, err := p.db.Exec(stmt); err != nil {
 		return fmt.Errorf("create embeddings table: %w", err)
 	}
 
 	// HNSW index for cosine distance.
-	_, err := p.db.Exec(`CREATE INDEX IF NOT EXISTS embeddings_hnsw_idx
-		ON embeddings USING hnsw (embedding vector_cosine_ops)`)
+	_, err := p.db.Exec(fmt.Sprintf(`CREATE INDEX IF NOT EXISTS %s
+		ON %s USING hnsw (embedding vector_cosine_ops)`,
+		pgIdentifier(p.indexPrefix+"_hnsw_idx"), pgIdentifier(p.tableName)))
 	if err != nil {
 		return fmt.Errorf("create HNSW index: %w", err)
 	}
-	if _, err := p.db.Exec(`CREATE INDEX IF NOT EXISTS embeddings_user_idx ON embeddings (user_id)`); err != nil {
+	if _, err := p.db.Exec(fmt.Sprintf(`CREATE INDEX IF NOT EXISTS %s ON %s (user_id)`,
+		pgIdentifier(p.indexPrefix+"_user_idx"), pgIdentifier(p.tableName))); err != nil {
 		return fmt.Errorf("create user_id index: %w", err)
 	}
-	if _, err := p.db.Exec(`CREATE INDEX IF NOT EXISTS embeddings_doc_idx ON embeddings (doc_id)`); err != nil {
+	if _, err := p.db.Exec(fmt.Sprintf(`CREATE INDEX IF NOT EXISTS %s ON %s (doc_id)`,
+		pgIdentifier(p.indexPrefix+"_doc_idx"), pgIdentifier(p.tableName))); err != nil {
 		return fmt.Errorf("create doc_id index: %w", err)
 	}
 	return nil
+}
+
+func (p *pgVectorStore) BeginReindex() (ReindexStore, error) {
+	if p.staging {
+		return nil, errors.New("cannot start a reindex from a staging vector store")
+	}
+	suffix := nextReindexSuffix()
+	stage := &pgVectorStore{
+		db:          p.db,
+		dimensions:  p.dimensions,
+		tableName:   p.tableName + suffix,
+		indexPrefix: p.indexPrefix + suffix,
+		staging:     true,
+	}
+	if _, err := p.db.Exec(fmt.Sprintf(`DROP TABLE IF EXISTS %s`, pgIdentifier(stage.tableName))); err != nil {
+		return nil, fmt.Errorf("remove previous reindex table: %w", err)
+	}
+	if err := stage.initSchema(); err != nil {
+		_ = stage.Rollback()
+		return nil, fmt.Errorf("create reindex vector store: %w", err)
+	}
+	return stage, nil
 }
 
 func (p *pgVectorStore) PutChunks(docID string, userID uint, chunks []Chunk) error {
@@ -78,14 +126,14 @@ func (p *pgVectorStore) PutChunks(docID string, userID uint, chunks []Chunk) err
 	}()
 
 	// Delete all existing chunks for this document.
-	if _, err = tx.Exec(`DELETE FROM embeddings WHERE doc_id = $1`, docID); err != nil {
+	if _, err = tx.Exec(fmt.Sprintf(`DELETE FROM %s WHERE doc_id = $1`, pgIdentifier(p.tableName)), docID); err != nil {
 		return fmt.Errorf("delete old embeddings: %w", err)
 	}
 
 	// Build a single multi-row INSERT for all chunks.
 	const cols = 6 // chunk_key, doc_id, chunk_idx, user_id, chunk_text, embedding
 	var sb strings.Builder
-	sb.WriteString(`INSERT INTO embeddings(chunk_key, doc_id, chunk_idx, user_id, chunk_text, embedding) VALUES `)
+	fmt.Fprintf(&sb, `INSERT INTO %s(chunk_key, doc_id, chunk_idx, user_id, chunk_text, embedding) VALUES `, pgIdentifier(p.tableName))
 	args := make([]any, 0, len(chunks)*cols)
 	for i, c := range chunks {
 		if i > 0 {
@@ -106,7 +154,7 @@ func (p *pgVectorStore) PutChunks(docID string, userID uint, chunks []Chunk) err
 }
 
 func (p *pgVectorStore) Delete(docID string) error {
-	_, err := p.db.Exec(`DELETE FROM embeddings WHERE doc_id = $1`, docID)
+	_, err := p.db.Exec(fmt.Sprintf(`DELETE FROM %s WHERE doc_id = $1`, pgIdentifier(p.tableName)), docID)
 	if err != nil {
 		return fmt.Errorf("delete embeddings: %w", err)
 	}
@@ -129,13 +177,13 @@ func (p *pgVectorStore) Search(vector []float32, topK int, threshold float64, us
 
 func (p *pgVectorStore) searchUser(vector []float32, topK int, threshold float64, userID uint) (_ []Result, err error) {
 	vecStr := pgVectorLiteral(vector)
-	rows, err := p.db.Query(
+	rows, err := p.db.Query(fmt.Sprintf(
 		`SELECT doc_id, chunk_idx, chunk_text, 1 - (embedding <=> $1::vector) AS similarity
-		 FROM embeddings
-		 WHERE 1 - (embedding <=> $1::vector) >= $2
-		   AND user_id = $4
-		 ORDER BY embedding <=> $1::vector
-		 LIMIT $3`,
+			 FROM %s
+			 WHERE 1 - (embedding <=> $1::vector) >= $2
+			   AND user_id = $4
+			 ORDER BY embedding <=> $1::vector
+			 LIMIT $3`, pgIdentifier(p.tableName)),
 		vecStr, threshold, topK, userID,
 	)
 	if err != nil {
@@ -159,13 +207,61 @@ func (p *pgVectorStore) searchUser(vector []float32, topK int, threshold float64
 }
 
 func (p *pgVectorStore) Clear() error {
-	if _, err := p.db.Exec(`DELETE FROM embeddings`); err != nil {
+	if _, err := p.db.Exec(fmt.Sprintf(`DELETE FROM %s`, pgIdentifier(p.tableName))); err != nil {
 		return fmt.Errorf("clear embeddings: %w", err)
 	}
 	return nil
 }
 
+func (p *pgVectorStore) Commit() error {
+	if !p.staging {
+		return errors.New("cannot commit a live vector store")
+	}
+	tx, err := p.db.Begin()
+	if err != nil {
+		return fmt.Errorf("begin vector store reindex commit: %w", err)
+	}
+	defer func() {
+		_ = tx.Rollback()
+	}()
+	if _, err := tx.Exec(fmt.Sprintf(`DROP TABLE %s`, pgIdentifier(pgEmbeddingsTable))); err != nil {
+		return fmt.Errorf("drop old embeddings table: %w", err)
+	}
+	if _, err := tx.Exec(fmt.Sprintf(`ALTER TABLE %s RENAME TO %s`,
+		pgIdentifier(p.tableName), pgIdentifier(pgEmbeddingsTable))); err != nil {
+		return fmt.Errorf("promote embeddings table: %w", err)
+	}
+	for _, suffix := range []string{"hnsw_idx", "user_idx", "doc_idx"} {
+		if _, err := tx.Exec(fmt.Sprintf(`ALTER INDEX %s RENAME TO %s`,
+			pgIdentifier(p.indexPrefix+"_"+suffix), pgIdentifier(pgEmbeddingsTable+"_"+suffix))); err != nil {
+			return fmt.Errorf("promote embeddings index: %w", err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit vector store reindex: %w", err)
+	}
+	p.tableName = pgEmbeddingsTable
+	p.indexPrefix = pgEmbeddingsTable
+	p.staging = false
+	p.ownsDB = true
+	return nil
+}
+
+func (p *pgVectorStore) Rollback() error {
+	if !p.staging {
+		return nil
+	}
+	if _, err := p.db.Exec(fmt.Sprintf(`DROP TABLE IF EXISTS %s`, pgIdentifier(p.tableName))); err != nil {
+		return fmt.Errorf("drop reindex embeddings table: %w", err)
+	}
+	p.staging = false
+	return nil
+}
+
 func (p *pgVectorStore) Close() error {
+	if !p.ownsDB {
+		return nil
+	}
 	return p.db.Close()
 }
 

--- a/server/vectorstore/sqlite.go
+++ b/server/vectorstore/sqlite.go
@@ -17,11 +17,19 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-const sqliteVectorSchemaVersion = 1
+const (
+	sqliteVectorSchemaVersion = 1
+	sqliteEmbeddingsTable     = "embeddings"
+	sqliteChunkMetaTable      = "chunk_meta"
+)
 
 type sqliteVectorStore struct {
-	db         *sql.DB
-	dimensions int
+	db             *sql.DB
+	dimensions     int
+	embeddingTable string
+	chunkMetaTable string
+	staging        bool
+	ownsDB         bool
 }
 
 func newSQLite(cfg *config.Config) (VectorStore, error) {
@@ -38,9 +46,23 @@ func newSQLite(cfg *config.Config) (VectorStore, error) {
 	db.SetMaxOpenConns(1)
 
 	return &sqliteVectorStore{
-		db:         db,
-		dimensions: cfg.SemanticSearch.Dimensions,
+		db:             db,
+		dimensions:     cfg.SemanticSearch.Dimensions,
+		embeddingTable: sqliteEmbeddingsTable,
+		chunkMetaTable: sqliteChunkMetaTable,
+		ownsDB:         true,
 	}, nil
+}
+
+func sqliteIdentifier(name string) string {
+	return `"` + strings.ReplaceAll(name, `"`, `""`) + `"`
+}
+
+func sqliteChunkMetaIndexName(tableName string) string {
+	if tableName == sqliteChunkMetaTable {
+		return "idx_chunk_meta_doc"
+	}
+	return tableName + "_doc_idx"
 }
 
 func (s *sqliteVectorStore) Init() error {
@@ -67,18 +89,8 @@ func (s *sqliteVectorStore) Init() error {
 		return fmt.Errorf("vector database schema version %d is newer than supported version %d", schemaVersion, sqliteVectorSchemaVersion)
 	}
 
-	// Regular table for chunk metadata (text content, doc association).
-	if _, err := tx.Exec(`CREATE TABLE IF NOT EXISTS chunk_meta (
-		chunk_key TEXT PRIMARY KEY,
-		doc_id TEXT NOT NULL,
-		chunk_idx INTEGER NOT NULL,
-		user_id INTEGER NOT NULL DEFAULT 0,
-		chunk_text TEXT NOT NULL
-	)`); err != nil {
-		return fmt.Errorf("create chunk_meta table: %w", err)
-	}
-	if _, err := tx.Exec(`CREATE INDEX IF NOT EXISTS idx_chunk_meta_doc ON chunk_meta(doc_id)`); err != nil {
-		return fmt.Errorf("create chunk_meta doc_id index: %w", err)
+	if err := s.createChunkMetaTable(tx, s.chunkMetaTable); err != nil {
+		return err
 	}
 
 	migratedVectors, err := s.initEmbeddingsTable(tx)
@@ -97,12 +109,30 @@ func (s *sqliteVectorStore) Init() error {
 	return nil
 }
 
-func (s *sqliteVectorStore) createEmbeddingsTable(tx *sql.Tx) error {
-	stmt := fmt.Sprintf(`CREATE VIRTUAL TABLE embeddings USING vec0(
+func (s *sqliteVectorStore) createChunkMetaTable(tx *sql.Tx, tableName string) error {
+	table := sqliteIdentifier(tableName)
+	if _, err := tx.Exec(fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s (
+		chunk_key TEXT PRIMARY KEY,
+		doc_id TEXT NOT NULL,
+		chunk_idx INTEGER NOT NULL,
+		user_id INTEGER NOT NULL DEFAULT 0,
+		chunk_text TEXT NOT NULL
+	)`, table)); err != nil {
+		return fmt.Errorf("create chunk_meta table: %w", err)
+	}
+	if _, err := tx.Exec(fmt.Sprintf(`CREATE INDEX IF NOT EXISTS %s ON %s(doc_id)`,
+		sqliteIdentifier(sqliteChunkMetaIndexName(tableName)), table)); err != nil {
+		return fmt.Errorf("create chunk_meta doc_id index: %w", err)
+	}
+	return nil
+}
+
+func (s *sqliteVectorStore) createEmbeddingsTable(tx *sql.Tx, tableName string) error {
+	stmt := fmt.Sprintf(`CREATE VIRTUAL TABLE %s USING vec0(
 		user_id INTEGER PARTITION KEY,
 		chunk_key TEXT PRIMARY KEY,
 		embedding FLOAT[%d] distance_metric=cosine
-	)`, s.dimensions)
+	)`, sqliteIdentifier(tableName), s.dimensions)
 	if _, err := tx.Exec(stmt); err != nil {
 		return fmt.Errorf("create embeddings table: %w", err)
 	}
@@ -111,9 +141,9 @@ func (s *sqliteVectorStore) createEmbeddingsTable(tx *sql.Tx) error {
 
 func (s *sqliteVectorStore) initEmbeddingsTable(tx *sql.Tx) (int64, error) {
 	var schema string
-	err := tx.QueryRow(`SELECT sql FROM sqlite_schema WHERE type = 'table' AND name = 'embeddings'`).Scan(&schema)
+	err := tx.QueryRow(`SELECT sql FROM sqlite_schema WHERE type = 'table' AND name = ?`, s.embeddingTable).Scan(&schema)
 	if errors.Is(err, sql.ErrNoRows) {
-		return -1, s.createEmbeddingsTable(tx)
+		return -1, s.createEmbeddingsTable(tx, s.embeddingTable)
 	}
 	if err != nil {
 		return -1, fmt.Errorf("read embeddings table schema: %w", err)
@@ -134,8 +164,8 @@ func (s *sqliteVectorStore) initEmbeddingsTable(tx *sql.Tx) (int64, error) {
 	)`); err != nil {
 		return -1, fmt.Errorf("create embeddings migration table: %w", err)
 	}
-	copyResult, err := tx.Exec(`INSERT INTO embeddings_cosine_migration(user_id, chunk_key, embedding)
-		SELECT user_id, chunk_key, embedding FROM embeddings`)
+	copyResult, err := tx.Exec(fmt.Sprintf(`INSERT INTO embeddings_cosine_migration(user_id, chunk_key, embedding)
+		SELECT user_id, chunk_key, embedding FROM %s`, sqliteIdentifier(s.embeddingTable)))
 	if err != nil {
 		return -1, fmt.Errorf("copy embeddings for cosine migration: %w", err)
 	}
@@ -143,14 +173,14 @@ func (s *sqliteVectorStore) initEmbeddingsTable(tx *sql.Tx) (int64, error) {
 	if err != nil {
 		return -1, fmt.Errorf("count embeddings for cosine migration: %w", err)
 	}
-	if _, err := tx.Exec(`DROP TABLE embeddings`); err != nil {
+	if _, err := tx.Exec(fmt.Sprintf(`DROP TABLE %s`, sqliteIdentifier(s.embeddingTable))); err != nil {
 		return -1, fmt.Errorf("drop L2 embeddings table: %w", err)
 	}
-	if err := s.createEmbeddingsTable(tx); err != nil {
+	if err := s.createEmbeddingsTable(tx, s.embeddingTable); err != nil {
 		return -1, err
 	}
-	restoreResult, err := tx.Exec(`INSERT INTO embeddings(user_id, chunk_key, embedding)
-		SELECT user_id, chunk_key, embedding FROM embeddings_cosine_migration`)
+	restoreResult, err := tx.Exec(fmt.Sprintf(`INSERT INTO %s(user_id, chunk_key, embedding)
+		SELECT user_id, chunk_key, embedding FROM embeddings_cosine_migration`, sqliteIdentifier(s.embeddingTable)))
 	if err != nil {
 		return -1, fmt.Errorf("restore embeddings after cosine migration: %w", err)
 	}
@@ -165,6 +195,42 @@ func (s *sqliteVectorStore) initEmbeddingsTable(tx *sql.Tx) (int64, error) {
 		return -1, fmt.Errorf("drop embeddings migration table: %w", err)
 	}
 	return migratedVectors, nil
+}
+
+func (s *sqliteVectorStore) BeginReindex() (ReindexStore, error) {
+	if s.staging {
+		return nil, errors.New("cannot start a reindex from a staging vector store")
+	}
+	suffix := nextReindexSuffix()
+	stage := &sqliteVectorStore{
+		db:             s.db,
+		dimensions:     s.dimensions,
+		embeddingTable: s.embeddingTable + suffix,
+		chunkMetaTable: s.chunkMetaTable + suffix,
+		staging:        true,
+	}
+	tx, err := s.db.Begin()
+	if err != nil {
+		return nil, fmt.Errorf("begin vector store reindex: %w", err)
+	}
+	defer func() {
+		_ = tx.Rollback()
+	}()
+	for _, tableName := range []string{stage.embeddingTable, stage.chunkMetaTable} {
+		if _, err := tx.Exec(fmt.Sprintf(`DROP TABLE IF EXISTS %s`, sqliteIdentifier(tableName))); err != nil {
+			return nil, fmt.Errorf("remove previous reindex table: %w", err)
+		}
+	}
+	if err := stage.createChunkMetaTable(tx, stage.chunkMetaTable); err != nil {
+		return nil, err
+	}
+	if err := stage.createEmbeddingsTable(tx, stage.embeddingTable); err != nil {
+		return nil, err
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("commit vector store reindex setup: %w", err)
+	}
+	return stage, nil
 }
 
 func chunkKey(docID string, chunkIdx int) string {
@@ -182,21 +248,23 @@ func (s *sqliteVectorStore) PutChunks(docID string, userID uint, chunks []Chunk)
 		}
 	}()
 
+	embeddingsTable := sqliteIdentifier(s.embeddingTable)
+	chunkMetaTable := sqliteIdentifier(s.chunkMetaTable)
 	// Delete all existing chunks for this document.
-	if _, err = tx.Exec(`DELETE FROM embeddings WHERE chunk_key IN (SELECT chunk_key FROM chunk_meta WHERE doc_id = ?)`, docID); err != nil {
+	if _, err = tx.Exec(fmt.Sprintf(`DELETE FROM %s WHERE chunk_key IN (SELECT chunk_key FROM %s WHERE doc_id = ?)`, embeddingsTable, chunkMetaTable), docID); err != nil {
 		return fmt.Errorf("delete old embeddings: %w", err)
 	}
-	if _, err = tx.Exec(`DELETE FROM chunk_meta WHERE doc_id = ?`, docID); err != nil {
+	if _, err = tx.Exec(fmt.Sprintf(`DELETE FROM %s WHERE doc_id = ?`, chunkMetaTable), docID); err != nil {
 		return fmt.Errorf("delete old chunk_meta: %w", err)
 	}
 
-	metaStmt, err := tx.Prepare(`INSERT INTO chunk_meta(chunk_key, doc_id, chunk_idx, user_id, chunk_text) VALUES (?, ?, ?, ?, ?)`)
+	metaStmt, err := tx.Prepare(fmt.Sprintf(`INSERT INTO %s(chunk_key, doc_id, chunk_idx, user_id, chunk_text) VALUES (?, ?, ?, ?, ?)`, chunkMetaTable))
 	if err != nil {
 		return fmt.Errorf("prepare chunk_meta insert: %w", err)
 	}
 	defer metaStmt.Close() //nolint:errcheck
 
-	embStmt, err := tx.Prepare(`INSERT INTO embeddings(user_id, chunk_key, embedding) VALUES (?, ?, ?)`)
+	embStmt, err := tx.Prepare(fmt.Sprintf(`INSERT INTO %s(user_id, chunk_key, embedding) VALUES (?, ?, ?)`, embeddingsTable))
 	if err != nil {
 		return fmt.Errorf("prepare embeddings insert: %w", err)
 	}
@@ -228,10 +296,12 @@ func (s *sqliteVectorStore) Delete(docID string) error {
 			_ = tx.Rollback()
 		}
 	}()
-	if _, err = tx.Exec(`DELETE FROM embeddings WHERE chunk_key IN (SELECT chunk_key FROM chunk_meta WHERE doc_id = ?)`, docID); err != nil {
+	embeddingsTable := sqliteIdentifier(s.embeddingTable)
+	chunkMetaTable := sqliteIdentifier(s.chunkMetaTable)
+	if _, err = tx.Exec(fmt.Sprintf(`DELETE FROM %s WHERE chunk_key IN (SELECT chunk_key FROM %s WHERE doc_id = ?)`, embeddingsTable, chunkMetaTable), docID); err != nil {
 		return fmt.Errorf("delete embeddings: %w", err)
 	}
-	if _, err = tx.Exec(`DELETE FROM chunk_meta WHERE doc_id = ?`, docID); err != nil {
+	if _, err = tx.Exec(fmt.Sprintf(`DELETE FROM %s WHERE doc_id = ?`, chunkMetaTable), docID); err != nil {
 		return fmt.Errorf("delete chunk_meta: %w", err)
 	}
 	return tx.Commit()
@@ -253,14 +323,14 @@ func (s *sqliteVectorStore) Search(vector []float32, topK int, threshold float64
 
 func (s *sqliteVectorStore) searchUser(vector []float32, topK int, threshold float64, userID uint) (_ []Result, err error) {
 	blob := float32ToBlob(vector)
-	rows, err := s.db.Query(
+	rows, err := s.db.Query(fmt.Sprintf(
 		`SELECT e.chunk_key, e.distance, COALESCE(m.doc_id, ''), COALESCE(m.chunk_idx, 0), COALESCE(m.chunk_text, '')
-		 FROM embeddings e
-		 LEFT JOIN chunk_meta m ON e.chunk_key = m.chunk_key
-		 WHERE e.embedding MATCH ?
-		   AND e.k = ?
-		   AND e.user_id = ?
-		 ORDER BY e.distance`,
+			 FROM %s e
+			 LEFT JOIN %s m ON e.chunk_key = m.chunk_key
+			 WHERE e.embedding MATCH ?
+			   AND e.k = ?
+			   AND e.user_id = ?
+			 ORDER BY e.distance`, sqliteIdentifier(s.embeddingTable), sqliteIdentifier(s.chunkMetaTable)),
 		blob, topK, userID,
 	)
 	if err != nil {
@@ -294,16 +364,92 @@ func (s *sqliteVectorStore) searchUser(vector []float32, topK int, threshold flo
 }
 
 func (s *sqliteVectorStore) Clear() error {
-	if _, err := s.db.Exec(`DELETE FROM embeddings`); err != nil {
+	if _, err := s.db.Exec(fmt.Sprintf(`DELETE FROM %s`, sqliteIdentifier(s.embeddingTable))); err != nil {
 		return fmt.Errorf("clear embeddings: %w", err)
 	}
-	if _, err := s.db.Exec(`DELETE FROM chunk_meta`); err != nil {
+	if _, err := s.db.Exec(fmt.Sprintf(`DELETE FROM %s`, sqliteIdentifier(s.chunkMetaTable))); err != nil {
 		return fmt.Errorf("clear chunk_meta: %w", err)
 	}
 	return nil
 }
 
+func (s *sqliteVectorStore) Commit() error {
+	if !s.staging {
+		return errors.New("cannot commit a live vector store")
+	}
+	tx, err := s.db.Begin()
+	if err != nil {
+		return fmt.Errorf("begin vector store reindex commit: %w", err)
+	}
+	defer func() {
+		_ = tx.Rollback()
+	}()
+	if _, err := tx.Exec(fmt.Sprintf(`DROP INDEX IF EXISTS %s`, sqliteIdentifier(sqliteChunkMetaIndexName(sqliteChunkMetaTable)))); err != nil {
+		return fmt.Errorf("drop old chunk_meta index: %w", err)
+	}
+	for _, tableName := range []string{sqliteEmbeddingsTable, sqliteChunkMetaTable} {
+		if _, err := tx.Exec(fmt.Sprintf(`DROP TABLE %s`, sqliteIdentifier(tableName))); err != nil {
+			return fmt.Errorf("drop old vector table: %w", err)
+		}
+	}
+	if err := s.createChunkMetaTable(tx, sqliteChunkMetaTable); err != nil {
+		return fmt.Errorf("create active chunk_meta table: %w", err)
+	}
+	if err := s.createEmbeddingsTable(tx, sqliteEmbeddingsTable); err != nil {
+		return fmt.Errorf("create active embeddings table: %w", err)
+	}
+	if _, err := tx.Exec(fmt.Sprintf(`INSERT INTO %s(chunk_key, doc_id, chunk_idx, user_id, chunk_text)
+		SELECT chunk_key, doc_id, chunk_idx, user_id, chunk_text FROM %s`,
+		sqliteIdentifier(sqliteChunkMetaTable), sqliteIdentifier(s.chunkMetaTable))); err != nil {
+		return fmt.Errorf("copy staged chunk_meta: %w", err)
+	}
+	if _, err := tx.Exec(fmt.Sprintf(`INSERT INTO %s(user_id, chunk_key, embedding)
+		SELECT user_id, chunk_key, embedding FROM %s`,
+		sqliteIdentifier(sqliteEmbeddingsTable), sqliteIdentifier(s.embeddingTable))); err != nil {
+		return fmt.Errorf("copy staged embeddings: %w", err)
+	}
+	for _, tableName := range []string{s.embeddingTable, s.chunkMetaTable} {
+		if _, err := tx.Exec(fmt.Sprintf(`DROP TABLE %s`, sqliteIdentifier(tableName))); err != nil {
+			return fmt.Errorf("drop staged vector table: %w", err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit vector store reindex: %w", err)
+	}
+	s.embeddingTable = sqliteEmbeddingsTable
+	s.chunkMetaTable = sqliteChunkMetaTable
+	s.staging = false
+	s.ownsDB = true
+	return nil
+}
+
+func (s *sqliteVectorStore) Rollback() error {
+	if !s.staging {
+		return nil
+	}
+	tx, err := s.db.Begin()
+	if err != nil {
+		return fmt.Errorf("begin vector store reindex rollback: %w", err)
+	}
+	defer func() {
+		_ = tx.Rollback()
+	}()
+	for _, tableName := range []string{s.embeddingTable, s.chunkMetaTable} {
+		if _, err := tx.Exec(fmt.Sprintf(`DROP TABLE IF EXISTS %s`, sqliteIdentifier(tableName))); err != nil {
+			return fmt.Errorf("drop reindex table: %w", err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit vector store reindex rollback: %w", err)
+	}
+	s.staging = false
+	return nil
+}
+
 func (s *sqliteVectorStore) Close() error {
+	if !s.ownsDB {
+		return nil
+	}
 	return s.db.Close()
 }
 

--- a/server/vectorstore/sqlite_test.go
+++ b/server/vectorstore/sqlite_test.go
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package vectorstore
+
+import (
+	"testing"
+
+	"github.com/asciimoo/hister/server/testutil"
+)
+
+func newTestSQLiteVectorStore(t *testing.T) *sqliteVectorStore {
+	t.Helper()
+
+	cfg := testutil.Config(t)
+	cfg.Server.Database = "hister.sqlite3"
+	cfg.SemanticSearch.Dimensions = 2
+
+	store, err := newSQLite(cfg)
+	if err != nil {
+		t.Fatalf("newSQLite returned an error: %v", err)
+	}
+	if err := store.Init(); err != nil {
+		_ = store.Close()
+		t.Fatalf("Init returned an error: %v", err)
+	}
+	live := store.(*sqliteVectorStore)
+	t.Cleanup(func() {
+		if err := live.Close(); err != nil {
+			t.Errorf("close SQLite vector store: %v", err)
+		}
+	})
+	return live
+}
+
+func requireSQLiteResultDoc(t *testing.T, store *sqliteVectorStore, query []float32, want string) {
+	t.Helper()
+
+	results, err := store.Search(query, 10, 0.99, 0)
+	if err != nil {
+		t.Fatalf("Search returned an error: %v", err)
+	}
+	if len(results) != 1 || results[0].DocID != want {
+		t.Fatalf("Search returned %#v, want only document %q", results, want)
+	}
+}
+
+func requireSQLiteNoResults(t *testing.T, store *sqliteVectorStore, query []float32) {
+	t.Helper()
+
+	results, err := store.Search(query, 10, 0.99, 0)
+	if err != nil {
+		t.Fatalf("Search returned an error: %v", err)
+	}
+	if len(results) != 0 {
+		t.Fatalf("Search returned %#v, want no results", results)
+	}
+}
+
+func TestSQLiteReindexRollbackPreservesLiveVectors(t *testing.T) {
+	live := newTestSQLiteVectorStore(t)
+	if err := live.PutChunks("old", 0, []Chunk{{Index: 0, Text: "old", Embedding: []float32{1, 0}}}); err != nil {
+		t.Fatalf("seed live vector: %v", err)
+	}
+
+	staged, err := live.BeginReindex()
+	if err != nil {
+		t.Fatalf("BeginReindex returned an error: %v", err)
+	}
+	if err := staged.PutChunks("new", 0, []Chunk{{Index: 0, Text: "new", Embedding: []float32{0, 1}}}); err != nil {
+		t.Fatalf("seed staged vector: %v", err)
+	}
+	if err := staged.Rollback(); err != nil {
+		t.Fatalf("Rollback returned an error: %v", err)
+	}
+
+	requireSQLiteResultDoc(t, live, []float32{1, 0}, "old")
+	requireSQLiteNoResults(t, live, []float32{0, 1})
+}
+
+func TestSQLiteReindexCommitReplacesLiveVectors(t *testing.T) {
+	live := newTestSQLiteVectorStore(t)
+	if err := live.PutChunks("old", 0, []Chunk{{Index: 0, Text: "old", Embedding: []float32{1, 0}}}); err != nil {
+		t.Fatalf("seed live vector: %v", err)
+	}
+
+	staged, err := live.BeginReindex()
+	if err != nil {
+		t.Fatalf("BeginReindex returned an error: %v", err)
+	}
+	if err := staged.PutChunks("new", 0, []Chunk{{Index: 0, Text: "new", Embedding: []float32{0, 1}}}); err != nil {
+		t.Fatalf("seed staged vector: %v", err)
+	}
+	if err := staged.Commit(); err != nil {
+		t.Fatalf("Commit returned an error: %v", err)
+	}
+
+	requireSQLiteResultDoc(t, live, []float32{0, 1}, "new")
+	requireSQLiteNoResults(t, live, []float32{1, 0})
+}

--- a/server/vectorstore/vectorstore.go
+++ b/server/vectorstore/vectorstore.go
@@ -3,10 +3,19 @@
 package vectorstore
 
 import (
+	"fmt"
 	"sort"
+	"sync/atomic"
+	"time"
 
 	"github.com/asciimoo/hister/config"
 )
+
+var reindexSequence atomic.Uint64
+
+func nextReindexSuffix() string {
+	return fmt.Sprintf("_reindex_%d_%d", time.Now().UnixNano(), reindexSequence.Add(1))
+}
 
 const (
 	searchCandidateMultiplier = 4
@@ -106,10 +115,25 @@ func diversifySearchResults(results []Result, documentLimit, chunkLimit int) []R
 	return diverse
 }
 
+// ReindexStore is a vector store populated during a reindex. It must be
+// committed only after the replacement search indexes are ready, or rolled
+// back when reindexing fails.
+type ReindexStore interface {
+	VectorStore
+
+	Commit() error
+	Rollback() error
+}
+
 // VectorStore is the interface for vector similarity backends.
 type VectorStore interface {
 	// Init creates tables/extensions if missing. Safe to call on every startup.
 	Init() error
+
+	// BeginReindex creates an isolated store for rebuilding embeddings. The
+	// caller must commit it after the replacement indexes are ready or roll it
+	// back on failure.
+	BeginReindex() (ReindexStore, error)
 
 	// PutChunks upserts all chunk embeddings for a document, replacing any
 	// previous chunks. docID matches the Bleve document ID (URL).


### PR DESCRIPTION
Fixes #354

A failed semantic re‑index may empty the vector store after existing data gets cleared. All vector updates are now staged. Changes only go live once re‑index completes successfully, and get rolled back on embedding errors or job cancellation.

The existing vector and Bleve indexes stay usable until commit. Embedding errors are propagated upstream. Regression tests cover failure, cancellation, rollback, and successful‑commit scenarios.

Codex assisted with implementation and review. I’ve reviewed and fully understand the final patch.