### PR TITLE
[enh] allow safari-web-extension CORS preflight - refs #49

### DIFF
--- a/server/endpoints.go
+++ b/server/endpoints.go
@@ -83,7 +83,7 @@ func registerEndpoints(cfg *config.Config, idx *indexer.Indexer) http.Handler {
 	mux.HandleFunc("GET /opensearch.xml", createHandler(cfg, idx, serveOpensearch))
 	mux.HandleFunc("/", createHandler(cfg, idx, serveSPA))
 	// If base_url contains a path prefix, require it for application routes.
-	appHandler := http.Handler(mux)
+	appHandler := withExtensionCORS(http.Handler(mux))
 	basePrefix := cfg.BasePathPrefix()
 	if basePrefix != "" {
 		appHandler = withOptionalBasePathPrefix(basePrefix, appHandler)

--- a/server/extension.go
+++ b/server/extension.go
@@ -46,6 +46,19 @@ func browserExtensionRequest(origin, path string) bool {
 	return trustedBrowserExtensionOrigin(origin) && browserExtensionAPIPath(path)
 }
 
+// extensionCORSAllowHeaders returns the response Access-Control-Allow-Headers
+// value. Safari preflights every extension fetch and lists the actual request
+// headers in Access-Control-Request-Headers; echoing that list keeps
+// user-configured custom headers (reverse-proxy auth, etc.) working. When no
+// preflight header is present, fall back to the headers the extension always
+// sends.
+func extensionCORSAllowHeaders(r *http.Request) string {
+	if requested := r.Header.Get("Access-Control-Request-Headers"); requested != "" {
+		return requested
+	}
+	return "Content-Type, X-Access-Token, X-Hister-Public, X-CSRF-Token, Authorization"
+}
+
 // withExtensionCORS answers CORS preflight and attaches CORS headers for
 // requests that come from a trusted browser-extension origin on the extension
 // API surface.
@@ -64,7 +77,7 @@ func withExtensionCORS(next http.Handler) http.Handler {
 		h := w.Header()
 		h.Set("Access-Control-Allow-Origin", origin)
 		h.Set("Access-Control-Allow-Methods", "GET, HEAD, POST, OPTIONS")
-		h.Set("Access-Control-Allow-Headers", "Content-Type, X-Access-Token, X-Hister-Public, X-CSRF-Token, Authorization")
+		h.Set("Access-Control-Allow-Headers", extensionCORSAllowHeaders(r))
 		h.Set("Access-Control-Allow-Credentials", "true")
 		h.Set("Access-Control-Max-Age", "600")
 		h.Add("Vary", "Origin")

--- a/server/extension.go
+++ b/server/extension.go
@@ -1,0 +1,77 @@
+package server
+
+import (
+	"net/http"
+	"strings"
+)
+
+const chromeExtensionOrigin = "chrome-extension://cciilamhchpmbdnniabclekddabkifhb"
+
+// Paths the official Chrome/Firefox extensions and the unofficial Safari
+// port are allowed to call without a web-session CSRF token. Keep this in
+// lockstep with the endpoints the extension actually uses.
+var browserExtensionAPIPaths = map[string]struct{}{
+	"/add":          {},
+	"/api/add":      {},
+	"/api/add_pdf":  {},
+	"/api/config":   {},
+	"/api/rules":    {},
+	"/api/delete":   {},
+	"/api/label":    {},
+	"/api/versions": {},
+	"/api/history":  {},
+	"/api/profile":  {},
+	"/api/document": {},
+}
+
+func trustedBrowserExtensionOrigin(origin string) bool {
+	switch {
+	case strings.HasPrefix(origin, "moz-extension://"):
+		return true
+	case strings.HasPrefix(origin, "safari-web-extension://"):
+		return true
+	case origin == chromeExtensionOrigin:
+		return true
+	default:
+		return false
+	}
+}
+
+func browserExtensionAPIPath(path string) bool {
+	_, ok := browserExtensionAPIPaths[path]
+	return ok
+}
+
+func browserExtensionRequest(origin, path string) bool {
+	return trustedBrowserExtensionOrigin(origin) && browserExtensionAPIPath(path)
+}
+
+// withExtensionCORS answers CORS preflight and attaches CORS headers for
+// requests that come from a trusted browser-extension origin on the extension
+// API surface.
+//
+// Chrome and Firefox exempt extension background fetches from CORS, but
+// Safari still preflights JSON / custom-header requests from the popup and
+// options pages. Without this, those pages cannot talk to a stock Hister
+// server (see asciimoo/hister#49).
+func withExtensionCORS(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		origin := r.Header.Get("Origin")
+		if !browserExtensionRequest(origin, r.URL.Path) {
+			next.ServeHTTP(w, r)
+			return
+		}
+		h := w.Header()
+		h.Set("Access-Control-Allow-Origin", origin)
+		h.Set("Access-Control-Allow-Methods", "GET, HEAD, POST, OPTIONS")
+		h.Set("Access-Control-Allow-Headers", "Content-Type, X-Access-Token, X-Hister-Public, X-CSRF-Token, Authorization, Cookie")
+		h.Set("Access-Control-Allow-Credentials", "true")
+		h.Set("Access-Control-Max-Age", "600")
+		h.Add("Vary", "Origin")
+		if r.Method == http.MethodOptions {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}

--- a/server/extension.go
+++ b/server/extension.go
@@ -64,7 +64,7 @@ func withExtensionCORS(next http.Handler) http.Handler {
 		h := w.Header()
 		h.Set("Access-Control-Allow-Origin", origin)
 		h.Set("Access-Control-Allow-Methods", "GET, HEAD, POST, OPTIONS")
-		h.Set("Access-Control-Allow-Headers", "Content-Type, X-Access-Token, X-Hister-Public, X-CSRF-Token, Authorization, Cookie")
+		h.Set("Access-Control-Allow-Headers", "Content-Type, X-Access-Token, X-Hister-Public, X-CSRF-Token, Authorization")
 		h.Set("Access-Control-Allow-Credentials", "true")
 		h.Set("Access-Control-Max-Age", "600")
 		h.Add("Vary", "Origin")

--- a/server/extension_test.go
+++ b/server/extension_test.go
@@ -1,0 +1,74 @@
+package server
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/asciimoo/hister/server/testutil"
+)
+
+func TestExtensionCORSPreflightAllowsSafari(t *testing.T) {
+	_, handler := newTokenTestServer(t, false)
+	origin := "safari-web-extension://aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+	rec := testutil.ServeHTTP(t, handler, http.MethodOptions, "/api/add", nil, map[string]string{
+		"Origin":                         origin,
+		"Access-Control-Request-Method":  "POST",
+		"Access-Control-Request-Headers": "content-type,x-access-token",
+	})
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("OPTIONS /api/add status = %d, want %d; body=%s", rec.Code, http.StatusNoContent, rec.Body.String())
+	}
+	if got := rec.Header().Get("Access-Control-Allow-Origin"); got != origin {
+		t.Fatalf("Access-Control-Allow-Origin = %q, want %q", got, origin)
+	}
+	allowHeaders := strings.ToLower(rec.Header().Get("Access-Control-Allow-Headers"))
+	if !strings.Contains(allowHeaders, "x-access-token") {
+		t.Fatalf("Access-Control-Allow-Headers = %q, want to include x-access-token", rec.Header().Get("Access-Control-Allow-Headers"))
+	}
+}
+
+func TestExtensionCORSPreflightRejectsUntrustedOrigin(t *testing.T) {
+	_, handler := newTokenTestServer(t, false)
+	rec := testutil.ServeHTTP(t, handler, http.MethodOptions, "/api/add", nil, map[string]string{
+		"Origin":                         "https://evil.example",
+		"Access-Control-Request-Method":  "POST",
+		"Access-Control-Request-Headers": "content-type",
+	})
+	if rec.Header().Get("Access-Control-Allow-Origin") == "https://evil.example" {
+		t.Fatal("untrusted origin received Access-Control-Allow-Origin")
+	}
+	if rec.Code == http.StatusNoContent {
+		t.Fatal("OPTIONS from an untrusted origin was treated as an extension preflight")
+	}
+}
+
+func TestExtensionCSRFAllowsSafariHistoryAndProfile(t *testing.T) {
+	_, handler := newTokenTestServer(t, false)
+	origin := "safari-web-extension://aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+	headers := map[string]string{
+		"Origin":         origin,
+		"Content-Type":   "application/json",
+		"X-Access-Token": "secret",
+	}
+
+	history := testutil.ServeHTTP(
+		t,
+		handler,
+		http.MethodPost,
+		"/api/history",
+		strings.NewReader(`{"url":"https://example.com","title":"Example","query":"q"}`),
+		headers,
+	)
+	if history.Code == http.StatusForbidden {
+		t.Fatalf("POST /api/history from Safari extension was CSRF-blocked: %s", history.Body.String())
+	}
+
+	profile := testutil.ServeHTTP(t, handler, http.MethodGet, "/api/profile", nil, headers)
+	if profile.Code == http.StatusForbidden {
+		t.Fatalf("GET /api/profile from Safari extension was CSRF-blocked: %s", profile.Body.String())
+	}
+	if got := profile.Header().Get("Access-Control-Allow-Origin"); got != origin {
+		t.Fatalf("GET /api/profile ACAO = %q, want %q", got, origin)
+	}
+}

--- a/server/extension_test.go
+++ b/server/extension_test.go
@@ -28,6 +28,23 @@ func TestExtensionCORSPreflightAllowsSafari(t *testing.T) {
 	}
 }
 
+func TestExtensionCORSPreflightEchoesCustomRequestHeaders(t *testing.T) {
+	_, handler := newTokenTestServer(t, false)
+	origin := "safari-web-extension://aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+	requested := "content-type,x-access-token,x-proxy-auth"
+	rec := testutil.ServeHTTP(t, handler, http.MethodOptions, "/api/add", nil, map[string]string{
+		"Origin":                         origin,
+		"Access-Control-Request-Method":  "POST",
+		"Access-Control-Request-Headers": requested,
+	})
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("OPTIONS /api/add status = %d, want %d; body=%s", rec.Code, http.StatusNoContent, rec.Body.String())
+	}
+	if got := rec.Header().Get("Access-Control-Allow-Headers"); got != requested {
+		t.Fatalf("Access-Control-Allow-Headers = %q, want echoed %q", got, requested)
+	}
+}
+
 func TestExtensionCORSPreflightRejectsUntrustedOrigin(t *testing.T) {
 	_, handler := newTokenTestServer(t, false)
 	rec := testutil.ServeHTTP(t, handler, http.MethodOptions, "/api/add", nil, map[string]string{

--- a/server/server.go
+++ b/server/server.go
@@ -349,23 +349,12 @@ func withCSRF(handler endpointHandler) endpointHandler {
 			handler(c)
 			return
 		}
-		// Allow add, config requests from the addons
-		for _, p := range []string{"/add", "/api/add", "/api/add_pdf", "/api/config", "/api/rules", "/api/delete", "/api/label", "/api/versions"} {
-			if c.Request.URL.Path != p {
-				continue
-			}
-			if strings.HasPrefix(c.Request.Header.Get("Origin"), "moz-extension://") {
-				handler(c)
-				return
-			}
-			if strings.HasPrefix(c.Request.Header.Get("Origin"), "safari-web-extension://") {
-				handler(c)
-				return
-			}
-			if c.Request.Header.Get("Origin") == "chrome-extension://cciilamhchpmbdnniabclekddabkifhb" {
-				handler(c)
-				return
-			}
+		// Allow the browser extensions to call their API surface without a
+		// web-session CSRF token. Origin is browser-controlled, so a web
+		// page cannot spoof moz-extension:// / safari-web-extension://.
+		if browserExtensionRequest(c.Request.Header.Get("Origin"), c.Request.URL.Path) {
+			handler(c)
+			return
 		}
 
 		session, err := sessionStore.Get(c.Request, storeName)


### PR DESCRIPTION
Safari's extension popup still sends a CORS preflight (`OPTIONS`) for JSON bodies and `X-Access-Token`. Those requests currently fall through to the SPA handler, so token auth from the unofficial Safari extension fails even though CSRF already allows `safari-web-extension://` origins on a subset of paths.

This adds a small middleware that, only for trusted browser-extension origins on the extension API surface:

- answers `OPTIONS` with `204`
- reflects that origin in `Access-Control-Allow-*`
- skips CSRF on `/api/history` as well (the content script posts search-result history there; Chrome/Firefox already share this origin check)

Trusted origins are unchanged: `moz-extension://`, `safari-web-extension://`, and the packaged Chrome extension id. Other origins are not given CORS headers.

## Test plan

- [x] `go test ./server/ -run TestExtension`
- [x] `OPTIONS /api/add` from a `safari-web-extension://` origin returns 204 with `Access-Control-Allow-Origin` set to that origin
- [x] the same `OPTIONS` from `https://evil.example` does not get those headers
- [x] `POST /api/add` and `POST /api/history` from the Safari origin succeed (201 / 200) with an access token

Assistance: Cursor was used while writing the middleware and tests. The behaviour follows issue #49 and the earlier CORS POC in #46.