### PR TITLE
Add ChatGPT conversation extractor

### DIFF
--- a/server/extractor/extractor_test.go
+++ b/server/extractor/extractor_test.go
@@ -227,6 +227,7 @@ func TestDefaultRegistryOrder(t *testing.T) {
 		"Twitter",
 		"Notion",
 		"Ytdlp",
+		"ChatGPT",
 		"Readability",
 		"Basic",
 	}

--- a/server/extractor/extractors/chatgpt/extractor.go
+++ b/server/extractor/extractors/chatgpt/extractor.go
@@ -1,0 +1,489 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// Package chatgpt extracts rendered ChatGPT conversations as single documents.
+package chatgpt
+
+import (
+	"fmt"
+	stdhtml "html"
+	"net/url"
+	"strings"
+	"unicode"
+
+	"github.com/PuerkitoBio/goquery"
+	"golang.org/x/net/html"
+
+	"github.com/asciimoo/hister/server/extractor/sdk"
+	"github.com/asciimoo/hister/server/extractor/urlutil"
+	"github.com/asciimoo/hister/server/sanitizer"
+)
+
+const conversationType = "chatgpt"
+
+// ChatGPTExtractor extracts one visible ChatGPT conversation into one Hister
+// document. It intentionally works only with the rendered HTML already on the
+// document and never fetches conversation data itself.
+type ChatGPTExtractor struct {
+	sdk.ConfigSupport
+}
+
+var _ sdk.Extractor = (*ChatGPTExtractor)(nil)
+
+func (e *ChatGPTExtractor) Name() string {
+	return "ChatGPT"
+}
+
+func (e *ChatGPTExtractor) Description() string {
+	return "Extracts the visible user and assistant turns from ChatGPT conversations as one searchable document."
+}
+
+func (e *ChatGPTExtractor) Capabilities() sdk.Capabilities {
+	return sdk.Capabilities{Extract: true, Preview: true}
+}
+
+// Match accepts authenticated, custom GPT, and public shared conversation URLs
+// on chatgpt.com. Other ChatGPT pages are left to later extractors.
+func (e *ChatGPTExtractor) Match(d *sdk.Document) bool {
+	if d == nil {
+		return false
+	}
+	u, err := url.Parse(d.URL)
+	if err != nil || !strings.EqualFold(u.Scheme, "https") || u.User != nil {
+		return false
+	}
+	host := strings.ToLower(strings.TrimSuffix(u.Hostname(), "."))
+	if host != "chatgpt.com" && host != "www.chatgpt.com" {
+		return false
+	}
+
+	path := u.EscapedPath()
+	if !strings.HasPrefix(path, "/") {
+		return false
+	}
+	path = strings.TrimPrefix(path, "/")
+	if strings.HasSuffix(path, "/") {
+		path = strings.TrimSuffix(path, "/")
+	}
+	parts := strings.Split(path, "/")
+	var idParts []string
+	switch {
+	case len(parts) == 2 && (parts[0] == "c" || parts[0] == "share"):
+		idParts = []string{parts[1]}
+	case len(parts) == 4 && parts[0] == "g" && parts[2] == "c":
+		idParts = []string{parts[1], parts[3]}
+	default:
+		return false
+	}
+	for _, rawID := range idParts {
+		if !validConversationPathSegment(rawID) {
+			return false
+		}
+	}
+	return true
+}
+
+func validConversationPathSegment(rawID string) bool {
+	if rawID == "" {
+		return false
+	}
+	id, err := url.PathUnescape(rawID)
+	if err != nil || id == "." || id == ".." || strings.Contains(id, "/") {
+		return false
+	}
+	for _, r := range id {
+		if unicode.IsSpace(r) || unicode.IsControl(r) {
+			return false
+		}
+	}
+	return true
+}
+
+type conversationTurn struct {
+	role    string
+	content *goquery.Selection
+}
+
+func (e *ChatGPTExtractor) Extract(d *sdk.Document) sdk.ExtractResult {
+	if !e.Match(d) {
+		return sdk.ExtractFallback(fmt.Errorf("not a ChatGPT conversation URL"))
+	}
+	doc, turns, err := parseConversation(d)
+	if err != nil {
+		return sdk.ExtractFallback(err)
+	}
+	if len(turns) == 0 {
+		return sdk.ExtractFallback(fmt.Errorf("no visible user or assistant turns found"))
+	}
+
+	title := documentTitle(d, doc)
+	if title != "" {
+		d.Title = title
+	}
+	d.Text = conversationText(turns)
+	if d.Metadata == nil {
+		d.Metadata = make(map[string]any)
+	}
+	d.Metadata["type"] = conversationType
+	return sdk.Extracted()
+}
+
+func (e *ChatGPTExtractor) Preview(d *sdk.Document) sdk.PreviewResult {
+	if !e.Match(d) {
+		return sdk.PreviewFallback(fmt.Errorf("not a ChatGPT conversation URL"))
+	}
+	doc, turns, err := parseConversation(d)
+	if err != nil {
+		return sdk.PreviewFallback(err)
+	}
+	if len(turns) == 0 {
+		return sdk.PreviewFallback(fmt.Errorf("no visible user or assistant turns found"))
+	}
+
+	base, err := url.Parse(d.URL)
+	if err != nil {
+		return sdk.PreviewFallback(err)
+	}
+
+	var b strings.Builder
+	if title := documentTitle(d, doc); title != "" {
+		fmt.Fprintf(&b, "<h1>%s</h1>", stdhtml.EscapeString(title))
+	}
+	for _, turn := range turns {
+		fmt.Fprintf(&b, "<div><h2>%s</h2>", stdhtml.EscapeString(roleLabel(turn.role)))
+		content := turn.content.Clone()
+		cleanConversationContent(content, turn.role)
+		urlutil.RewriteURLs(content, base)
+		htmlContent, err := content.Html()
+		if err != nil {
+			return sdk.PreviewFallback(err)
+		}
+		b.WriteString(htmlContent)
+		b.WriteString("</div>")
+	}
+
+	content := sanitizer.SanitizeHTML(b.String())
+	if strings.TrimSpace(content) == "" {
+		return sdk.PreviewFallback(fmt.Errorf("no preview content"))
+	}
+	return sdk.Previewed(sdk.PreviewResponse{Content: content})
+}
+
+func parseConversation(d *sdk.Document) (*goquery.Document, []conversationTurn, error) {
+	if d == nil {
+		return nil, nil, fmt.Errorf("nil document")
+	}
+	doc, err := goquery.NewDocumentFromReader(strings.NewReader(d.HTML))
+	if err != nil {
+		return nil, nil, err
+	}
+	return doc, findConversationTurns(doc), nil
+}
+
+func findConversationTurns(doc *goquery.Document) []conversationTurn {
+	if doc == nil {
+		return nil
+	}
+	if turns := findArticleConversationTurns(doc); len(turns) > 0 {
+		return turns
+	}
+	return findRoleConversationTurns(doc)
+}
+
+func findArticleConversationTurns(doc *goquery.Document) []conversationTurn {
+	turns := make([]conversationTurn, 0)
+	doc.Find(`article[data-testid^="conversation-turn-"]`).Each(func(_ int, article *goquery.Selection) {
+		if isHiddenElement(article) {
+			return
+		}
+		roleNode, role := findRoleNode(article)
+		if roleNode == nil || isHiddenElement(roleNode) {
+			return
+		}
+
+		content := roleNode.Clone()
+		cleanConversationContent(content, role)
+		if strings.TrimSpace(conversationSelectionText(content)) == "" {
+			return
+		}
+		turns = append(turns, conversationTurn{role: role, content: content})
+	})
+	return turns
+}
+
+func findRoleConversationTurns(doc *goquery.Document) []conversationTurn {
+	turns := make([]conversationTurn, 0)
+	doc.Find(`[data-message-author-role]`).Each(func(_ int, roleNode *goquery.Selection) {
+		role := normalizeRole(roleNode.AttrOr("data-message-author-role", ""))
+		if role == "" || hasRoleAncestor(roleNode) || isHiddenElement(roleNode) {
+			return
+		}
+
+		content := roleNode.Clone()
+		cleanConversationContent(content, role)
+		if strings.TrimSpace(conversationSelectionText(content)) == "" {
+			return
+		}
+		turns = append(turns, conversationTurn{role: role, content: content})
+	})
+	return turns
+}
+
+func findRoleNode(article *goquery.Selection) (*goquery.Selection, string) {
+	if article == nil || article.Length() == 0 {
+		return nil, ""
+	}
+	if rawRole, ok := article.Attr("data-message-author-role"); ok {
+		role := normalizeRole(rawRole)
+		if role == "" {
+			return nil, ""
+		}
+		return article, role
+	}
+
+	var selected *goquery.Selection
+	role := ""
+	article.Find(`[data-message-author-role]`).EachWithBreak(func(_ int, candidate *goquery.Selection) bool {
+		candidateRole := normalizeRole(candidate.AttrOr("data-message-author-role", ""))
+		if candidateRole == "" || hasRoleAncestor(candidate) {
+			return true
+		}
+		selected = candidate
+		role = candidateRole
+		return false
+	})
+	return selected, role
+}
+
+func normalizeRole(raw string) string {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "user":
+		return "user"
+	case "assistant":
+		return "assistant"
+	default:
+		return ""
+	}
+}
+
+func hasRoleAncestor(selection *goquery.Selection) bool {
+	found := false
+	selection.ParentsFiltered(`[data-message-author-role]`).EachWithBreak(func(_ int, ancestor *goquery.Selection) bool {
+		found = true
+		return false
+	})
+	return found
+}
+
+func cleanConversationContent(content *goquery.Selection, role string) {
+	if content == nil {
+		return
+	}
+	content.Find(`[data-message-author-role]`).Each(func(_ int, nested *goquery.Selection) {
+		if normalizeRole(nested.AttrOr("data-message-author-role", "")) != role {
+			nested.Remove()
+		}
+	})
+	content.Find(`script, style, noscript, template, button, svg, img, picture, video, audio, iframe, embed, object, canvas, source, form, input, textarea, select, option`).Remove()
+	content.Find(`[hidden], [aria-hidden]`).Each(func(_ int, nested *goquery.Selection) {
+		if isHiddenElement(nested) {
+			nested.Remove()
+		}
+	})
+}
+
+func isHiddenElement(selection *goquery.Selection) bool {
+	if selection == nil || selection.Length() == 0 {
+		return false
+	}
+	if hasHiddenMarker(selection) {
+		return true
+	}
+	found := false
+	selection.Parents().EachWithBreak(func(_ int, ancestor *goquery.Selection) bool {
+		if hasHiddenMarker(ancestor) {
+			found = true
+			return false
+		}
+		return true
+	})
+	return found
+}
+
+func hasHiddenMarker(selection *goquery.Selection) bool {
+	if _, ok := selection.Attr("hidden"); ok {
+		return true
+	}
+	return strings.EqualFold(strings.TrimSpace(selection.AttrOr("aria-hidden", "")), "true")
+}
+
+func documentTitle(d *sdk.Document, doc *goquery.Document) string {
+	if d != nil {
+		if title := sanitizer.SanitizeText(d.Title); title != "" {
+			return title
+		}
+	}
+	if doc != nil {
+		return sanitizer.SanitizeText(doc.Find("title").First().Text())
+	}
+	return ""
+}
+
+func roleLabel(role string) string {
+	if role == "assistant" {
+		return "Assistant"
+	}
+	return "User"
+}
+
+func conversationText(turns []conversationTurn) string {
+	var b strings.Builder
+	for _, turn := range turns {
+		text := conversationSelectionText(turn.content)
+		if text == "" {
+			continue
+		}
+		if b.Len() > 0 {
+			b.WriteString("\n\n")
+		}
+		b.WriteString(roleLabel(turn.role))
+		b.WriteString(":\n")
+		b.WriteString(text)
+	}
+	return strings.TrimSpace(b.String())
+}
+
+var conversationBlockElements = map[string]bool{
+	"address": true, "article": true, "blockquote": true, "dd": true, "div": true,
+	"dl": true, "dt": true, "figcaption": true, "figure": true, "footer": true,
+	"h1": true, "h2": true, "h3": true, "h4": true, "h5": true, "h6": true,
+	"header": true, "main": true, "p": true, "section": true,
+}
+
+type conversationTextWriter struct {
+	b        strings.Builder
+	rowCells []int
+}
+
+func conversationSelectionText(selection *goquery.Selection) string {
+	if selection == nil || selection.Length() == 0 {
+		return ""
+	}
+	writer := &conversationTextWriter{}
+	for _, node := range selection.Nodes {
+		writer.writeNode(node)
+	}
+	return normalizeConversationText(writer.b.String())
+}
+
+func (w *conversationTextWriter) writeNode(node *html.Node) {
+	if node == nil {
+		return
+	}
+	if node.Type == html.TextNode {
+		w.b.WriteString(node.Data)
+		return
+	}
+	if node.Type != html.ElementNode {
+		for child := node.FirstChild; child != nil; child = child.NextSibling {
+			w.writeNode(child)
+		}
+		return
+	}
+
+	name := strings.ToLower(node.Data)
+	switch name {
+	case "script", "style", "noscript", "template", "button", "svg", "img", "picture", "video", "audio", "iframe", "embed", "object", "canvas", "source", "form", "input", "textarea", "select", "option":
+		return
+	case "br":
+		w.writeBreak()
+		return
+	case "pre":
+		w.writeBreak()
+		for child := node.FirstChild; child != nil; child = child.NextSibling {
+			w.writeNode(child)
+		}
+		w.writeBreak()
+		return
+	case "li":
+		w.writeBreak()
+		w.b.WriteString("- ")
+		for child := node.FirstChild; child != nil; child = child.NextSibling {
+			w.writeNode(child)
+		}
+		w.writeBreak()
+		return
+	case "ul", "ol":
+		w.writeBreak()
+		for child := node.FirstChild; child != nil; child = child.NextSibling {
+			w.writeNode(child)
+		}
+		w.writeBreak()
+		return
+	case "table":
+		w.writeBreak()
+		for child := node.FirstChild; child != nil; child = child.NextSibling {
+			w.writeNode(child)
+		}
+		w.writeBreak()
+		return
+	case "tr":
+		w.writeBreak()
+		w.rowCells = append(w.rowCells, 0)
+		for child := node.FirstChild; child != nil; child = child.NextSibling {
+			w.writeNode(child)
+		}
+		w.rowCells = w.rowCells[:len(w.rowCells)-1]
+		w.writeBreak()
+		return
+	case "td", "th":
+		if len(w.rowCells) > 0 {
+			last := len(w.rowCells) - 1
+			if w.rowCells[last] > 0 {
+				w.b.WriteString(" | ")
+			}
+			w.rowCells[last]++
+		}
+		for child := node.FirstChild; child != nil; child = child.NextSibling {
+			w.writeNode(child)
+		}
+		return
+	}
+
+	if conversationBlockElements[name] {
+		w.writeBreak()
+	}
+	for child := node.FirstChild; child != nil; child = child.NextSibling {
+		w.writeNode(child)
+	}
+	if conversationBlockElements[name] {
+		w.writeBreak()
+	}
+}
+
+func (w *conversationTextWriter) writeBreak() {
+	if w.b.Len() > 0 && !strings.HasSuffix(w.b.String(), "\n") {
+		w.b.WriteByte('\n')
+	}
+}
+
+func normalizeConversationText(text string) string {
+	text = strings.ReplaceAll(text, "\u00a0", " ")
+	text = strings.ReplaceAll(text, "\r\n", "\n")
+	text = strings.ReplaceAll(text, "\r", "\n")
+	lines := strings.Split(text, "\n")
+	cleaned := make([]string, 0, len(lines))
+	blank := false
+	for _, line := range lines {
+		line = strings.Join(strings.Fields(line), " ")
+		if line == "" {
+			if len(cleaned) > 0 && !blank {
+				cleaned = append(cleaned, "")
+				blank = true
+			}
+			continue
+		}
+		cleaned = append(cleaned, line)
+		blank = false
+	}
+	return strings.TrimSpace(strings.Join(cleaned, "\n"))
+}

--- a/server/extractor/extractors/chatgpt/extractor.go
+++ b/server/extractor/extractors/chatgpt/extractor.go
@@ -61,9 +61,7 @@ func (e *ChatGPTExtractor) Match(d *sdk.Document) bool {
 		return false
 	}
 	path = strings.TrimPrefix(path, "/")
-	if strings.HasSuffix(path, "/") {
-		path = strings.TrimSuffix(path, "/")
-	}
+	path, _ = strings.CutSuffix(path, "/")
 	parts := strings.Split(path, "/")
 	var idParts []string
 	switch {

--- a/server/extractor/extractors/chatgpt/extractor.go
+++ b/server/extractor/extractors/chatgpt/extractor.go
@@ -112,7 +112,7 @@ func (e *ChatGPTExtractor) Extract(d *sdk.Document) sdk.ExtractResult {
 		return sdk.ExtractFallback(err)
 	}
 	if len(turns) == 0 {
-		return sdk.ExtractFallback(fmt.Errorf("no visible user or assistant turns found"))
+		return sdk.AbortExtraction(fmt.Errorf("no visible user or assistant turns found"))
 	}
 
 	title := documentTitle(d, doc)

--- a/server/extractor/extractors/chatgpt/extractor_test.go
+++ b/server/extractor/extractors/chatgpt/extractor_test.go
@@ -1,0 +1,370 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package chatgpt
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/asciimoo/hister/server/document"
+	"github.com/asciimoo/hister/server/extractor/sdk"
+)
+
+func TestMatchConversationURLForms(t *testing.T) {
+	extractor := &ChatGPTExtractor{}
+	tests := []struct {
+		name string
+		url  string
+		want bool
+	}{
+		{name: "authenticated conversation", url: "https://chatgpt.com/c/conv-123", want: true},
+		{name: "public shared conversation", url: "https://chatgpt.com/share/conv-123", want: true},
+		{name: "custom GPT conversation", url: "https://chatgpt.com/g/gpt-123/c/conv-123", want: true},
+		{name: "custom GPT on www host", url: "https://www.chatgpt.com/g/gpt-123/c/conv-123", want: true},
+		{name: "custom GPT trailing slash", url: "https://chatgpt.com/g/gpt-123/c/conv-123/", want: true},
+		{name: "trailing slash", url: "https://chatgpt.com/c/conv-123/", want: true},
+		{name: "chatgpt home", url: "https://chatgpt.com/", want: false},
+		{name: "empty conversation path", url: "https://chatgpt.com/c/", want: false},
+		{name: "extra path segment", url: "https://chatgpt.com/c/conv-123/extra", want: false},
+		{name: "unrelated chatgpt page", url: "https://chatgpt.com/g/gpt-123", want: false},
+		{name: "custom GPT empty GPT ID", url: "https://chatgpt.com/g//c/conv-123", want: false},
+		{name: "custom GPT empty conversation ID", url: "https://chatgpt.com/g/gpt-123/c/", want: false},
+		{name: "custom GPT extra path segment", url: "https://chatgpt.com/g/gpt-123/c/conv-123/extra", want: false},
+		{name: "custom GPT encoded slash in GPT ID", url: "https://chatgpt.com/g/gpt%2F123/c/conv-123", want: false},
+		{name: "custom GPT encoded slash in conversation ID", url: "https://chatgpt.com/g/gpt-123/c/conv%2F123", want: false},
+		{name: "custom GPT dot GPT ID", url: "https://chatgpt.com/g/./c/conv-123", want: false},
+		{name: "custom GPT dot conversation ID", url: "https://chatgpt.com/g/gpt-123/c/..", want: false},
+		{name: "custom GPT encoded dot GPT ID", url: "https://chatgpt.com/g/%2E/c/conv-123", want: false},
+		{name: "custom GPT encoded dot conversation ID", url: "https://chatgpt.com/g/gpt-123/c/%2E%2E", want: false},
+		{name: "custom GPT whitespace GPT ID", url: "https://chatgpt.com/g/gpt%20123/c/conv-123", want: false},
+		{name: "custom GPT control conversation ID", url: "https://chatgpt.com/g/gpt-123/c/conv%00-123", want: false},
+		{name: "lookalike host", url: "https://notchatgpt.com/c/conv-123", want: false},
+		{name: "wrong scheme", url: "http://chatgpt.com/c/conv-123", want: false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := extractor.Match(&document.Document{URL: test.url})
+			if got != test.want {
+				t.Fatalf("Match(%q) = %v, want %v", test.url, got, test.want)
+			}
+		})
+	}
+}
+
+func TestExtractsConversationAsOneRichDocument(t *testing.T) {
+	html, err := os.ReadFile("testdata/conversation.html")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, url := range []string{
+		"https://chatgpt.com/c/conv-123",
+		"https://chatgpt.com/share/conv-123",
+	} {
+		t.Run(url, func(t *testing.T) {
+			doc := &document.Document{URL: url, HTML: string(html), UserID: 7}
+			extractor := &ChatGPTExtractor{}
+
+			decision, err := extractor.Extract(doc).Unpack()
+			if err != nil {
+				t.Fatalf("Extract returned an error: %v", err)
+			}
+			if decision != sdk.ExtractorSuccess {
+				t.Fatalf("Extract decision = %v, want %v", decision, sdk.ExtractorSuccess)
+			}
+			if doc.SkipIndexing {
+				t.Fatal("conversation was marked to skip indexing")
+			}
+			if len(doc.ExtraDocuments) != 0 {
+				t.Fatalf("ExtraDocuments length = %d, want 0", len(doc.ExtraDocuments))
+			}
+			if got, want := doc.Title, "Project planning | ChatGPT"; got != want {
+				t.Fatalf("title = %q, want %q", got, want)
+			}
+			if got, want := doc.Metadata["type"], "chatgpt"; got != want {
+				t.Fatalf("metadata type = %#v, want %#v", got, want)
+			}
+
+			for _, want := range []string{
+				"User:",
+				"Please draft a project plan.",
+				"Assistant:",
+				"Project plan",
+				"- Design",
+				"- Build",
+				"Phase | Owner",
+				"Draft | Ada",
+				"go test ./server/...",
+				"guide",
+				"Nested answer.",
+			} {
+				if !strings.Contains(doc.Text, want) {
+					t.Errorf("indexed text is missing %q: %q", want, doc.Text)
+				}
+			}
+			for _, unwanted := range []string{"System-only content", "Tool-only content"} {
+				if strings.Contains(doc.Text, unwanted) {
+					t.Errorf("indexed text contains ignored turn %q: %q", unwanted, doc.Text)
+				}
+			}
+			if got := strings.Count(doc.Text, "Nested answer."); got != 1 {
+				t.Fatalf("nested role content appears %d times in indexed text, want 1: %q", got, doc.Text)
+			}
+			if user, assistant := strings.Index(doc.Text, "User:"), strings.Index(doc.Text, "Assistant:"); user < 0 || assistant < 0 || user >= assistant {
+				t.Fatalf("role labels are missing or out of order: %q", doc.Text)
+			}
+
+			preview, decision, err := extractor.Preview(doc).Unpack()
+			if err != nil {
+				t.Fatalf("Preview returned an error: %v", err)
+			}
+			if decision != sdk.ExtractorSuccess {
+				t.Fatalf("Preview decision = %v, want %v", decision, sdk.ExtractorSuccess)
+			}
+			for _, want := range []string{
+				"Project planning | ChatGPT",
+				"<h2>User</h2>",
+				"<h2>Assistant</h2>",
+				"<h2>Project plan</h2>",
+				`href="https://chatgpt.com/docs/start"`,
+				"Nested answer.",
+			} {
+				if !strings.Contains(preview.Content, want) {
+					t.Errorf("preview is missing %q: %s", want, preview.Content)
+				}
+			}
+			for _, unwanted := range []string{"<script", "onclick", "javascript:", "<img", "<iframe", "generated.png"} {
+				if strings.Contains(strings.ToLower(preview.Content), strings.ToLower(unwanted)) {
+					t.Errorf("preview contains unsafe or unsupported content %q: %s", unwanted, preview.Content)
+				}
+			}
+			if user, assistant := strings.Index(preview.Content, "<h2>User</h2>"), strings.Index(preview.Content, "<h2>Assistant</h2>"); user < 0 || assistant < 0 || user >= assistant {
+				t.Fatalf("preview role labels are missing or out of order: %s", preview.Content)
+			}
+		})
+	}
+}
+
+func TestExtractFallsBackWithoutVisibleUserOrAssistantTurns(t *testing.T) {
+	doc := &document.Document{
+		URL: "https://chatgpt.com/c/empty-123",
+		HTML: `<html><head><title>Empty ChatGPT shell</title></head><body>
+			<div id="__next"></div>
+			<article data-testid="conversation-turn-0"><div data-message-author-role="system">System content</div></article>
+			<article data-testid="conversation-turn-1"><div data-message-author-role="tool">Tool content</div></article>
+		</body></html>`,
+	}
+
+	decision, err := (&ChatGPTExtractor{}).Extract(doc).Unpack()
+	if decision != sdk.ExtractorFallback {
+		t.Fatalf("Extract decision = %v, want %v", decision, sdk.ExtractorFallback)
+	}
+	if err == nil {
+		t.Fatal("Extract returned no fallback diagnostic")
+	}
+	if doc.Text != "" {
+		t.Fatalf("fallback populated text: %q", doc.Text)
+	}
+
+	preview, previewDecision, previewErr := (&ChatGPTExtractor{}).Preview(doc).Unpack()
+	if previewDecision != sdk.ExtractorFallback {
+		t.Fatalf("Preview decision = %v, want %v", previewDecision, sdk.ExtractorFallback)
+	}
+	if previewErr == nil {
+		t.Fatal("Preview returned no fallback diagnostic")
+	}
+	if preview.Content != "" {
+		t.Fatalf("fallback populated preview: %q", preview.Content)
+	}
+}
+
+func TestExtractFallsBackForUnmatchedURL(t *testing.T) {
+	html, err := os.ReadFile("testdata/conversation.html")
+	if err != nil {
+		t.Fatal(err)
+	}
+	doc := &document.Document{
+		URL:  "https://chatgpt.com/g/gpt-123",
+		HTML: string(html),
+	}
+
+	decision, err := (&ChatGPTExtractor{}).Extract(doc).Unpack()
+	if decision != sdk.ExtractorFallback {
+		t.Fatalf("Extract decision = %v, want %v", decision, sdk.ExtractorFallback)
+	}
+	if err == nil {
+		t.Fatal("Extract returned no fallback diagnostic")
+	}
+}
+
+func TestSkipsHiddenAndNestedInternalContent(t *testing.T) {
+	doc := &document.Document{
+		URL: "https://chatgpt.com/c/visibility-123",
+		HTML: `<html><body>
+			<div hidden><article data-testid="conversation-turn-hidden-ancestor"><div data-message-author-role="user">Hidden ancestor</div></article></div>
+			<article data-testid="conversation-turn-hidden-root" aria-hidden="true"><div data-message-author-role="assistant">Hidden root</div></article>
+			<article data-testid="conversation-turn-hidden-role"><div data-message-author-role="assistant" hidden>Hidden role</div></article>
+			<article data-testid="conversation-turn-system-parent">
+				<div data-message-author-role="system"><div data-message-author-role="user">Misnested user</div></div>
+			</article>
+			<article data-testid="conversation-turn-visible">
+				<div data-message-author-role="assistant">
+					<p>Visible answer.</p>
+					<div data-message-author-role="system">Nested system content.</div>
+					<div data-message-author-role="assistant"><p>Nested duplicate answer.</p></div>
+				</div>
+			</article>
+		</body></html>`,
+	}
+
+	decision, err := (&ChatGPTExtractor{}).Extract(doc).Unpack()
+	if err != nil || decision != sdk.ExtractorSuccess {
+		t.Fatalf("Extract returned decision %v and error %v", decision, err)
+	}
+	if got, want := doc.Text, "Assistant:\nVisible answer.\n\nNested duplicate answer."; got != want {
+		t.Fatalf("indexed text = %q, want %q", got, want)
+	}
+	for _, unwanted := range []string{"Hidden ancestor", "Hidden root", "Hidden role", "Misnested user", "Nested system content"} {
+		if strings.Contains(doc.Text, unwanted) {
+			t.Fatalf("indexed text contains hidden or internal content %q: %q", unwanted, doc.Text)
+		}
+	}
+	if got := strings.Count(doc.Text, "Nested duplicate answer."); got != 1 {
+		t.Fatalf("nested duplicate content appears %d times, want 1: %q", got, doc.Text)
+	}
+
+	preview, previewDecision, err := (&ChatGPTExtractor{}).Preview(doc).Unpack()
+	if err != nil || previewDecision != sdk.ExtractorSuccess {
+		t.Fatalf("Preview returned decision %v and error %v", previewDecision, err)
+	}
+	for _, unwanted := range []string{"Hidden ancestor", "Hidden root", "Hidden role", "Misnested user", "Nested system content"} {
+		if strings.Contains(preview.Content, unwanted) {
+			t.Fatalf("preview contains hidden or internal content %q: %s", unwanted, preview.Content)
+		}
+	}
+}
+
+func TestExtractsPublicShareRoleNodesWithoutArticleWrappers(t *testing.T) {
+	html, err := os.ReadFile("testdata/public-share.html")
+	if err != nil {
+		t.Fatal(err)
+	}
+	doc := &document.Document{
+		URL:  "https://chatgpt.com/share/sleep-123",
+		HTML: string(html),
+	}
+
+	decision, err := (&ChatGPTExtractor{}).Extract(doc).Unpack()
+	if err != nil {
+		t.Fatalf("Extract returned an error: %v", err)
+	}
+	if decision != sdk.ExtractorSuccess {
+		t.Fatalf("Extract decision = %v, want %v", decision, sdk.ExtractorSuccess)
+	}
+	if got, want := doc.Title, "Sleep Optimization Discussion"; got != want {
+		t.Fatalf("title = %q, want %q", got, want)
+	}
+
+	ordered := []string{
+		"How can I improve my sleep quality?",
+		"Keep a consistent schedule.",
+		"Expose the duplicate marker only once.",
+		"Limit caffeine later in the day.",
+		"What about exercise timing?",
+		"Exercise earlier when possible.",
+		"How long should I sleep?",
+		"Aim for a regular duration.",
+	}
+	previous := -1
+	for _, want := range ordered {
+		position := strings.Index(doc.Text, want)
+		if position <= previous {
+			t.Fatalf("indexed text is missing or out of order for %q: %q", want, doc.Text)
+		}
+		previous = position
+	}
+	if got := strings.Count(doc.Text, "Expose the duplicate marker only once."); got != 1 {
+		t.Fatalf("nested same-role content appears %d times, want 1: %q", got, doc.Text)
+	}
+	for _, unwanted := range []string{
+		"Internal system instructions must not be indexed.",
+		"Hidden assistant content must not be indexed.",
+	} {
+		if strings.Contains(doc.Text, unwanted) {
+			t.Fatalf("indexed text contains filtered content %q: %q", unwanted, doc.Text)
+		}
+	}
+
+	preview, previewDecision, err := (&ChatGPTExtractor{}).Preview(doc).Unpack()
+	if err != nil {
+		t.Fatalf("Preview returned an error: %v", err)
+	}
+	if previewDecision != sdk.ExtractorSuccess {
+		t.Fatalf("Preview decision = %v, want %v", previewDecision, sdk.ExtractorSuccess)
+	}
+	if got := strings.Count(preview.Content, "<h2>User</h2>"); got != 3 {
+		t.Fatalf("preview contains %d user headings, want 3: %s", got, preview.Content)
+	}
+	if got := strings.Count(preview.Content, "<h2>Assistant</h2>"); got != 4 {
+		t.Fatalf("preview contains %d assistant headings, want 4: %s", got, preview.Content)
+	}
+	for _, unwanted := range []string{
+		"Internal system instructions must not be indexed.",
+		"Hidden assistant content must not be indexed.",
+	} {
+		if strings.Contains(preview.Content, unwanted) {
+			t.Fatalf("preview contains filtered content %q: %s", unwanted, preview.Content)
+		}
+	}
+}
+
+func TestExtractsCustomGPTRoleNodesWithoutArticleWrappers(t *testing.T) {
+	html, err := os.ReadFile("testdata/public-share.html")
+	if err != nil {
+		t.Fatal(err)
+	}
+	doc := &document.Document{
+		URL:  "https://chatgpt.com/g/gpt-123/c/conv-123",
+		HTML: string(html),
+	}
+
+	decision, err := (&ChatGPTExtractor{}).Extract(doc).Unpack()
+	if err != nil {
+		t.Fatalf("Extract returned an error: %v", err)
+	}
+	if decision != sdk.ExtractorSuccess {
+		t.Fatalf("Extract decision = %v, want %v", decision, sdk.ExtractorSuccess)
+	}
+	if len(doc.ExtraDocuments) != 0 {
+		t.Fatalf("ExtraDocuments length = %d, want 0", len(doc.ExtraDocuments))
+	}
+
+	roleOrder := []string{"User:", "Assistant:", "User:", "Assistant:", "User:", "Assistant:"}
+	position := 0
+	for _, role := range roleOrder {
+		found := strings.Index(doc.Text[position:], role)
+		if found < 0 {
+			t.Fatalf("indexed text is missing role %q after byte %d: %q", role, position, doc.Text)
+		}
+		position += found + len(role)
+	}
+
+	ordered := []string{
+		"How can I improve my sleep quality?",
+		"Keep a consistent schedule.",
+		"What about exercise timing?",
+		"Exercise earlier when possible.",
+		"How long should I sleep?",
+		"Aim for a regular duration.",
+	}
+	previous := -1
+	for _, want := range ordered {
+		position := strings.Index(doc.Text, want)
+		if position <= previous {
+			t.Fatalf("indexed text is missing or out of order for %q: %q", want, doc.Text)
+		}
+		previous = position
+	}
+}

--- a/server/extractor/extractors/chatgpt/extractor_test.go
+++ b/server/extractor/extractors/chatgpt/extractor_test.go
@@ -147,7 +147,7 @@ func TestExtractsConversationAsOneRichDocument(t *testing.T) {
 	}
 }
 
-func TestExtractFallsBackWithoutVisibleUserOrAssistantTurns(t *testing.T) {
+func TestExtractAbortsWithoutVisibleUserOrAssistantTurns(t *testing.T) {
 	doc := &document.Document{
 		URL: "https://chatgpt.com/c/empty-123",
 		HTML: `<html><head><title>Empty ChatGPT shell</title></head><body>
@@ -158,14 +158,17 @@ func TestExtractFallsBackWithoutVisibleUserOrAssistantTurns(t *testing.T) {
 	}
 
 	decision, err := (&ChatGPTExtractor{}).Extract(doc).Unpack()
-	if decision != sdk.ExtractorFallback {
-		t.Fatalf("Extract decision = %v, want %v", decision, sdk.ExtractorFallback)
+	if decision != sdk.ExtractorAbort {
+		t.Fatalf("Extract decision = %v, want %v", decision, sdk.ExtractorAbort)
 	}
 	if err == nil {
-		t.Fatal("Extract returned no fallback diagnostic")
+		t.Fatal("Extract returned no abort diagnostic")
+	}
+	if got, want := err.Error(), "no visible user or assistant turns found"; got != want {
+		t.Fatalf("Extract diagnostic = %q, want %q", got, want)
 	}
 	if doc.Text != "" {
-		t.Fatalf("fallback populated text: %q", doc.Text)
+		t.Fatalf("abort populated text: %q", doc.Text)
 	}
 
 	preview, previewDecision, previewErr := (&ChatGPTExtractor{}).Preview(doc).Unpack()

--- a/server/extractor/extractors/chatgpt/testdata/conversation.html
+++ b/server/extractor/extractors/chatgpt/testdata/conversation.html
@@ -1,0 +1,49 @@
+<!doctype html>
+<html>
+  <head>
+    <title>Project planning | ChatGPT</title>
+    <style>.hidden { display: none }</style>
+  </head>
+  <body>
+    <main>
+      <article data-testid="conversation-turn-0">
+        <div data-message-author-role="user">
+          <div class="whitespace-pre-wrap">Please draft a project plan.</div>
+          <button type="button">Copy</button>
+        </div>
+      </article>
+      <article data-testid="conversation-turn-1">
+        <div data-message-author-role="assistant">
+          <div class="markdown">
+            <h2>Project plan</h2>
+            <p>Read the <a href="/docs/start">guide</a>.</p>
+            <ul>
+              <li>Design</li>
+              <li>Build</li>
+            </ul>
+            <table>
+              <thead><tr><th>Phase</th><th>Owner</th></tr></thead>
+              <tbody><tr><td>Draft</td><td>Ada</td></tr></tbody>
+            </table>
+            <pre><code>go test ./server/...</code></pre>
+            <p><a href="javascript:alert(1)" onclick="alert(2)">Unsafe link</a></p>
+            <img src="https://cdn.example.invalid/generated.png" alt="generated image">
+            <iframe src="https://embed.example.invalid/ignored"></iframe>
+            <script>alert("ignored")</script>
+          </div>
+        </div>
+      </article>
+      <article data-testid="conversation-turn-2">
+        <div data-message-author-role="system">System-only content must not be indexed.</div>
+      </article>
+      <article data-testid="conversation-turn-3">
+        <div data-message-author-role="assistant">
+          <div data-message-author-role="assistant"><p>Nested answer.</p></div>
+        </div>
+      </article>
+      <article data-testid="conversation-turn-4">
+        <div data-message-author-role="tool">Tool-only content must not be indexed.</div>
+      </article>
+    </main>
+  </body>
+</html>

--- a/server/extractor/extractors/chatgpt/testdata/public-share.html
+++ b/server/extractor/extractors/chatgpt/testdata/public-share.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<html>
+  <head>
+    <title>Sleep Optimization Discussion</title>
+  </head>
+  <body>
+    <main data-page="shared-conversation">
+      <div data-message-author-role="user">
+        <p>How can I improve my sleep quality?</p>
+      </div>
+      <div data-message-author-role="assistant">
+        <p>Keep a consistent schedule.</p>
+        <div data-message-author-role="assistant">
+          <p>Expose the duplicate marker only once.</p>
+        </div>
+        <div data-message-author-role="system">
+          <p>Internal system instructions must not be indexed.</p>
+        </div>
+      </div>
+      <div data-message-author-role="assistant">
+        <p>Limit caffeine later in the day.</p>
+      </div>
+      <div data-message-author-role="user">
+        <p>What about exercise timing?</p>
+      </div>
+      <div data-message-author-role="assistant">
+        <p>Exercise earlier when possible.</p>
+      </div>
+      <div data-message-author-role="user">
+        <p>How long should I sleep?</p>
+      </div>
+      <div data-message-author-role="assistant">
+        <p>Aim for a regular duration.</p>
+      </div>
+      <div hidden data-message-author-role="assistant">
+        <p>Hidden assistant content must not be indexed.</p>
+      </div>
+    </main>
+  </body>
+</html>

--- a/server/extractor/extractors/ytdlp/ytdlp_test.go
+++ b/server/extractor/extractors/ytdlp/ytdlp_test.go
@@ -261,7 +261,7 @@ func TestMatch(t *testing.T) {
 		{"https://artist.bandcamp.com/track/song", true},
 		{"https://www.tiktok.com/@user/video/123", true},
 		{"https://www.ted.com/talks/some_talk", true},
-		{"https://archive.org/details/something", true},
+		{"https://archive.org/details/something", false},
 		{"https://videos.peertube.example.com/w/abc", true},
 		{"https://www.youtube.com/", false},
 		{"https://www.youtube.com", false},

--- a/server/extractor/live_cases.yaml
+++ b/server/extractor/live_cases.yaml
@@ -287,6 +287,25 @@ cases:
         - Share to web
       min_preview_length: 500
 
+  - name: chatgpt_public_share_chromedp
+    url: https://chatgpt.com/share/6a6a1580-8e2c-83e8-ad79-4017715b7f6f
+    backend: chromedp
+    backend_options:
+      capture_delay: 3
+    extractor: ChatGPT
+    timeout: 35
+    expect:
+      title_contains:
+        - Sleep Optimization Discussion
+      text_contains:
+        - "User:"
+        - "Assistant:"
+      min_text_length: 100
+      preview_contains:
+        - User
+        - Assistant
+      min_preview_length: 100
+
   - name: ytdlp_archive_big_buck_bunny
     url: https://archive.org/details/BigBuckBunny_328
     fetch: false

--- a/server/extractor/registry.go
+++ b/server/extractor/registry.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/asciimoo/hister/config"
 	"github.com/asciimoo/hister/server/extractor/extractors/bluesky"
+	"github.com/asciimoo/hister/server/extractor/extractors/chatgpt"
 	"github.com/asciimoo/hister/server/extractor/extractors/discourse"
 	"github.com/asciimoo/hister/server/extractor/extractors/embeddedvideo"
 	"github.com/asciimoo/hister/server/extractor/extractors/github"
@@ -69,6 +70,7 @@ func DefaultExtractors() []Extractor {
 		&twitter.TwitterExtractor{},
 		&notion.NotionExtractor{},
 		&ytdlp.YtdlpExtractor{},
+		&chatgpt.ChatGPTExtractor{},
 		&readabilityExtractor{},
 		&basicExtractor{},
 	}

--- a/webui/website/src/content/docs/extractors.md
+++ b/webui/website/src/content/docs/extractors.md
@@ -368,6 +368,19 @@ extractors:
         - vimeo.com
 ```
 
+### `chatgpt`
+
+Extracts a ChatGPT conversation as one document. Each
+visible user and assistant turn is retained in order and labelled in both the
+indexed text and the preview. Headings, lists, tables, code blocks, and ordinary
+safe links are preserved in the sanitized preview. System, tool, internal, and
+unsupported media content is ignored.
+
+**Matches:** `https://chatgpt.com/c/<conversation-id>` authenticated,
+`https://chatgpt.com/share/<conversation-id>` public shared, and
+`https://chatgpt.com/g/<gpt-id>/c/<conversation-id>` custom GPT conversation URLs
+(including `www.chatgpt.com`).
+
 ### `readability`
 
 Generic article extractor using the


### PR DESCRIPTION
This PR adds an extractor for ChatGPT. It works for both private and public chats. 
Messages by ChatGPT and the user are clearly labeled.
Disclaimer: I have used codex to help me with the development.

Closes: #650