### PR TITLE
nix: drop x86_64-darwin for 26.11

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -12,7 +12,7 @@
     inputs.flake-parts.lib.mkFlake { inherit inputs; } {
       systems = [
         "x86_64-linux"
-        "x86_64-darwin"
+        # "x86_64-darwin" # No longer supported in 26.11
         "aarch64-linux"
         "aarch64-darwin"
       ];


### PR DESCRIPTION
No longer supported in 26.11