### PR TITLE
Add a Safari companion

### DIFF
--- a/cmd/companion.go
+++ b/cmd/companion.go
@@ -7,7 +7,10 @@ import (
 	"os/signal"
 
 	qutebrowsercompanion "github.com/asciimoo/hister/cmd/companion/qutebrowser"
+	safaricompanion "github.com/asciimoo/hister/cmd/companion/safari"
+	"github.com/asciimoo/hister/server/crawler"
 
+	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 )
 
@@ -104,5 +107,108 @@ func qutebrowserCompanionOptions(cmd *cobra.Command) qutebrowsercompanion.Option
 	opts.RequestTimeout, _ = cmd.Flags().GetDuration("request-timeout")
 	opts.MaxFaviconBytes, _ = cmd.Flags().GetInt64("max-favicon-bytes")
 	opts.UserAgent = UserAgent
+	return opts
+}
+
+var companionSafariCmd = &cobra.Command{
+	Use:   "safari",
+	Short: "Index newly visited Safari pages by watching its history",
+	Long: `Watch Safari's history database and index pages as they are visited.
+
+Safari has no Hister extension, so an index built with "hister import browser safari"
+goes stale as soon as the import finishes. This follows the same database and indexes
+new visits as they appear.
+
+Only the URL is available, so each page is fetched and indexed the way "hister index"
+would fetch it: a page behind a login is indexed as an anonymous visitor sees it.
+
+Reading Safari's history requires Full Disk Access for the terminal or application
+running hister. Destination settings come from the global --server-url, --token, and
+--client-timeout options.`,
+	Args: cobra.NoArgs,
+	Run: func(cmd *cobra.Command, _ []string) {
+		ctx, stop := signal.NotifyContext(cmd.Context(), os.Interrupt)
+		defer stop()
+
+		// One crawler for the life of the command, matching how "hister index" reuses a single
+		// crawler across a URL list so a backend with a persistent connection is not rebuilt
+		// for every page.
+		cr, err := crawler.New(&cfg.Crawler, nil)
+		if err != nil {
+			exit(1, "Failed to create crawler: "+err.Error())
+			return
+		}
+		defer func() {
+			if err := cr.Close(); err != nil {
+				log.Warn().Err(err).Msg("crawler close error")
+			}
+		}()
+
+		opts := safariCompanionOptions(cmd)
+		indexer := &crawlingURLIndexer{crawler: cr, label: opts.Label}
+		if err := safaricompanion.Run(ctx, opts, indexer); err != nil &&
+			!errors.Is(err, context.Canceled) {
+			exit(1, "Safari companion error: "+err.Error())
+		}
+	},
+}
+
+// crawlingURLIndexer fetches and indexes URLs, which is what the Safari companion needs and the
+// qutebrowser companion does not: DevTools hands qutebrowser a rendered page, while Safari's
+// history yields only an address.
+type crawlingURLIndexer struct {
+	crawler crawler.Crawler
+	label   string
+}
+
+func (i *crawlingURLIndexer) IndexURLs(ctx context.Context, urls []string) error {
+	c := newClient()
+	for _, u := range urls {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		// Revisiting a page is the common case, so ask before fetching. Without this the
+		// companion would re-crawl a site every time it was opened.
+		exists, err := c.DocumentExists(u)
+		if err != nil {
+			log.Warn().Err(err).Str("URL", u).Msg("Failed to check if URL is already indexed")
+		} else if exists {
+			continue
+		}
+		if err := indexURL(ctx, i.crawler, u, i.label); err != nil {
+			// A page that will not fetch — a private host, a login wall, a 404 — must not stop
+			// the ones after it, and must not make the whole pass fail and be retried forever.
+			log.Warn().Err(err).Str("URL", u).Msg("Failed to index visited URL")
+		}
+	}
+	return nil
+}
+
+func addSafariCompanionFlags(cmd *cobra.Command) {
+	defaults := safaricompanion.DefaultOptions()
+	cmd.Flags().String("history-path", defaults.HistoryPath, "Safari history database")
+	cmd.Flags().String("state-path", defaults.StatePath, "file recording the last visit indexed")
+	cmd.Flags().Duration(
+		"poll-interval",
+		defaults.PollInterval,
+		"how often the history database is checked for new visits",
+	)
+	cmd.Flags().Int("batch-size", defaults.BatchSize, "how many URLs are indexed at a time")
+	cmd.Flags().Bool(
+		"catch-up",
+		defaults.CatchUp,
+		"index the whole existing history on first run instead of only new visits",
+	)
+	cmd.Flags().String("label", defaults.Label, "label applied to indexed documents")
+}
+
+func safariCompanionOptions(cmd *cobra.Command) safaricompanion.Options {
+	opts := safaricompanion.DefaultOptions()
+	opts.HistoryPath, _ = cmd.Flags().GetString("history-path")
+	opts.StatePath, _ = cmd.Flags().GetString("state-path")
+	opts.PollInterval, _ = cmd.Flags().GetDuration("poll-interval")
+	opts.BatchSize, _ = cmd.Flags().GetInt("batch-size")
+	opts.CatchUp, _ = cmd.Flags().GetBool("catch-up")
+	opts.Label, _ = cmd.Flags().GetString("label")
 	return opts
 }

--- a/cmd/companion/safari/companion.go
+++ b/cmd/companion/safari/companion.go
@@ -1,0 +1,262 @@
+// Package safari watches Safari's browsing history and indexes newly visited pages.
+//
+// Safari has no Hister extension, so a Safari user's index is frozen at whatever the last
+// `hister import browser safari` captured. It does, however, write every visit to a SQLite
+// database of its own, which makes that file a live feed. This follows it.
+//
+// It is a companion in the same sense qutebrowser's is — a local process that keeps the index in
+// step with a browser Hister cannot otherwise reach — but it works from the other end. qutebrowser
+// hands over rendered pages through DevTools; Safari hands over addresses, so the pages have to be
+// fetched. That is why this takes a URLIndexer rather than a DocumentSubmitter, and it means a
+// page behind a login indexes as whatever an anonymous client sees.
+package safari
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/rs/zerolog/log"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+// coreDataEpoch is 2001-01-01 in Unix seconds. Safari records visit times as seconds from there,
+// the Core Data reference date, rather than from 1970.
+const coreDataEpoch = 978_307_200
+
+type state struct {
+	LastVisitTime float64 `json:"last_visit_time"`
+	LastRun       string  `json:"last_run"`
+}
+
+// Run follows Safari's history until ctx is cancelled.
+func Run(ctx context.Context, input Options, indexer URLIndexer) error {
+	opts, err := normalizeOptions(input)
+	if err != nil {
+		return err
+	}
+
+	log.Info().
+		Str("history", opts.historyPath).
+		Dur("interval", opts.pollInterval).
+		Msg("Watching Safari history")
+
+	ticker := time.NewTicker(opts.pollInterval)
+	defer ticker.Stop()
+
+	var lastFingerprint string
+	catchUp := opts.catchUp
+	for {
+		// The database is only read when something has written to it. An idle machine therefore
+		// costs three stat() calls per interval rather than copying a database that has not
+		// changed, which matters when the interval is seconds and the file is tens of megabytes.
+		if fingerprint := sourceFingerprint(opts.historyPath); fingerprint != lastFingerprint {
+			lastFingerprint = fingerprint
+			if err := pass(ctx, opts, indexer, catchUp); err != nil {
+				if ctx.Err() != nil {
+					return ctx.Err()
+				}
+				// One bad pass must not end the companion: it is meant to still be running
+				// tomorrow, and the next poll may well succeed.
+				log.Warn().Err(err).Msg("Safari history pass failed")
+			}
+			catchUp = false
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}
+
+// sourceFingerprint summarises the modification times of the history database and its
+// write-ahead log.
+//
+// The -wal file is the one that moves. SQLite in WAL mode appends there and folds the changes into
+// the main database only at a checkpoint, so watching History.db alone would miss visits for
+// minutes and then deliver them in a lump.
+func sourceFingerprint(path string) string {
+	var fingerprint strings.Builder
+	for _, suffix := range []string{"", "-wal", "-shm"} {
+		if info, err := os.Stat(path + suffix); err == nil {
+			fmt.Fprintf(&fingerprint, "%d:", info.ModTime().UnixNano())
+			continue
+		}
+		fingerprint.WriteString("0:")
+	}
+	return fingerprint.String()
+}
+
+func pass(ctx context.Context, opts normalizedOptions, indexer URLIndexer, catchUp bool) error {
+	current := loadState(opts.statePath)
+	if current.LastVisitTime == 0 && !catchUp {
+		// Start from now rather than from the beginning of time. An existing history is what
+		// `hister import browser safari` is for; replaying it here, a batch at a time, is not what
+		// "watch for new pages" means and would crawl thousands of pages unasked.
+		current.LastVisitTime = float64(time.Now().Unix() - coreDataEpoch)
+		log.Info().Msg("No previous state; indexing visits from now on")
+	}
+
+	urls, newest, err := visitsSince(opts.historyPath, current.LastVisitTime)
+	if err != nil {
+		return err
+	}
+
+	for start := 0; start < len(urls); start += opts.batchSize {
+		end := min(start+opts.batchSize, len(urls))
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		batch := urls[start:end]
+		if err := indexer.IndexURLs(ctx, batch); err != nil {
+			// The state is not advanced past a batch that failed, so the next pass retries it.
+			return fmt.Errorf("index %d url(s): %w", len(batch), err)
+		}
+		log.Info().Int("count", len(batch)).Msg("Indexed newly visited pages")
+	}
+
+	current.LastVisitTime = newest
+	return saveState(opts.statePath, current)
+}
+
+// visitsSince returns URLs visited after the given Safari timestamp, and the newest visit seen.
+//
+// Read from a copy. Safari holds the database open and its write-ahead log may carry visits not
+// yet folded into the main file, so opening the original as immutable — which is what the browser
+// import does, correctly, for a one-off read — would silently miss exactly the recent visits this
+// exists to catch. Copying all three parts takes a consistent snapshot without asking anybody to
+// quit their browser.
+func visitsSince(historyPath string, after float64) (_ []string, _ float64, err error) {
+	dir, err := os.MkdirTemp("", "hister-safari-companion-")
+	if err != nil {
+		return nil, after, err
+	}
+	defer func() {
+		if removeErr := os.RemoveAll(dir); removeErr != nil && err == nil {
+			err = removeErr
+		}
+	}()
+
+	work := filepath.Join(dir, "History.db")
+	for _, suffix := range []string{"", "-wal", "-shm"} {
+		if copyErr := copyFile(historyPath+suffix, work+suffix); copyErr != nil {
+			if suffix == "" {
+				return nil, after, fmt.Errorf("copy safari history: %w", copyErr)
+			}
+			// A missing -wal or -shm only means SQLite has checkpointed. Not a problem.
+		}
+	}
+
+	db, err := sql.Open("sqlite3", "file:"+work+"?mode=ro")
+	if err != nil {
+		return nil, after, err
+	}
+	defer func() {
+		if closeErr := db.Close(); closeErr != nil && err == nil {
+			err = closeErr
+		}
+	}()
+
+	rows, err := db.Query(
+		"SELECT history_items.url, history_visits.visit_time "+
+			"FROM history_visits "+
+			"JOIN history_items ON history_items.id = history_visits.history_item "+
+			"WHERE history_visits.visit_time > ? "+
+			"AND (history_items.url LIKE 'http://%' OR history_items.url LIKE 'https://%') "+
+			"ORDER BY history_visits.visit_time",
+		after,
+	)
+	if err != nil {
+		return nil, after, err
+	}
+	defer func() {
+		if closeErr := rows.Close(); closeErr != nil && err == nil {
+			err = closeErr
+		}
+	}()
+
+	newest := after
+	seen := make(map[string]bool)
+	var urls []string
+	for rows.Next() {
+		var rawURL string
+		var visitTime float64
+		if err := rows.Scan(&rawURL, &visitTime); err != nil {
+			return nil, newest, err
+		}
+		if visitTime > newest {
+			newest = visitTime
+		}
+		// Reloading a page records several visits to one URL; only the first is news. Anything
+		// beyond this is left to the indexer, which already skips what it holds.
+		if seen[rawURL] {
+			continue
+		}
+		seen[rawURL] = true
+		urls = append(urls, rawURL)
+	}
+	return urls, newest, rows.Err()
+}
+
+func copyFile(src, dst string) (err error) {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if closeErr := in.Close(); closeErr != nil && err == nil {
+			err = closeErr
+		}
+	}()
+	out, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if closeErr := out.Close(); closeErr != nil && err == nil {
+			err = closeErr
+		}
+	}()
+	_, err = io.Copy(out, in)
+	return err
+}
+
+func loadState(path string) state {
+	var current state
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return current
+	}
+	if err := json.Unmarshal(data, &current); err != nil {
+		log.Warn().Err(err).Str("path", path).Msg("Ignoring unreadable companion state")
+		return state{}
+	}
+	return current
+}
+
+func saveState(path string, current state) error {
+	current.LastRun = time.Now().Format(time.RFC3339)
+	data, err := json.MarshalIndent(current, "", "  ")
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	// Written to a temporary file and renamed, so an interrupted write cannot leave a truncated
+	// state behind and send the next run back to the beginning.
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o600); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
+}

--- a/cmd/companion/safari/companion_test.go
+++ b/cmd/companion/safari/companion_test.go
@@ -1,0 +1,222 @@
+package safari
+
+import (
+	"database/sql"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestVisitsSinceReturnsOnlyNewerVisits(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "History.db")
+	writeSafariHistory(t, path, []visit{
+		{url: "https://example.com/old", at: 1000},
+		{url: "https://example.com/new", at: 3000},
+	})
+
+	urls, newest, err := visitsSince(path, 2000)
+	if err != nil {
+		t.Fatalf("visitsSince() returned error: %v", err)
+	}
+	if len(urls) != 1 || urls[0] != "https://example.com/new" {
+		t.Fatalf("visitsSince() = %v, want only the newer URL", urls)
+	}
+	// The high-water mark must move to the newest visit SEEN, not to the newest returned, or a
+	// pass that filters everything out would replay the same rows forever.
+	if newest != 3000 {
+		t.Fatalf("visitsSince() newest = %v, want 3000", newest)
+	}
+}
+
+func TestVisitsSinceDeduplicatesRepeatVisits(t *testing.T) {
+	// Reloading a page records a visit each time. The companion should offer the URL once.
+	path := filepath.Join(t.TempDir(), "History.db")
+	writeSafariHistory(t, path, []visit{
+		{url: "https://example.com/page", at: 1100},
+		{url: "https://example.com/page", at: 1200},
+		{url: "https://example.com/page", at: 1300},
+	})
+
+	urls, _, err := visitsSince(path, 1000)
+	if err != nil {
+		t.Fatalf("visitsSince() returned error: %v", err)
+	}
+	if len(urls) != 1 {
+		t.Fatalf("visitsSince() returned %d URLs, want 1", len(urls))
+	}
+}
+
+func TestVisitsSinceIgnoresNonHTTPSchemes(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "History.db")
+	writeSafariHistory(t, path, []visit{
+		{url: "https://example.com/page", at: 1100},
+		{url: "file:///Users/someone/notes.txt", at: 1200},
+		{url: "about:blank", at: 1300},
+	})
+
+	urls, _, err := visitsSince(path, 1000)
+	if err != nil {
+		t.Fatalf("visitsSince() returned error: %v", err)
+	}
+	if len(urls) != 1 || urls[0] != "https://example.com/page" {
+		t.Fatalf("visitsSince() = %v, want only the http(s) URL", urls)
+	}
+}
+
+func TestVisitsSinceReadsWhileTheDatabaseIsOpen(t *testing.T) {
+	// Safari holds its history open, so the companion must not need exclusive access. Keeping a
+	// writable handle open across the call reproduces that.
+	path := filepath.Join(t.TempDir(), "History.db")
+	writeSafariHistory(t, path, []visit{{url: "https://example.com/page", at: 1100}})
+
+	held, err := sql.Open("sqlite3", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := held.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}()
+	if err := held.Ping(); err != nil {
+		t.Fatal(err)
+	}
+
+	urls, _, err := visitsSince(path, 1000)
+	if err != nil {
+		t.Fatalf("visitsSince() returned error while the database was open: %v", err)
+	}
+	if len(urls) != 1 {
+		t.Fatalf("visitsSince() returned %d URLs, want 1", len(urls))
+	}
+}
+
+func TestNormalizeOptionsRejectsMissingHistory(t *testing.T) {
+	// Reported when the command starts rather than once per poll forever.
+	_, err := normalizeOptions(Options{
+		HistoryPath: filepath.Join(t.TempDir(), "absent", "History.db"),
+		StatePath:   filepath.Join(t.TempDir(), "state.json"),
+	})
+	if err == nil {
+		t.Fatal("normalizeOptions() accepted a history path that does not exist")
+	}
+}
+
+func TestNormalizeOptionsFillsDefaults(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "History.db")
+	writeSafariHistory(t, path, nil)
+
+	opts, err := normalizeOptions(Options{
+		HistoryPath: path,
+		StatePath:   filepath.Join(t.TempDir(), "state.json"),
+	})
+	if err != nil {
+		t.Fatalf("normalizeOptions() returned error: %v", err)
+	}
+	if opts.pollInterval != defaultPollInterval {
+		t.Fatalf("pollInterval = %v, want %v", opts.pollInterval, defaultPollInterval)
+	}
+	if opts.batchSize != defaultBatchSize {
+		t.Fatalf("batchSize = %d, want %d", opts.batchSize, defaultBatchSize)
+	}
+}
+
+func TestStateRoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "nested", "state.json")
+	if err := saveState(path, state{LastVisitTime: 1234.5}); err != nil {
+		t.Fatalf("saveState() returned error: %v", err)
+	}
+	if got := loadState(path).LastVisitTime; got != 1234.5 {
+		t.Fatalf("loadState() = %v, want 1234.5", got)
+	}
+}
+
+func TestLoadStateToleratesRubbish(t *testing.T) {
+	// A truncated or hand-edited state file must not be fatal: the companion falls back to
+	// starting from now, which is the same thing it does on a first run.
+	path := filepath.Join(t.TempDir(), "state.json")
+	if err := os.WriteFile(path, []byte("{not json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if got := loadState(path).LastVisitTime; got != 0 {
+		t.Fatalf("loadState() = %v, want the zero value", got)
+	}
+}
+
+func TestSourceFingerprintTracksTheWriteAheadLog(t *testing.T) {
+	// The -wal file is where SQLite appends between checkpoints, so a fingerprint that ignored it
+	// would leave the companion asleep through a burst of browsing.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "History.db")
+	writeSafariHistory(t, path, nil)
+
+	before := sourceFingerprint(path)
+	if err := os.WriteFile(path+"-wal", []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if after := sourceFingerprint(path); after == before {
+		t.Fatal("sourceFingerprint() did not change when the -wal file appeared")
+	}
+}
+
+type visit struct {
+	url string
+	at  float64
+}
+
+func writeSafariHistory(t *testing.T, path string, visits []visit) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	db, err := sql.Open("sqlite3", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := db.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}()
+	// The two tables Safari uses, with only the columns the companion reads. visit_time is REAL,
+	// as Safari stores it.
+	if _, err := db.Exec(
+		"CREATE TABLE history_items (id INTEGER PRIMARY KEY, url TEXT, visit_count INTEGER)",
+	); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(
+		"CREATE TABLE history_visits (id INTEGER PRIMARY KEY, history_item INTEGER, visit_time REAL)",
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	items := map[string]int{}
+	for _, v := range visits {
+		id, ok := items[v.url]
+		if !ok {
+			id = len(items) + 1
+			items[v.url] = id
+			if _, err := db.Exec(
+				"INSERT INTO history_items (id, url, visit_count) VALUES (?, ?, 1)", id, v.url,
+			); err != nil {
+				t.Fatal(err)
+			}
+		}
+		if _, err := db.Exec(
+			"INSERT INTO history_visits (history_item, visit_time) VALUES (?, ?)", id, v.at,
+		); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func TestCoreDataEpochMatchesTheReferenceDate(t *testing.T) {
+	// 2001-01-01 UTC in Unix seconds. Hard-coded so a sign flip or a typo fails here rather than
+	// quietly indexing the wrong decade.
+	want := time.Date(2001, 1, 1, 0, 0, 0, 0, time.UTC).Unix()
+	if coreDataEpoch != want {
+		t.Fatalf("coreDataEpoch = %d, want %d", coreDataEpoch, want)
+	}
+}

--- a/cmd/companion/safari/options.go
+++ b/cmd/companion/safari/options.go
@@ -1,0 +1,147 @@
+package safari
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+const (
+	// defaultPollInterval is short because the point of a companion is that a page is searchable
+	// while you are still thinking about it. The cost of a poll that finds nothing is three
+	// stat() calls — see the modification-time check in Run.
+	defaultPollInterval = 10 * time.Second
+	// defaultBatchSize bounds how many URLs are handed over at once, so a burst of restored tabs
+	// becomes several crawls rather than one very long one.
+	defaultBatchSize = 25
+)
+
+// URLIndexer crawls and indexes URLs.
+//
+// Deliberately narrow, and deliberately not the client. The qutebrowser companion submits finished
+// documents because DevTools hands it the rendered page; Safari's history gives us only addresses,
+// so something has to fetch them. Keeping that behind an interface leaves this package free of the
+// crawler and testable without a network — the concrete implementation is wired in cmd, where the
+// crawl machinery already lives.
+type URLIndexer interface {
+	IndexURLs(ctx context.Context, urls []string) error
+}
+
+// Options configures Safari history monitoring.
+type Options struct {
+	// HistoryPath is Safari's history database. Empty means the standard location.
+	HistoryPath string
+	// StatePath records the most recent visit already seen, so a restart does not re-index.
+	// Empty means the standard location.
+	StatePath string
+	// PollInterval is how often the database is checked for changes.
+	PollInterval time.Duration
+	// BatchSize is the largest number of URLs handed to the indexer at once.
+	BatchSize int
+	// CatchUp indexes everything in the history on first run rather than only new visits.
+	// Off by default: an existing history belongs to `hister import browser safari`, and
+	// replaying months of it one batch at a time is not what "watch for new pages" means.
+	CatchUp bool
+	// Label is applied to indexed documents.
+	Label string
+}
+
+type normalizedOptions struct {
+	historyPath  string
+	statePath    string
+	pollInterval time.Duration
+	batchSize    int
+	catchUp      bool
+	label        string
+}
+
+// DefaultOptions returns the default Safari companion settings.
+func DefaultOptions() Options {
+	return Options{
+		HistoryPath:  DefaultHistoryPath(),
+		StatePath:    DefaultStatePath(),
+		PollInterval: defaultPollInterval,
+		BatchSize:    defaultBatchSize,
+		Label:        "safari",
+	}
+}
+
+// DefaultHistoryPath is where Safari keeps its history. One fixed location per user, with no
+// profile directories to search.
+func DefaultHistoryPath() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, "Library", "Safari", "History.db")
+}
+
+// DefaultStatePath is where the companion remembers how far it has read.
+func DefaultStatePath() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".local", "state", "hister", "safari-companion.json")
+}
+
+func normalizeOptions(input Options) (normalizedOptions, error) {
+	normalized := normalizedOptions{
+		historyPath:  input.HistoryPath,
+		statePath:    input.StatePath,
+		pollInterval: input.PollInterval,
+		batchSize:    input.BatchSize,
+		catchUp:      input.CatchUp,
+		label:        input.Label,
+	}
+
+	if normalized.historyPath == "" {
+		normalized.historyPath = DefaultHistoryPath()
+	}
+	if normalized.historyPath == "" {
+		return normalized, errors.New("safari history path is not set and cannot be derived")
+	}
+	if normalized.statePath == "" {
+		normalized.statePath = DefaultStatePath()
+	}
+	if normalized.statePath == "" {
+		return normalized, errors.New("state path is not set and cannot be derived")
+	}
+	if normalized.pollInterval <= 0 {
+		normalized.pollInterval = defaultPollInterval
+	}
+	if normalized.batchSize <= 0 {
+		normalized.batchSize = defaultBatchSize
+	}
+
+	// Checked up front rather than on the first poll, so a wrong path or a missing Full Disk
+	// Access grant is reported when the command starts instead of once a second forever.
+	if err := historyReadable(normalized.historyPath); err != nil {
+		return normalized, err
+	}
+	return normalized, nil
+}
+
+// historyReadable reports why Safari's history cannot be read, or nil if it can.
+//
+// ~/Library/Safari is protected on macOS, and the resulting failure is easy to misread: without
+// the grant the SQLite driver reports "unable to open database file", which looks like a file
+// permission problem and is not one — no chmod will fix it. Opening the file here turns that into
+// an error naming the setting.
+func historyReadable(path string) error {
+	f, err := os.Open(path)
+	if err == nil {
+		return f.Close()
+	}
+	if errors.Is(err, os.ErrPermission) {
+		return fmt.Errorf(
+			"%w: reading Safari's history requires Full Disk Access for the terminal or "+
+				"application running hister (System Settings > Privacy & Security > Full Disk Access)",
+			err,
+		)
+	}
+	return err
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -301,6 +301,8 @@ func init() {
 	crawlCmd.AddCommand(crawlURLsCmd)
 	crawlCmd.AddCommand(crawlDeleteCmd)
 	companionCmd.AddCommand(companionQutebrowserCmd)
+	companionCmd.AddCommand(companionSafariCmd)
+	addSafariCompanionFlags(companionSafariCmd)
 	importCmd.AddCommand(importFileCmd)
 	importCmd.AddCommand(importBrowserCmd)
 	importCmd.AddCommand(importLinkdingCmd)

--- a/cmd/scope.go
+++ b/cmd/scope.go
@@ -59,6 +59,7 @@ func configureCommandScopes() {
 
 	setCommandScope(companionCmd, executionScopeRemote, "client-timeout")
 	setCommandScope(companionQutebrowserCmd, executionScopeRemote, "client-timeout")
+	setCommandScope(companionSafariCmd, executionScopeRemote, "client-timeout")
 
 	setCommandScope(importFileCmd, executionScopeHybrid)
 	setCommandScope(importBrowserCmd, executionScopeHybrid, "client-timeout")

--- a/webui/website/src/content/docs/browser-extension.md
+++ b/webui/website/src/content/docs/browser-extension.md
@@ -43,6 +43,7 @@ The Hister browser extension is the primary way to automatically index your brow
 - **Chrome / Chromium / Edge**: [Install from Chrome Web Store](https://chromewebstore.google.com/detail/hister/cciilamhchpmbdnniabclekddabkifhb)
 - **Firefox**: [Install from Firefox Add-ons](https://addons.mozilla.org/en-US/firefox/addon/hister/) (also works on Firefox for Android)
 - **qutebrowser**: Use the built in `hister companion qutebrowser` command as described below.
+- **Safari**: Use the built in `hister companion safari` command as described below.
 
 After installing, click the extension icon in your browser toolbar to open the popup and verify the server URL is correct.
 
@@ -93,6 +94,35 @@ thirty seconds for continuously changing pages.
 Remote debugging provides complete access to open browser pages. The companion
 accepts only a localhost or loopback IP DevTools endpoint. Never expose the Qt
 WebEngine debugging port to a network.
+
+
+### Safari
+
+Safari has no Hister extension. The `hister companion safari` command keeps the
+index current instead, by following the history database Safari maintains
+anyway and indexing pages as they are visited:
+
+```bash
+hister companion safari
+```
+
+**It is not equivalent to the extension.** Safari's history records addresses,
+not page content, so the companion asks Hister's crawler to fetch each page. A
+page behind a login is indexed as an anonymous visitor sees it, and a page built
+by JavaScript may index as an empty shell. Where the extension captures what you
+saw, this records where you went and fetches what is there now.
+
+Reading the history requires Full Disk Access for the terminal or application
+running Hister, granted under System Settings > Privacy & Security > Full Disk
+Access. The requirement is checked at startup.
+
+The first run indexes visits from the moment it starts. Existing history belongs
+to [`hister import browser`](import#importing-browser-history); use `--catch-up` to index it
+here instead. Use `--poll-interval`, `--batch-size`, `--state-path`, or
+`--label` to change its behaviour, and `--help` for every option.
+
+Pages already in the index are not fetched again, so revisiting a site costs
+nothing.
 
 ## Features
 

--- a/webui/website/src/content/docs/browser-ingestion.md
+++ b/webui/website/src/content/docs/browser-ingestion.md
@@ -15,7 +15,7 @@ Hister can collect browsing data in two different ways. The browser extension ca
 | Capture pages behind a login                      | [Browser extension](browser-extension)                      | It sees the page already rendered in your signed in browser tab             |
 | Bring in existing browser history                 | [`hister import browser`](import#importing-browser-history) | It reads qualifying URLs from the browser history database                  |
 | Index an entire public site                       | [Website crawler](crawler)                                  | It follows permitted links instead of relying on your visit history         |
-| Keep a browser database continuously synchronized | No direct option                                            | Browser history import is an explicit import, not a continuous sync service |
+| Keep a browser database continuously synchronized | No direct option, except Safari                             | Browser history import is an explicit import, not a continuous sync service. `hister companion safari` follows Safari's history database, but indexes fetched pages rather than captured ones |
 
 ## Browser Extension Capture
 


### PR DESCRIPTION
Adds `hister companion safari`, which watches Safari's history database and indexes pages as they
are visited.

### Related to #49, but a different road

#49 asks for Safari support and pursues it through the extension: repackage the Chrome MV3 manifest
as a Safari Web Extension, and fix the CORS preflight on `POST /add` that currently 500s (#46).
That is live indexing with the rendered page, and it remains the better answer when it lands —
nothing here replaces it.

This arrives at the same destination by a different road, and one that needs nothing from Apple, no
extension packaging, and no signing: Safari writes every visit to a SQLite database of its own,
which makes that file a live feed. **I am not proposing this instead of #46 — I am proposing it as
something that works today and keeps working if the extension route stalls.**

I would not close #49 on this. The extension gets the page as rendered, including anything behind a
login; this gets an address and fetches it, so a logged-in page is indexed as an anonymous visitor
sees it. Those are different capabilities and both are worth having.

### Why it takes a URLIndexer rather than a DocumentSubmitter

The qutebrowser companion only needs `DocumentSubmitter`, because DevTools hands it a rendered
page. Safari's history hands over addresses, so the pages have to be fetched.

Rather than pull the crawler into the companion package, it depends on a narrow `URLIndexer` and
the crawl wiring stays in `cmd`, where it already lives. That keeps the package free of crawler
internals and testable without a network — the same property that makes the qutebrowser package
tidy.

The concrete implementation reuses `indexURL` and skips anything `DocumentExists` already reports,
so revisiting a site does not re-crawl it.

### Two details that are not obvious

**It watches the `-wal` file, not just `History.db`.** SQLite in WAL mode appends there and folds
changes into the main database only at a checkpoint, so watching the main file alone sleeps through
a burst of browsing and then delivers it in a lump.

**It reads from a copy of all three parts.** Opening the original as `immutable=1` — which is what
the browser import does, correctly, for a one-off read — skips the write-ahead log, and so would
miss exactly the recent visits this exists to catch. Copying also means nobody has to quit their
browser. There is a test that holds a writable handle open across the read to keep that honest.

The database is only opened when a modification time changes, so an idle machine costs three
`stat()` calls per poll rather than repeatedly copying a file that has not moved.

### Behaviour

First run indexes from the moment it starts rather than replaying the whole history — that is what
`hister import browser safari` is for, and crawling thousands of pages unasked is not what "watch
for new pages" should mean. `--catch-up` overrides it.

Full Disk Access is checked at startup, so a missing grant is reported once with the setting named
rather than every poll as a permission error that no `chmod` will fix.

### Testing

`go build ./...`, `go test ./...` and `golangci-lint run ./cmd/...` are clean. Nine tests covering
the timestamp filter, deduplication of repeat visits, non-HTTP schemes, reading while the database
is held open, option defaults and validation, state round-tripping and tolerance of a corrupt state
file, and the `-wal` fingerprint.

### Notes for review

- macOS only in practice. The command is registered on all platforms and simply fails at startup
  with "no such file" elsewhere; I can gate it behind a build tag if you would rather.
- `visit_time` is `REAL` in Safari and the fixtures declare it so. Comparison against a numeric
  parameter works because SQLite compares across storage classes.
- The default state path is `~/.local/state/hister/safari-companion.json`. Say if there is a
  convention I have missed.
- No filtering of which URLs get indexed beyond the `http(s)` scheme check — that felt like the
  server's business, not the companion's, but I may have drawn the line in the wrong place.
