### PR TITLE
Import Safari browsing history

### DIFF
--- a/cmd/browser.go
+++ b/cmd/browser.go
@@ -187,16 +187,9 @@ func importBrowser(browser string, cmd *cobra.Command, startDate *time.Time) {
 }
 
 func importHistoryFile(file_path string, cmd *cobra.Command, startDate *time.Time) {
-	var table string
-
-	if strings.HasSuffix(file_path, "places.sqlite") {
-		table = "moz_places"
-	} else if strings.HasSuffix(file_path, "History") {
-		table = "urls"
-	} else if strings.HasSuffix(file_path, "History.db") {
-		table = "History"
-	} else {
-		log.Fatal().Str("file", file_path).Msg("Couldn't auto detect table")
+	table, err := detectHistoryTable(file_path)
+	if err != nil {
+		log.Fatal().Err(err).Str("file", file_path).Msg("Couldn't auto detect table")
 	}
 
 	importDB([]DBToImport{
@@ -207,6 +200,64 @@ func importHistoryFile(file_path string, cmd *cobra.Command, startDate *time.Tim
 	},
 		cmd,
 		startDate)
+}
+
+// detectHistoryTable identifies a browser history database by the tables it contains.
+//
+// This used to guess from the filename, which cannot work: Safari and Ladybird both call their
+// database History.db, so a Safari history was read as Ladybird's and failed with "no such table:
+// History". Chrome's is called History with no extension, which the same check would have to
+// distinguish by the absence of a suffix.
+//
+// What a database IS cannot be settled by what it is called, and the answer is inside it. Safari is
+// checked first because it is the only one identified by a pair of tables, so a match is
+// unambiguous.
+func detectHistoryTable(path string) (_ string, err error) {
+	db, err := sql.Open("sqlite3", fmt.Sprintf("file:%s?immutable=1&mode=ro", path))
+	if err != nil {
+		return "", fmt.Errorf("open database: %w", err)
+	}
+	defer func() {
+		if closeErr := db.Close(); closeErr != nil && err == nil {
+			err = closeErr
+		}
+	}()
+
+	rows, err := db.Query("SELECT name FROM sqlite_master WHERE type = 'table'")
+	if err != nil {
+		return "", fmt.Errorf("read schema: %w", err)
+	}
+	defer func() {
+		if closeErr := rows.Close(); closeErr != nil && err == nil {
+			err = closeErr
+		}
+	}()
+
+	tables := make(map[string]bool)
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return "", err
+		}
+		// SQLite is case-insensitive about table names; the schema records whatever case created
+		// them, so compare in one case and return the name this code expects to query.
+		tables[strings.ToLower(name)] = true
+	}
+	if err := rows.Err(); err != nil {
+		return "", err
+	}
+
+	switch {
+	case tables["history_items"] && tables["history_visits"]:
+		return "safari", nil
+	case tables["moz_places"]:
+		return "moz_places", nil
+	case tables["urls"]:
+		return "urls", nil
+	case tables["history"]:
+		return "History", nil
+	}
+	return "", errors.New("no recognised browser history table found")
 }
 
 func importDB(databases []DBToImport, cmd *cobra.Command, startDate *time.Time) {

--- a/cmd/browser.go
+++ b/cmd/browser.go
@@ -213,6 +213,12 @@ func importHistoryFile(file_path string, cmd *cobra.Command, startDate *time.Tim
 // checked first because it is the only one identified by a pair of tables, so a match is
 // unambiguous.
 func detectHistoryTable(path string) (_ string, err error) {
+	// Before opening it, not after: a path-only import reaches here first, and without this the
+	// driver's "unable to open database file" would arrive ahead of any explanation.
+	if err := browserHistoryReadable(path); err != nil {
+		return "", err
+	}
+
 	db, err := sql.Open("sqlite3", fmt.Sprintf("file:%s?immutable=1&mode=ro", path))
 	if err != nil {
 		return "", fmt.Errorf("open database: %w", err)
@@ -593,22 +599,31 @@ func browserImportStartDate(cmd *cobra.Command) (*time.Time, error) {
 // browserHistoryReadable reports why a history database cannot be read, or nil if it can.
 //
 // sql.Open is lazy, so a file the process may not read fails much later and much less clearly —
-// the driver reports "unable to open database file", which on macOS sends people looking at file
-// permissions when the cause is that ~/Library/Safari is protected by the system's privacy
-// controls and no chmod will help. Opening the file here turns that into an answer.
+// the driver reports "unable to open database file", which sends people looking at file
+// permissions. On Safari's history that is the wrong place to look: the directory is protected by
+// macOS privacy controls and no chmod will help. Opening the file here turns that into an answer.
+//
+// The hint is limited to Safari deliberately. A permission error on a Chrome profile is an ordinary
+// permission error, and telling somebody to open the Full Disk Access pane would send them off to
+// change a system setting that was never the problem.
 func browserHistoryReadable(path string) error {
 	f, err := os.Open(path)
 	if err == nil {
 		return f.Close()
 	}
-	if runtime.GOOS == "darwin" && errors.Is(err, os.ErrPermission) {
+	if runtime.GOOS == "darwin" && errors.Is(err, os.ErrPermission) && isSafariHistoryPath(path) {
 		return fmt.Errorf(
-			"%w: on macOS, reading this database requires Full Disk Access for the terminal or "+
+			"%w: reading Safari's history requires Full Disk Access for the terminal or "+
 				"application running hister (System Settings > Privacy & Security > Full Disk Access)",
 			err,
 		)
 	}
 	return err
+}
+
+// isSafariHistoryPath reports whether a path is inside Safari's protected data directory.
+func isSafariHistoryPath(path string) bool {
+	return strings.Contains(filepath.ToSlash(strings.ToLower(path)), "/library/safari/")
 }
 
 func browserImportURLQuery(table string, minVisit int, startDate *time.Time) (string, error) {
@@ -1175,6 +1190,8 @@ func getBrowserType(path string) string {
 		return "opera"
 	} else if strings.Contains(path, "ladybird") {
 		return "ladybird"
+	} else if strings.Contains(path, "safari") {
+		return "safari"
 	} else {
 		return "unknown"
 	}

--- a/cmd/browser.go
+++ b/cmd/browser.go
@@ -36,10 +36,12 @@ Usage:
   hister import browser DB_PATH                auto-detect browser type
   hister import browser BROWSER_TYPE DB_PATH   import a browser type with a specific database path
 
-Browser types supported for automatic detection: firefox, chrome, chromium, brave, edge, vivaldi, opera, zen, waterfox, ladybird
+Browser types supported for automatic detection: firefox, chrome, chromium, brave, edge, vivaldi, opera, zen, waterfox, ladybird, safari
 
 The Firefox URL database is usually located at ~/.mozilla/firefox/*.default/places.sqlite
 The Chrome/Chromium URL database is usually located at ~/.config/chromium/Default/History
+The Safari URL database is located at ~/Library/Safari/History.db (macOS only), and reading it
+requires Full Disk Access for the terminal or application running hister
 
 Use --start-date (format: YYYY-MM-DD) to only import URLs whose most recent
 recorded visit is on or after the given date.
@@ -395,13 +397,33 @@ func importDB(databases []DBToImport, cmd *cobra.Command, startDate *time.Time) 
 	}
 }
 
-type browserHistoryTimestampSchema struct {
-	column             string
+// browserHistorySource describes where a browser keeps the two things an import needs: the URL,
+// and when that URL was last visited.
+//
+// Most browsers keep both in one flat table, so from is empty and the table name is used as the
+// FROM clause directly. Safari does not: it holds URLs in history_items and one row per visit in
+// history_visits, so it needs a join. Expressing that as a derived table keeps every other
+// browser's query byte for byte what it was.
+type browserHistorySource struct {
+	// from is the FROM clause. Empty means the table name itself.
+	from string
+	// column is the last-visit timestamp as exposed by from.
+	column string
+	// unitsPerSecond and epochOffsetSeconds convert a Unix timestamp into the browser's own
+	// representation: (unix + epochOffsetSeconds) * unitsPerSecond.
 	unitsPerSecond     int64
 	epochOffsetSeconds int64
 }
 
-var browserHistoryTimestampSchemas = map[string]browserHistoryTimestampSchema{
+// fromExpr returns the FROM clause for a source reached under table.
+func (s browserHistorySource) fromExpr(table string) string {
+	if s.from != "" {
+		return s.from
+	}
+	return table
+}
+
+var browserHistorySources = map[string]browserHistorySource{
 	"history": {
 		column:         "last_visited_time",
 		unitsPerSecond: 1_000,
@@ -414,6 +436,26 @@ var browserHistoryTimestampSchemas = map[string]browserHistoryTimestampSchema{
 		column:             "last_visit_time",
 		unitsPerSecond:     1_000_000,
 		epochOffsetSeconds: 11_644_473_600,
+	},
+	// Safari, and the reason from exists.
+	//
+	// The visits are reduced to the most recent one per URL so the derived table has the same
+	// shape as every other browser's: one row per URL, carrying visit_count so --min-visit
+	// keeps working.
+	//
+	// Its epoch offset is NEGATIVE because Safari counts from 2001-01-01, the Core Data epoch,
+	// rather than from 1970 — a Unix timestamp is 978,307,200 seconds further along than the
+	// same moment expressed in Safari's terms.
+	"safari": {
+		from: "(SELECT history_items.url AS url, " +
+			"history_items.visit_count AS visit_count, " +
+			"MAX(history_visits.visit_time) AS last_visit_time " +
+			"FROM history_items " +
+			"JOIN history_visits ON history_visits.history_item = history_items.id " +
+			"GROUP BY history_items.id) AS safari_history",
+		column:             "last_visit_time",
+		unitsPerSecond:     1,
+		epochOffsetSeconds: -978_307_200,
 	},
 }
 
@@ -431,6 +473,15 @@ func prepareBrowserImports(
 			issues = append(issues, browserImportPreparationIssue{
 				databaseFile: database.databaseFile,
 				err:          fmt.Errorf("create browser history query: %w", err),
+			})
+			continue
+		}
+
+		if err := browserHistoryReadable(database.databaseFile); err != nil {
+			issues = append(issues, browserImportPreparationIssue{
+				databaseFile: database.databaseFile,
+				query:        q,
+				err:          fmt.Errorf("open database: %w", err),
 			})
 			continue
 		}
@@ -488,8 +539,36 @@ func browserImportStartDate(cmd *cobra.Command) (*time.Time, error) {
 	return &startDate, nil
 }
 
+// browserHistoryReadable reports why a history database cannot be read, or nil if it can.
+//
+// sql.Open is lazy, so a file the process may not read fails much later and much less clearly —
+// the driver reports "unable to open database file", which on macOS sends people looking at file
+// permissions when the cause is that ~/Library/Safari is protected by the system's privacy
+// controls and no chmod will help. Opening the file here turns that into an answer.
+func browserHistoryReadable(path string) error {
+	f, err := os.Open(path)
+	if err == nil {
+		return f.Close()
+	}
+	if runtime.GOOS == "darwin" && errors.Is(err, os.ErrPermission) {
+		return fmt.Errorf(
+			"%w: on macOS, reading this database requires Full Disk Access for the terminal or "+
+				"application running hister (System Settings > Privacy & Security > Full Disk Access)",
+			err,
+		)
+	}
+	return err
+}
+
 func browserImportURLQuery(table string, minVisit int, startDate *time.Time) (string, error) {
-	q := fmt.Sprintf("SELECT DISTINCT url FROM %s WHERE (url LIKE 'http://%%' OR url LIKE 'https://%%')", table)
+	// An unknown table is still usable: it is passed through as the FROM clause, which is what
+	// lets a caller name a table this code has never heard of. Only date filtering needs to know
+	// the schema, so only date filtering fails on one.
+	source, known := browserHistorySources[strings.ToLower(table)]
+	q := fmt.Sprintf(
+		"SELECT DISTINCT url FROM %s WHERE (url LIKE 'http://%%' OR url LIKE 'https://%%')",
+		source.fromExpr(table),
+	)
 	if minVisit > 1 {
 		q += fmt.Sprintf(" AND visit_count >= %d", minVisit)
 	}
@@ -497,12 +576,11 @@ func browserImportURLQuery(table string, minVisit int, startDate *time.Time) (st
 		return q, nil
 	}
 
-	schema, ok := browserHistoryTimestampSchemas[strings.ToLower(table)]
-	if !ok {
+	if !known {
 		return "", fmt.Errorf("start date filtering is not supported for browser history table %q", table)
 	}
-	startTimestamp := (startDate.Unix() + schema.epochOffsetSeconds) * schema.unitsPerSecond
-	q += fmt.Sprintf(" AND %s >= %d", schema.column, startTimestamp)
+	startTimestamp := (startDate.Unix() + source.epochOffsetSeconds) * source.unitsPerSecond
+	q += fmt.Sprintf(" AND %s >= %d", source.column, startTimestamp)
 	return q, nil
 }
 
@@ -681,12 +759,25 @@ func getDBPaths() []browserDB {
 	chromium_table := "urls"
 	firefox_table := "moz_places"
 	ladybird_table := "History"
+	safari_table := "safari"
 
 	switch runtime.GOOS {
 	default:
 		log.Fatal().Msgf("Failed to detect os")
 	case "darwin":
 		candidates = []browserDBCandidates{
+			// safari
+			//
+			// One fixed location, with no profile directories to glob: Safari keeps a single
+			// history database per user. Reading it requires Full Disk Access — see
+			// browserHistoryReadable.
+			{
+				"Safari",
+				safari_table,
+				[]string{
+					filepath.Join(home, "Library", "Safari", "History.db"),
+				},
+			},
 			// firefox
 			{
 				"Firefox",
@@ -959,6 +1050,8 @@ func browserTableName(browser string) string {
 		return "urls"
 	case "ladybird":
 		return "History"
+	case "safari":
+		return "safari"
 	}
 	return ""
 }

--- a/cmd/browser_test.go
+++ b/cmd/browser_test.go
@@ -5,7 +5,9 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 )
 
 func TestPrepareBrowserImportsContinuesAfterUnusableDatabase(t *testing.T) {
@@ -74,6 +76,118 @@ func writeBrowserHistoryFile(t *testing.T, path string, createTable bool, urls [
 	}
 	for _, u := range urls {
 		if _, err := db.Exec("INSERT INTO urls (url, visit_count) VALUES (?, 1)", u); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func TestBrowserImportURLQueryFlatSchemasUnchanged(t *testing.T) {
+	// A regression guard, not a feature test. Introducing a FROM expression for Safari must not
+	// alter a single byte of the query every other browser has always produced.
+	for _, table := range []string{"urls", "moz_places", "history", "some_unknown_table"} {
+		got, err := browserImportURLQuery(table, 0, nil)
+		if err != nil {
+			t.Fatalf("browserImportURLQuery(%q) returned error: %v", table, err)
+		}
+		want := "SELECT DISTINCT url FROM " + table +
+			" WHERE (url LIKE 'http://%' OR url LIKE 'https://%')"
+		if got != want {
+			t.Fatalf("browserImportURLQuery(%q) = %q, want %q", table, got, want)
+		}
+	}
+}
+
+func TestBrowserImportURLQuerySafariJoinsVisits(t *testing.T) {
+	got, err := browserImportURLQuery("safari", 0, nil)
+	if err != nil {
+		t.Fatalf("browserImportURLQuery(safari) returned error: %v", err)
+	}
+	for _, want := range []string{"history_items", "history_visits", "MAX(history_visits.visit_time)"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("browserImportURLQuery(safari) = %q, missing %q", got, want)
+		}
+	}
+}
+
+func TestBrowserImportURLQuerySafariUsesCoreDataEpoch(t *testing.T) {
+	// Safari counts seconds from 2001-01-01, so a Unix timestamp is 978,307,200 seconds ahead of
+	// the same moment in its terms. Hard-coding the expected value rather than recomputing it
+	// means a sign flip in the offset fails here rather than silently importing the wrong decade.
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	got, err := browserImportURLQuery("safari", 0, &start)
+	if err != nil {
+		t.Fatalf("browserImportURLQuery(safari) returned error: %v", err)
+	}
+	const want = "AND last_visit_time >= 788918400"
+	if !strings.Contains(got, want) {
+		t.Fatalf("browserImportURLQuery(safari) = %q, missing %q", got, want)
+	}
+}
+
+func TestPrepareBrowserImportsReadsSafariHistory(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "Safari", "History.db")
+	writeSafariHistoryFile(t, path, map[string]int64{
+		// visit_time values are seconds since 2001-01-01.
+		"https://example.com/kept":    788918400 + 86400, // a day after the cut-off below
+		"https://example.com/too-old": 788918400 - 86400,
+	})
+
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	choices, issues := prepareBrowserImports([]DBToImport{
+		{table: "safari", databaseFile: path},
+	}, 0, &start, nil)
+	if len(issues) != 0 {
+		t.Fatalf("prepareBrowserImports() returned issues: %v", issues)
+	}
+	if len(choices) != 1 {
+		t.Fatalf("prepareBrowserImports() returned %d choices, want 1", len(choices))
+	}
+	defer func() {
+		if err := choices[0].db.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}()
+	if choices[0].urls != 1 {
+		t.Fatalf("prepareBrowserImports() URL count = %d, want 1 (the older visit should be filtered out)", choices[0].urls)
+	}
+}
+
+func writeSafariHistoryFile(t *testing.T, path string, visits map[string]int64) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	db, err := sql.Open("sqlite3", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := db.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}()
+	// The two tables Safari actually uses, with only the columns the import reads.
+	if _, err := db.Exec(
+		"CREATE TABLE history_items (id INTEGER PRIMARY KEY, url TEXT, visit_count INTEGER)",
+	); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(
+		"CREATE TABLE history_visits (id INTEGER PRIMARY KEY, history_item INTEGER, visit_time REAL)",
+	); err != nil {
+		t.Fatal(err)
+	}
+	id := 0
+	for url, visitTime := range visits {
+		id++
+		if _, err := db.Exec(
+			"INSERT INTO history_items (id, url, visit_count) VALUES (?, ?, 1)", id, url,
+		); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := db.Exec(
+			"INSERT INTO history_visits (history_item, visit_time) VALUES (?, ?)", id, visitTime,
+		); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/cmd/browser_test.go
+++ b/cmd/browser_test.go
@@ -192,3 +192,66 @@ func writeSafariHistoryFile(t *testing.T, path string, visits map[string]int64) 
 		}
 	}
 }
+
+func TestDetectHistoryTableIdentifiesByContent(t *testing.T) {
+	// Safari and Ladybird both call their database History.db, so a name cannot separate them.
+	// This is the case ad3lre reported on #694: a path-only import of Safari's history was read
+	// as Ladybird's and failed with "no such table: History".
+	dir := t.TempDir()
+
+	safari := filepath.Join(dir, "safari", "History.db")
+	writeSafariHistoryFile(t, safari, map[string]int64{"https://example.com": 1})
+
+	ladybird := filepath.Join(dir, "ladybird", "History.db")
+	writeTables(t, ladybird, "CREATE TABLE History (url TEXT, last_visited_time INTEGER)")
+
+	chrome := filepath.Join(dir, "chrome", "History")
+	writeTables(t, chrome, "CREATE TABLE urls (url TEXT, visit_count INTEGER)")
+
+	firefox := filepath.Join(dir, "firefox", "places.sqlite")
+	writeTables(t, firefox, "CREATE TABLE moz_places (url TEXT, last_visit_date INTEGER)")
+
+	for _, tc := range []struct{ name, path, want string }{
+		{"safari", safari, "safari"},
+		{"ladybird", ladybird, "History"},
+		{"chrome", chrome, "urls"},
+		{"firefox", firefox, "moz_places"},
+	} {
+		got, err := detectHistoryTable(tc.path)
+		if err != nil {
+			t.Fatalf("detectHistoryTable(%s) returned error: %v", tc.name, err)
+		}
+		if got != tc.want {
+			t.Fatalf("detectHistoryTable(%s) = %q, want %q", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestDetectHistoryTableRejectsUnknownSchema(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "History.db")
+	writeTables(t, path, "CREATE TABLE something_else (a TEXT)")
+	if _, err := detectHistoryTable(path); err == nil {
+		t.Fatal("detectHistoryTable() accepted a database with no history table")
+	}
+}
+
+func writeTables(t *testing.T, path string, statements ...string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	db, err := sql.Open("sqlite3", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := db.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}()
+	for _, stmt := range statements {
+		if _, err := db.Exec(stmt); err != nil {
+			t.Fatal(err)
+		}
+	}
+}

--- a/cmd/browser_test.go
+++ b/cmd/browser_test.go
@@ -255,3 +255,28 @@ func writeTables(t *testing.T, path string, statements ...string) {
 		}
 	}
 }
+
+func TestGetBrowserTypeRecognisesSafari(t *testing.T) {
+	// Without this the selection screen labels Safari "unknown", and typing "safari" at the
+	// exclusion prompt matches nothing.
+	got := getBrowserType("/Users/someone/Library/Safari/History.db")
+	if got != "safari" {
+		t.Fatalf("getBrowserType() = %q, want %q", got, "safari")
+	}
+}
+
+func TestIsSafariHistoryPath(t *testing.T) {
+	// The Full Disk Access hint is only true for Safari's protected directory. Anywhere else, a
+	// permission error is an ordinary permission error and the hint would send someone to change
+	// a system setting that was never the problem.
+	for path, want := range map[string]bool{
+		"/Users/someone/Library/Safari/History.db":                         true,
+		"/Users/someone/library/safari/History.db":                         true,
+		"/Users/someone/Library/Application Support/Google/Chrome/History": false,
+		"/tmp/History.db": false,
+	} {
+		if got := isSafariHistoryPath(path); got != want {
+			t.Fatalf("isSafariHistoryPath(%q) = %v, want %v", path, got, want)
+		}
+	}
+}

--- a/webui/website/src/content/docs/import.md
+++ b/webui/website/src/content/docs/import.md
@@ -136,10 +136,6 @@ hister import browser safari
 
 **Reading it requires Full Disk Access** for the terminal or application running Hister, granted under System Settings > Privacy & Security > Full Disk Access. Without it the import fails with a permission error naming the setting.
 
-Safari splits its history across two tables, storing one row per visit, and counts timestamps from 2001-01-01 rather than 1970. Hister handles all of this internally; `--start-date` and `--min-visit` behave exactly as they do for any other browser.
-
-Safari has no Hister browser extension, so an import is a snapshot rather than a running feed: re-run it to pick up pages visited since.
-
 Use `--min-visit N` to import only URLs that have at least `N` recorded visits.
 Use `--start-date YYYY-MM-DD` to import only URLs whose most recent recorded
 visit is on or after that date:

--- a/webui/website/src/content/docs/import.md
+++ b/webui/website/src/content/docs/import.md
@@ -122,7 +122,23 @@ hister import browser ~/.mozilla/firefox/example.default/places.sqlite
 hister import browser firefox ~/.mozilla/firefox/example.default/places.sqlite
 ```
 
-Firefox stores history in `places.sqlite` inside its profile directory. Chromium based browsers usually store it in a file named `History` inside their profile directory.
+Firefox stores history in `places.sqlite` inside its profile directory. Chromium based browsers usually store it in a file named `History` inside their profile directory. Safari stores it in `~/Library/Safari/History.db`.
+
+When only a path is given, the browser is identified by the tables the database contains rather than by its filename. This matters because the filenames overlap: Safari and Ladybird both use `History.db`.
+
+### Safari
+
+Safari is supported on macOS. It keeps a single history database per user, so there are no profile directories to choose between:
+
+```bash
+hister import browser safari
+```
+
+**Reading it requires Full Disk Access** for the terminal or application running Hister, granted under System Settings > Privacy & Security > Full Disk Access. Without it the import fails with a permission error naming the setting.
+
+Safari splits its history across two tables, storing one row per visit, and counts timestamps from 2001-01-01 rather than 1970. Hister handles all of this internally; `--start-date` and `--min-visit` behave exactly as they do for any other browser.
+
+Safari has no Hister browser extension, so an import is a snapshot rather than a running feed: re-run it to pick up pages visited since.
 
 Use `--min-visit N` to import only URLs that have at least `N` recorded visits.
 Use `--start-date YYYY-MM-DD` to import only URLs whose most recent recorded


### PR DESCRIPTION
Safari is the default browser on macOS and the only major one `hister import browser` could not
read. This adds it.

**Not related to #49 / #46.** Those are about running the extension as a Safari Web Extension for
live indexing, and the CORS preflight that blocks it. This is the bulk import path and touches
nothing they touch — I mention it only because "Safari" in a title invites the assumption.

### Why the change has this shape

The import turned out to need very little from a browser. `browserImportURLQuery` builds the whole
thing as:

```sql
SELECT DISTINCT url FROM <table> WHERE (url LIKE 'http://%' OR url LIKE 'https://%')
```

plus optional `visit_count` and timestamp clauses. It reads the URL and nothing else — no title, no
visit dates — because hister fetches and indexes each page itself. So supporting a browser is
mostly a question of what shape its history is in.

Safari's is the one shape that does not fit: URLs live in `history_items`, one row per visit in
`history_visits`. There is no single table name that answers the query.

Rather than branch inside the query builder, `browserHistoryTimestampSchema` becomes
`browserHistorySource`, which can also carry a FROM clause. Browsers with a flat schema leave it
empty and use their table name exactly as before — including the existing pass-through that lets a
caller name a table this code has never heard of. Safari supplies a derived table that joins the
two and reduces visits to the most recent per URL, so it presents the same one-row-per-URL shape
everything else already has, `visit_count` included so `--min-visit` keeps working.

Its epoch offset is negative: Safari counts seconds from 2001-01-01 rather than 1970, so a Unix
timestamp is 978,307,200 seconds further along than the same moment in its terms. The existing
`(unix + offset) * units` arithmetic handles that unchanged.

### The Full Disk Access diagnostic

`~/Library/Safari/History.db` is protected by TCC, so hister cannot read it unless the terminal or
application running it has been granted Full Disk Access. `sql.Open` is lazy, so without the grant
the failure surfaces later as the driver's "unable to open database file" — which on macOS reads as
a file-permission problem and is not one. No `chmod` fixes it. Opening the file up front turns that
into an error that names the setting.

**Happy to split this out** if you would rather keep the PR to one concern. It is here because it
is the first thing a macOS user will hit, and the error it replaces sends people in the wrong
direction.

### Testing

`go build ./...`, `go test ./...` and `golangci-lint run ./cmd/...` are all clean.

Four tests added, the most important being `TestBrowserImportURLQueryFlatSchemasUnchanged` — a
regression guard asserting that introducing a FROM expression does not alter one byte of the query
the other browsers produce, unknown table names included. That is the actual risk this refactor
carries.

`TestPrepareBrowserImportsReadsSafariHistory` runs end to end against a Safari-shaped database with
one visit either side of a `--start-date` cut-off, so the date filter is exercised through the
derived table rather than only asserted about.

### Notes for review

- `visit_time` is stored as `REAL` in Safari, and the test fixture declares it that way. The
  comparison against an integer timestamp works because SQLite compares numerically across storage
  classes, but it is worth knowing rather than discovering.
- The macOS detection path and the Full Disk Access branch are not covered by tests: the first
  needs `GOOS == "darwin"` and a real home directory, the second an unreadable file. `getDBPaths`
  has no existing coverage either, so this is consistent with the file rather than a new gap — but
  say if you would like it addressed.
- The derived table is a string literal in what was previously a table of constants. The tidier
  alternative gives every browser an explicit FROM clause naming its own table, at the cost of
  touching all of them. I took the smaller diff; happy to switch if you prefer the other trade.
