### PR TITLE
[enh] Add native user service management for Hister for linux and macos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## Unreleased
+
+### New Features
+
+#### Background service install
+
+`hister service install` writes a user-level LaunchAgent on macOS or a systemd
+user unit on Linux, then starts `hister listen` so the server can run
+without an open terminal. Start, stop, restart, status, and uninstall are
+included. `hister service status` exits 0 when running, 3 when stopped, and
+4 when not installed. Install fails if unpersisted `HISTER__*` or
+`HISTER_PORT` environment variables are set. The command does not change Nix,
+Docker, or the example system unit in `contrib/systemd`. Windows is not
+supported yet.
+
+---
+
 ## v0.18.0
 
 ### New Features

--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ Hister is a private search engine for the pages you visit and the files you keep
 
    On Windows, run `.\hister.exe listen` in PowerShell.
 
+   To keep Hister running after you close the terminal on macOS or systemd Linux:
+
+   ```bash
+   ./hister service install
+   ```
+
 4. Open <http://127.0.0.1:4433> and install the browser extension for [Firefox](https://addons.mozilla.org/en-US/firefox/addon/hister/) or [Chrome](https://chromewebstore.google.com/detail/hister/cciilamhchpmbdnniabclekddabkifhb).
 
 No configuration is required for a local personal setup. See the [complete quickstart](https://hister.org/docs/quickstart) to import existing browser history and choose what Hister indexes.

--- a/cmd/exit.go
+++ b/cmd/exit.go
@@ -1,0 +1,43 @@
+// SPDX-FileContributor: sathwick-p
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package cmd
+
+import "errors"
+
+// ExitCoder is an error that carries a process exit code. Cobra RunE
+// functions return these instead of calling os.Exit.
+type ExitCoder interface {
+	error
+	ExitCode() int
+}
+
+type exitCodeError struct {
+	code int
+	msg  string
+}
+
+func (e *exitCodeError) Error() string {
+	return e.msg
+}
+
+func (e *exitCodeError) ExitCode() int {
+	return e.code
+}
+
+func exitError(code int, msg string) error {
+	return &exitCodeError{code: code, msg: msg}
+}
+
+// ProcessExitCode maps an Execute error to a process status.
+// 0 is success; errors that do not implement ExitCoder are 1.
+func ProcessExitCode(err error) int {
+	if err == nil {
+		return 0
+	}
+	if ec, ok := errors.AsType[ExitCoder](err); ok {
+		return ec.ExitCode()
+	}
+	return 1
+}

--- a/cmd/exit_test.go
+++ b/cmd/exit_test.go
@@ -1,0 +1,31 @@
+// SPDX-FileContributor: sathwick-p
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package cmd
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestProcessExitCode(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want int
+	}{
+		{name: "nil", err: nil, want: 0},
+		{name: "plain", err: errors.New("boom"), want: 1},
+		{name: "stopped", err: exitError(3, "stopped"), want: 3},
+		{name: "not installed", err: exitError(4, "missing"), want: 4},
+		{name: "wrapped", err: errors.Join(exitError(3, "stopped"), errors.New("extra")), want: 3},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ProcessExitCode(tt.err); got != tt.want {
+				t.Fatalf("ProcessExitCode() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -1,0 +1,169 @@
+// SPDX-FileContributor: sathwick-p
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
+
+	"github.com/asciimoo/hister/config"
+)
+
+const skipConfigInitAnnotation = "hister_skip_config_init"
+
+func persistentPreRun(cmd *cobra.Command, _ []string) error {
+	if skipConfigInit(cmd) {
+		return nil
+	}
+	if isServiceInstall(cmd) {
+		if err := pinInstallConfigPath(); err != nil {
+			return printPreRunError(cmd, err)
+		}
+	}
+	if err := initialize(); err != nil {
+		return printPreRunError(cmd, err)
+	}
+	if isServiceInstall(cmd) {
+		if err := verifyLoadedInstallConfig(); err != nil {
+			return printPreRunError(cmd, err)
+		}
+	}
+	return nil
+}
+
+func printPreRunError(cmd *cobra.Command, err error) error {
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+	cliPrintln(cliErrorStyle.Render("Error!") + " " + err.Error())
+	return err
+}
+
+func skipConfigInit(cmd *cobra.Command) bool {
+	return cmd.Annotations[skipConfigInitAnnotation] == "true"
+}
+
+func isServiceInstall(cmd *cobra.Command) bool {
+	return cmd.Name() == "install" && cmd.Parent() != nil && cmd.Parent().Name() == "service"
+}
+
+var installConfigPinned bool
+
+func pinInstallConfigPath() error {
+	path := cfgFile
+	if !rootCmd.PersistentFlags().Changed("config") {
+		path = os.Getenv("HISTER_CONFIG")
+		if path == "" {
+			return nil
+		}
+	}
+	if path == "" {
+		return errors.New("config path is empty")
+	}
+	abs, err := readableRegularFile(path)
+	if err != nil {
+		return err
+	}
+	cfgFile = abs
+	installConfigPinned = true
+	return nil
+}
+
+func verifyLoadedInstallConfig() error {
+	if !installConfigPinned {
+		return nil
+	}
+	got, ok := cfg.SourcePath()
+	if !ok || got != cfgFile {
+		return fmt.Errorf("config file %q was not loaded", cfgFile)
+	}
+	return nil
+}
+
+func readableRegularFile(path string) (string, error) {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", fmt.Errorf("config path %q: %w", path, err)
+	}
+	st, err := os.Stat(abs)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", fmt.Errorf("config file %q does not exist", abs)
+		}
+		return "", fmt.Errorf("config file %q: %w", abs, err)
+	}
+	if !st.Mode().IsRegular() {
+		return "", fmt.Errorf("config file %q is not a regular file", abs)
+	}
+	f, err := os.Open(abs)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", fmt.Errorf("config file %q does not exist", abs)
+		}
+		return "", fmt.Errorf("config file %q: %w", abs, err)
+	}
+	closeErr := f.Close()
+	if closeErr != nil {
+		return "", fmt.Errorf("config file %q: %w", abs, closeErr)
+	}
+	return abs, nil
+}
+
+func initialize() error {
+	if ll := os.Getenv("HISTER__APP__LOG_LEVEL"); ll != "debug" {
+		zerolog.SetGlobalLevel(zerolog.InfoLevel)
+	} else {
+		zerolog.SetGlobalLevel(zerolog.DebugLevel)
+	}
+	if err := initConfig(); err != nil {
+		return err
+	}
+	if cfg.Crawler.UserAgent != "" {
+		UserAgent = cfg.Crawler.UserAgent
+	}
+	initLog()
+	log.Debug().Str("filename", cfg.Filename()).Msg("Config initialization complete")
+	log.Debug().Msg("Logging initialization complete")
+	return nil
+}
+
+func initConfig() error {
+	var err error
+
+	if !installConfigPinned && !rootCmd.PersistentFlags().Changed("config") {
+		if envConfig := os.Getenv("HISTER_CONFIG"); envConfig != "" {
+			cfgFile = envConfig
+		}
+	}
+
+	cfg, err = config.Load(cfgFile)
+	if err != nil {
+		return fmt.Errorf("failed to initialize config: %w", err)
+	}
+
+	if v, _ := rootCmd.PersistentFlags().GetString("log-level"); v != "" && (rootCmd.Flags().Changed("log-level") || cfg.App.LogLevel == "") {
+		cfg.App.LogLevel = v
+	}
+	if v, _ := rootCmd.PersistentFlags().GetString("search-url"); v != "" && (rootCmd.Flags().Changed("search-url") || cfg.App.SearchURL == "") {
+		cfg.App.SearchURL = v
+	}
+	if v, _ := rootCmd.PersistentFlags().GetString("server-url"); v != "" && rootCmd.Flags().Changed("server-url") {
+		if err := cfg.UpdateBaseURL(v); err != nil {
+			return fmt.Errorf("failed to initialize config: %w", err)
+		}
+	}
+	if v, _ := rootCmd.PersistentFlags().GetString("token"); rootCmd.PersistentFlags().Changed("token") {
+		cfg.App.AccessToken = v
+	}
+	if err := cfg.ValidatePublicMode(); err != nil {
+		return fmt.Errorf("failed to initialize config: %w", err)
+	}
+	return nil
+}

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -1,0 +1,178 @@
+// SPDX-FileContributor: sathwick-p
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+func TestRequireExplicitInstallConfigMissingFile(t *testing.T) {
+	resetRootState(t)
+	missing := filepath.Join(t.TempDir(), "nope.yml")
+	cfgFile = missing
+	rootCmd.PersistentFlags().Lookup("config").Changed = true
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("XDG_STATE_HOME", filepath.Join(home, ".local/state"))
+	t.Setenv("HISTER_DATA_DIR", filepath.Join(home, "data"))
+
+	err := pinInstallConfigPath()
+	if err == nil {
+		t.Fatal("expected error for missing --config file")
+	}
+	if _, statErr := os.Stat(filepath.Join(home, "data")); !os.IsNotExist(statErr) {
+		t.Fatalf("data directory was created before install config validation failed: %v", statErr)
+	}
+	if _, err := os.Stat(filepath.Join(home, "data", ".secret_key")); !os.IsNotExist(err) {
+		t.Fatal("secret key was created for a missing install --config")
+	}
+}
+
+func TestRequireExplicitInstallConfigUnreadable(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root can read mode 000 files")
+	}
+	resetRootState(t)
+	path := filepath.Join(t.TempDir(), "secret.yml")
+	if err := os.WriteFile(path, []byte("app:\n  title: x\n"), 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(path, 0o600) })
+	cfgFile = path
+	rootCmd.PersistentFlags().Lookup("config").Changed = true
+	if err := pinInstallConfigPath(); err == nil {
+		t.Fatal("expected error for unreadable --config file")
+	}
+}
+
+func TestRequireExplicitInstallConfigDirectory(t *testing.T) {
+	resetRootState(t)
+	dir := t.TempDir()
+	cfgFile = dir
+	rootCmd.PersistentFlags().Lookup("config").Changed = true
+	if err := pinInstallConfigPath(); err == nil {
+		t.Fatal("expected directory config path to be rejected")
+	} else if !strings.Contains(err.Error(), "not a regular file") {
+		t.Fatalf("directory config error = %v", err)
+	}
+}
+
+func TestRequireExplicitInstallConfigAbsolute(t *testing.T) {
+	resetRootState(t)
+	dir := t.TempDir()
+	t.Chdir(dir)
+	if err := os.WriteFile("mine.yml", []byte("app:\n  title: x\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfgFile = "./mine.yml"
+	rootCmd.PersistentFlags().Lookup("config").Changed = true
+	if err := pinInstallConfigPath(); err != nil {
+		t.Fatal(err)
+	}
+	want, err := filepath.Abs("mine.yml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfgFile != want {
+		t.Fatalf("cfgFile = %q, want %q", cfgFile, want)
+	}
+}
+
+func TestRequireExplicitInstallConfigUnchangedSkips(t *testing.T) {
+	resetRootState(t)
+	cfgFile = filepath.Join(t.TempDir(), "missing.yml")
+	if err := pinInstallConfigPath(); err != nil {
+		t.Fatalf("unchanged --config: %v", err)
+	}
+}
+
+func TestPinInstallConfigFromHISTERConfig(t *testing.T) {
+	resetRootState(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "env.yml")
+	if err := os.WriteFile(path, []byte("app:\n  title: env\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HISTER_CONFIG", path)
+	if err := pinInstallConfigPath(); err != nil {
+		t.Fatal(err)
+	}
+	want, err := filepath.Abs(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfgFile != want {
+		t.Fatalf("cfgFile = %q, want %q", cfgFile, want)
+	}
+	if !installConfigPinned {
+		t.Fatal("expected installConfigPinned")
+	}
+}
+
+func TestPinInstallConfigHISTERConfigMissing(t *testing.T) {
+	resetRootState(t)
+	missing := filepath.Join(t.TempDir(), "nope.yml")
+	t.Setenv("HISTER_CONFIG", missing)
+	if err := pinInstallConfigPath(); err == nil {
+		t.Fatal("expected error for missing HISTER_CONFIG")
+	}
+}
+
+func TestSkipConfigInitAnnotation(t *testing.T) {
+	cmd := serviceStatusCmd
+	if !skipConfigInit(cmd) {
+		t.Fatal("status command should skip config init")
+	}
+	if skipConfigInit(serviceInstallCmd) {
+		t.Fatal("install command must load config")
+	}
+}
+
+func resetRootState(t *testing.T) {
+	t.Helper()
+	prevFile := cfgFile
+	prevCfg := cfg
+	prevPinned := installConfigPinned
+	t.Cleanup(func() {
+		cfgFile = prevFile
+		cfg = prevCfg
+		installConfigPinned = prevPinned
+		resetCommandTree(rootCmd)
+		rootCmd.SetArgs(nil)
+	})
+	cfgFile = "config.yml"
+	cfg = nil
+	installConfigPinned = false
+	resetCommandTree(rootCmd)
+	rootCmd.SetArgs(nil)
+}
+
+func resetCommandTree(cmd *cobra.Command) {
+	cmd.SilenceErrors = false
+	cmd.SilenceUsage = false
+	resetFlagSet(cmd.PersistentFlags())
+	resetFlagSet(cmd.Flags())
+	for _, child := range cmd.Commands() {
+		resetCommandTree(child)
+	}
+}
+
+func resetFlagSet(fs *pflag.FlagSet) {
+	if fs == nil {
+		return
+	}
+	fs.VisitAll(func(f *pflag.Flag) {
+		f.Changed = false
+		_ = f.Value.Set(f.DefValue)
+	})
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -152,28 +152,28 @@ var rootCmd = &cobra.Command{
 	Short:   "Your own search engine",
 	Long:    "Hister - your own search engine",
 	Version: Version,
-	//Run: func(_ *cobra.Command, _ []string) {
-	//},
 }
 
 var listenCmd = &cobra.Command{
 	Use:   "listen",
 	Short: "Start the Hister HTTP server",
 	Long:  `Start the Hister HTTP server and watch configured directories for file changes.`,
-	PreRun: func(cmd *cobra.Command, _ []string) {
+	PreRunE: func(cmd *cobra.Command, _ []string) error {
 		if public, _ := cmd.Flags().GetBool("public"); public {
 			cfg.App.Public = true
 		}
 		if err := cfg.ValidatePublicMode(); err != nil {
-			exit(1, "Failed to initialize config: "+err.Error())
+			return fmt.Errorf("failed to initialize config: %w", err)
 		}
+		return nil
 	},
-	Run: func(cmd *cobra.Command, _ []string) {
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		cmd.SilenceUsage = true
 		idx := initIndex()
 		defer idx.Close()
 		if a, err := cmd.Flags().GetString("address"); err == nil && cmd.Flags().Changed("address") {
 			if err := cfg.UpdateListenAddress(a); err != nil {
-				exit(1, `Failed to set server address: `+err.Error())
+				return fmt.Errorf("failed to set server address: %w", err)
 			}
 		}
 		if (cfg.App.AccessToken != "" || cfg.App.UserHandling) && strings.HasPrefix(cfg.BaseURL(""), "http://") {
@@ -206,7 +206,7 @@ var listenCmd = &cobra.Command{
 			}()
 		}
 		server.Version = Version
-		server.Listen(cfg, idx)
+		return server.Listen(cfg, idx)
 	},
 }
 
@@ -268,6 +268,7 @@ func requireUserHandlingAndInitDB(_ *cobra.Command, _ []string) {
 
 func init() {
 	dcfg := config.CreateDefaultConfig()
+	rootCmd.PersistentPreRunE = persistentPreRun
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "config.yml", "config file (default paths: ./config.yml or $HOME/.histerrc or $HOME/.config/hister/config.yml)")
 	rootCmd.PersistentFlags().StringP("log-level", "l", "info", "set log level (possible options: error, warning, info, debug, trace)")
 	rootCmd.PersistentFlags().StringP("search-url", "s", dcfg.App.SearchURL, "set default search engine url")
@@ -276,6 +277,7 @@ func init() {
 	rootCmd.PersistentFlags().Int("client-timeout", 0, "HTTP client timeout in seconds (default 10; explicitly set 0 to disable the timeout)")
 
 	rootCmd.AddCommand(listenCmd)
+	registerServiceCommand()
 	rootCmd.AddCommand(createConfigCmd)
 	rootCmd.AddCommand(listURLsCmd)
 	rootCmd.AddCommand(listFilesCmd)
@@ -367,8 +369,6 @@ func init() {
 	searchCmd.Flags().String("sort", "relevance", "result order: relevance, date, domain, or visits")
 	configureCommandScopes()
 
-	cobra.OnInitialize(initialize)
-
 	zerolog.CallerMarshalFunc = func(_ uintptr, file string, line int) string {
 		dir, fn := filepath.Split(file)
 		if dir == "" {
@@ -414,54 +414,6 @@ func newConsoleWriter(out io.Writer, noColor bool) zerolog.ConsoleWriter {
 			}
 			return fmt.Sprintf("| %s |", lipgloss.NewStyle().Foreground(color).Bold(true).Render(level))
 		},
-	}
-}
-
-func initialize() {
-	if ll := os.Getenv("HISTER__APP__LOG_LEVEL"); ll != "debug" {
-		zerolog.SetGlobalLevel(zerolog.InfoLevel)
-	} else {
-		zerolog.SetGlobalLevel(zerolog.DebugLevel)
-	}
-	initConfig()
-	if cfg.Crawler.UserAgent != "" {
-		UserAgent = cfg.Crawler.UserAgent
-	}
-	initLog()
-	log.Debug().Str("filename", cfg.Filename()).Msg("Config initialization complete")
-	log.Debug().Msg("Logging initialization complete")
-}
-
-func initConfig() {
-	var err error
-
-	if !rootCmd.PersistentFlags().Changed("config") {
-		if envConfig := os.Getenv("HISTER_CONFIG"); envConfig != "" {
-			cfgFile = envConfig
-		}
-	}
-
-	cfg, err = config.Load(cfgFile)
-	if err != nil {
-		exit(1, "Failed to initialize config: "+err.Error())
-	}
-
-	if v, _ := rootCmd.PersistentFlags().GetString("log-level"); v != "" && (rootCmd.Flags().Changed("log-level") || cfg.App.LogLevel == "") {
-		cfg.App.LogLevel = v
-	}
-	if v, _ := rootCmd.PersistentFlags().GetString("search-url"); v != "" && (rootCmd.Flags().Changed("search-url") || cfg.App.SearchURL == "") {
-		cfg.App.SearchURL = v
-	}
-	if v, _ := rootCmd.PersistentFlags().GetString("server-url"); v != "" && rootCmd.Flags().Changed("server-url") {
-		if err := cfg.UpdateBaseURL(v); err != nil {
-			exit(1, "Failed to initialize config: "+err.Error())
-		}
-	}
-	if v, _ := rootCmd.PersistentFlags().GetString("token"); rootCmd.PersistentFlags().Changed("token") {
-		cfg.App.AccessToken = v
-	}
-	if err := cfg.ValidatePublicMode(); err != nil {
-		exit(1, "Failed to initialize config: "+err.Error())
 	}
 }
 

--- a/cmd/scope.go
+++ b/cmd/scope.go
@@ -69,6 +69,8 @@ func configureCommandScopes() {
 	setCommandScope(importShaarliCmd, executionScopeRemote)
 	setCommandScope(importWallabagCmd, executionScopeRemote)
 
+	configureServiceScopes()
+
 	configureScopeGroups(rootCmd)
 	configureScopeGroups(importCmd)
 	configureScopeGroups(crawlCmd)
@@ -174,6 +176,10 @@ func applicableGlobalFlags(cmd *cobra.Command) (map[string]bool, bool) {
 	}
 	result := make(map[string]bool)
 	for name := range strings.SplitSeq(raw, ",") {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
 		result[name] = true
 	}
 	return result, true

--- a/cmd/service.go
+++ b/cmd/service.go
@@ -1,0 +1,327 @@
+// SPDX-FileContributor: sathwick-p
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
+
+	"github.com/asciimoo/hister/internal/svc"
+)
+
+var newServiceManager = svc.New
+
+const serviceStartCheckDelay = 2 * time.Second
+
+var serviceCmd = &cobra.Command{
+	Use:   "service",
+	Short: "Install and control a background Hister server",
+	Long:  "Install a user-level background service that runs `hister listen`, or start, stop, and query that service.",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		return cmd.Help()
+	},
+}
+
+var serviceInstallCmd = &cobra.Command{
+	Use:   "install",
+	Short: "Install and start a user-level Hister service",
+	Args:  cobra.NoArgs,
+	RunE:  runServiceInstall,
+}
+
+var serviceUninstallCmd = &cobra.Command{
+	Use:   "uninstall",
+	Short: "Stop the service and remove the Hister-managed definition",
+	Args:  cobra.NoArgs,
+	RunE:  runServiceUninstall,
+}
+
+var serviceStartCmd = &cobra.Command{
+	Use:   "start",
+	Short: "Start the installed Hister service",
+	Args:  cobra.NoArgs,
+	RunE:  runServiceStart,
+}
+
+var serviceStopCmd = &cobra.Command{
+	Use:   "stop",
+	Short: "Stop the installed Hister service",
+	Args:  cobra.NoArgs,
+	RunE:  runServiceStop,
+}
+
+var serviceRestartCmd = &cobra.Command{
+	Use:   "restart",
+	Short: "Restart the installed Hister service",
+	Args:  cobra.NoArgs,
+	RunE:  runServiceRestart,
+}
+
+var serviceStatusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Show whether the Hister service is running",
+	Args:  cobra.NoArgs,
+	RunE:  runServiceStatus,
+}
+
+func registerServiceCommand() {
+	serviceInstallCmd.Flags().Bool("force", false, "replace an existing Hister-managed service definition")
+	serviceInstallCmd.Flags().Bool("no-start", false, "write the service definition without starting it")
+
+	annotateSkipConfig := func(cmd *cobra.Command) {
+		if cmd.Annotations == nil {
+			cmd.Annotations = make(map[string]string)
+		}
+		cmd.Annotations[skipConfigInitAnnotation] = "true"
+	}
+	annotateSkipConfig(serviceCmd)
+	annotateSkipConfig(serviceUninstallCmd)
+	annotateSkipConfig(serviceStartCmd)
+	annotateSkipConfig(serviceStopCmd)
+	annotateSkipConfig(serviceRestartCmd)
+	annotateSkipConfig(serviceStatusCmd)
+
+	serviceCmd.AddCommand(
+		serviceInstallCmd,
+		serviceUninstallCmd,
+		serviceStartCmd,
+		serviceStopCmd,
+		serviceRestartCmd,
+		serviceStatusCmd,
+	)
+	rootCmd.AddCommand(serviceCmd)
+}
+
+func configureServiceScopes() {
+	setCommandScope(serviceCmd, executionScopeLocal)
+	setCommandScope(serviceInstallCmd, executionScopeLocal)
+	setCommandScope(serviceUninstallCmd, executionScopeLocal)
+	setCommandScope(serviceStartCmd, executionScopeLocal)
+	setCommandScope(serviceStopCmd, executionScopeLocal)
+	setCommandScope(serviceRestartCmd, executionScopeLocal)
+	setCommandScope(serviceStatusCmd, executionScopeLocal)
+	serviceInstallCmd.Annotations[applicableFlagsAnnotation] = "config"
+	for _, cmd := range []*cobra.Command{
+		serviceCmd, serviceUninstallCmd, serviceStartCmd,
+		serviceStopCmd, serviceRestartCmd, serviceStatusCmd,
+	} {
+		cmd.Annotations[applicableFlagsAnnotation] = ""
+	}
+	configureScopeGroups(serviceCmd)
+}
+
+func runServiceInstall(cmd *cobra.Command, _ []string) error {
+	cmd.SilenceUsage = true
+	force, _ := cmd.Flags().GetBool("force")
+	noStart, _ := cmd.Flags().GetBool("no-start")
+
+	if err := refuseUnpersistedInstallEnv(); err != nil {
+		return err
+	}
+
+	bin, err := svc.ResolveBinary()
+	if err != nil {
+		return err
+	}
+	dataDir, err := filepath.Abs(cfg.App.Directory)
+	if err != nil {
+		return fmt.Errorf("data directory: %w", err)
+	}
+	def := svc.Definition{
+		Binary:  bin,
+		DataDir: dataDir,
+	}
+	if path, ok := cfg.SourcePath(); ok {
+		def.ConfigPath = path
+	}
+
+	m, err := newServiceManager()
+	if err != nil {
+		return err
+	}
+	if err := m.Install(def, svc.InstallOptions{Force: force, NoStart: noStart}); err != nil {
+		return err
+	}
+
+	printInstallSummary(m, def, noStart)
+	if !noStart {
+		time.Sleep(serviceStartCheckDelay)
+	}
+	st, err := m.Status()
+	if err != nil {
+		if noStart {
+			log.Warn().Err(err).Msg("Installed, but could not query service status")
+			return nil
+		}
+		return fmt.Errorf("installed service definition at %s, but could not query status: %w", m.DefinitionPath(), err)
+	}
+	cliPrintf("  Status:      %s\n", st.String())
+	if !noStart && st.State != svc.StateRunning {
+		return fmt.Errorf("installed service definition at %s, but the process is not running", m.DefinitionPath())
+	}
+	return nil
+}
+
+func runServiceUninstall(cmd *cobra.Command, _ []string) error {
+	cmd.SilenceUsage = true
+	m, err := newServiceManager()
+	if err != nil {
+		return err
+	}
+	st, err := m.Status()
+	if err != nil {
+		return err
+	}
+	if err := m.Uninstall(); err != nil {
+		return err
+	}
+	if st.State == svc.StateNotInstalled {
+		cliPrintln("Hister service is not installed.")
+		return nil
+	}
+	cliPrintln(cliSuccessStyle.Render("✓") + " Removed the Hister service definition.")
+	cliPrintln("Indexed data was not deleted.")
+	return nil
+}
+
+func runServiceStart(cmd *cobra.Command, _ []string) error {
+	return runServiceControl(cmd, func(m svc.Manager) error { return m.Start() }, "Started the Hister service.")
+}
+
+func runServiceStop(cmd *cobra.Command, _ []string) error {
+	return runServiceControl(cmd, func(m svc.Manager) error { return m.Stop() }, "Stopped the Hister service.")
+}
+
+func runServiceRestart(cmd *cobra.Command, _ []string) error {
+	return runServiceControl(cmd, func(m svc.Manager) error { return m.Restart() }, "Restarted the Hister service.")
+}
+
+func runServiceControl(cmd *cobra.Command, op func(svc.Manager) error, okMsg string) error {
+	cmd.SilenceUsage = true
+	m, err := newServiceManager()
+	if err != nil {
+		return err
+	}
+	if err := op(m); err != nil {
+		return err
+	}
+	cliPrintln(cliSuccessStyle.Render("✓") + " " + okMsg)
+	return nil
+}
+
+func runServiceStatus(cmd *cobra.Command, _ []string) error {
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+	m, err := newServiceManager()
+	if err != nil {
+		cmd.SilenceErrors = false
+		return err
+	}
+	st, err := m.Status()
+	if err != nil {
+		cmd.SilenceErrors = false
+		return err
+	}
+	printServiceStatus(st)
+	code := st.ExitCode()
+	if code == svc.ExitRunning {
+		return nil
+	}
+	return exitError(code, st.String())
+}
+
+func printInstallSummary(m svc.Manager, def svc.Definition, noStart bool) {
+	cliPrintln(cliSuccessStyle.Render("✓") + " Installed a " + m.Platform() + " user service.")
+	cliPrintf("  Definition:  %s\n", m.DefinitionPath())
+	cliPrintf("  Binary:      %s\n", def.Binary)
+	if def.ConfigPath != "" {
+		cliPrintf("  Config:      %s\n", def.ConfigPath)
+	} else {
+		cliPrintln("  Config:      built-in defaults (no --config)")
+	}
+	cliPrintf("  Data:        %s\n", def.DataDir)
+	for i, logPath := range m.Logs() {
+		if i == 0 {
+			cliPrintf("  Logs:        %s\n", logPath)
+		} else {
+			cliPrintf("              %s\n", logPath)
+		}
+	}
+	if noStart {
+		cliPrintln("  The service was not started (--no-start).")
+	}
+	if note := m.LoginNote(); note != "" {
+		cliPrintln(note)
+	}
+}
+
+func printServiceStatus(st svc.Status) {
+	cliPrintf("Hister service (%s)\n", st.Platform)
+	if st.DefinitionPath != "" {
+		cliPrintf("  Definition:  %s\n", st.DefinitionPath)
+	}
+	cliPrintf("  Status:      %s\n", st.String())
+	if st.ExternallyManaged {
+		cliPrintln("  Note:        managed outside `hister service`; change it through its original configuration or package manager")
+	}
+}
+
+func refuseUnpersistedInstallEnv() error {
+	names := unpersistedInstallEnvNames()
+	if len(names) == 0 {
+		return nil
+	}
+	return fmt.Errorf("refusing to install while unpersisted environment overrides are set: %s", strings.Join(names, ", "))
+}
+
+func unpersistedInstallEnvNames() []string {
+	var names []string
+	seen := map[string]struct{}{}
+	add := func(name string) {
+		if _, ok := seen[name]; ok {
+			return
+		}
+		seen[name] = struct{}{}
+		names = append(names, name)
+	}
+	pinnedConfig := false
+	if cfg != nil {
+		_, pinnedConfig = cfg.SourcePath()
+	}
+	for _, env := range os.Environ() {
+		name, val, _ := strings.Cut(env, "=")
+		if val == "" {
+			continue
+		}
+		switch name {
+		case "HISTER_DATA_DIR", "HISTER__APP__DIRECTORY":
+			continue
+		case "HISTER_CONFIG":
+			abs, absErr := filepath.Abs(val)
+			if absErr == nil && pinnedConfig {
+				if src, ok := cfg.SourcePath(); ok && src == abs {
+					continue
+				}
+			}
+			add(name)
+		case "HISTER_PORT":
+			add(name)
+		default:
+			if strings.HasPrefix(name, "HISTER__") {
+				add(name)
+			}
+		}
+	}
+	slices.Sort(names)
+	return names
+}

--- a/cmd/service_test.go
+++ b/cmd/service_test.go
@@ -1,0 +1,501 @@
+// SPDX-FileContributor: sathwick-p
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package cmd
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/asciimoo/hister/internal/svc"
+)
+
+type fakeManager struct {
+	platform                string
+	path                    string
+	installed               bool
+	running                 bool
+	foreign                 bool
+	lastDef                 svc.Definition
+	lastOpts                svc.InstallOptions
+	installErr              error
+	startErr                error
+	stopErr                 error
+	statusErr               error
+	stayStoppedAfterInstall bool
+}
+
+func (f *fakeManager) Platform() string       { return f.platform }
+func (f *fakeManager) DefinitionPath() string { return f.path }
+func (f *fakeManager) Logs() []string         { return []string{"/tmp/hister.log"} }
+func (f *fakeManager) LoginNote() string      { return "login note" }
+
+func (f *fakeManager) Install(def svc.Definition, opts svc.InstallOptions) error {
+	if f.installErr != nil {
+		return f.installErr
+	}
+	f.lastDef = def
+	f.lastOpts = opts
+	f.installed = true
+	if !opts.NoStart && !f.stayStoppedAfterInstall {
+		f.running = true
+	}
+	return nil
+}
+
+func (f *fakeManager) Uninstall() error {
+	if f.foreign {
+		return svc.ErrForeign
+	}
+	f.installed = false
+	f.running = false
+	return nil
+}
+
+func (f *fakeManager) Start() error {
+	if f.startErr != nil {
+		return f.startErr
+	}
+	if f.foreign {
+		return svc.ErrForeign
+	}
+	if !f.installed {
+		return svc.ErrNotInstalled
+	}
+	f.running = true
+	return nil
+}
+
+func (f *fakeManager) Stop() error {
+	if f.stopErr != nil {
+		return f.stopErr
+	}
+	if f.foreign {
+		return svc.ErrForeign
+	}
+	f.running = false
+	return nil
+}
+
+func (f *fakeManager) Restart() error {
+	if err := f.Stop(); err != nil {
+		return err
+	}
+	return f.Start()
+}
+
+func (f *fakeManager) Status() (svc.Status, error) {
+	if f.statusErr != nil {
+		return svc.Status{}, f.statusErr
+	}
+	st := svc.Status{Platform: f.platform, DefinitionPath: f.path, ExternallyManaged: f.foreign}
+	switch {
+	case f.running:
+		st.State = svc.StateRunning
+		st.PID = 11
+	case f.installed || f.foreign:
+		st.State = svc.StateStopped
+	default:
+		st.State = svc.StateNotInstalled
+	}
+	return st, nil
+}
+
+func isolateHome(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("XDG_STATE_HOME", filepath.Join(home, ".local/state"))
+	t.Setenv("XDG_DATA_HOME", filepath.Join(home, ".local/share"))
+	t.Setenv("HISTER_DATA_DIR", filepath.Join(home, "hister-data"))
+	t.Setenv("HISTER_CONFIG", "")
+	t.Setenv("HISTER_PORT", "")
+	return home
+}
+
+func withFakeManager(t *testing.T, m svc.Manager) {
+	t.Helper()
+	orig := newServiceManager
+	newServiceManager = func() (svc.Manager, error) { return m, nil }
+	t.Cleanup(func() { newServiceManager = orig })
+}
+
+func executeArgs(t *testing.T, args ...string) error {
+	t.Helper()
+	resetRootState(t)
+	rootCmd.SetArgs(args)
+	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+	return rootCmd.Execute()
+}
+
+func TestServiceHelpNoSubcommand(t *testing.T) {
+	isolateHome(t)
+	var buf bytes.Buffer
+	rootCmd.SetOut(&buf)
+	rootCmd.SetErr(&buf)
+	t.Cleanup(func() {
+		rootCmd.SetOut(nil)
+		rootCmd.SetErr(nil)
+	})
+	if err := executeArgs(t, "service"); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(buf.String(), "install") {
+		t.Fatalf("help output: %s", buf.String())
+	}
+}
+
+func TestServiceInstallHelpHidesLogLevel(t *testing.T) {
+	isolateHome(t)
+	var buf bytes.Buffer
+	rootCmd.SetOut(&buf)
+	rootCmd.SetErr(&buf)
+	t.Cleanup(func() {
+		rootCmd.SetOut(nil)
+		rootCmd.SetErr(nil)
+	})
+	if err := executeArgs(t, "service", "install", "--help"); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	if strings.Contains(out, "log-level") || strings.Contains(out, "--log-level") {
+		t.Fatalf("install help should hide --log-level:\n%s", out)
+	}
+	if !strings.Contains(out, "--config") {
+		t.Fatalf("install help should show --config:\n%s", out)
+	}
+}
+
+func TestServiceStatusHelpHidesConfig(t *testing.T) {
+	isolateHome(t)
+	var buf bytes.Buffer
+	rootCmd.SetOut(&buf)
+	rootCmd.SetErr(&buf)
+	t.Cleanup(func() {
+		rootCmd.SetOut(nil)
+		rootCmd.SetErr(nil)
+	})
+	if err := executeArgs(t, "service", "status", "--help"); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	if strings.Contains(out, "--config") {
+		t.Fatalf("status help should hide --config:\n%s", out)
+	}
+	if strings.Contains(out, "log-level") || strings.Contains(out, "--log-level") {
+		t.Fatalf("status help should hide --log-level:\n%s", out)
+	}
+}
+
+func TestServiceUninstallHelpHidesConfig(t *testing.T) {
+	isolateHome(t)
+	var buf bytes.Buffer
+	rootCmd.SetOut(&buf)
+	rootCmd.SetErr(&buf)
+	t.Cleanup(func() {
+		rootCmd.SetOut(nil)
+		rootCmd.SetErr(nil)
+	})
+	if err := executeArgs(t, "service", "uninstall", "--help"); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	if strings.Contains(out, "--config") {
+		t.Fatalf("uninstall help should hide --config:\n%s", out)
+	}
+}
+
+func TestServiceStatusSkipBrokenConfig(t *testing.T) {
+	home := isolateHome(t)
+	cfgPath := filepath.Join(home, ".config", "hister", "config.yml")
+	if err := os.MkdirAll(filepath.Dir(cfgPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(cfgPath, []byte(":\n  - not yaml"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	fake := &fakeManager{platform: "fake", path: filepath.Join(home, "svc"), installed: true}
+	withFakeManager(t, fake)
+	err := executeArgs(t, "service", "status")
+	if ProcessExitCode(err) != svc.ExitStopped {
+		t.Fatalf("status err=%v code=%d", err, ProcessExitCode(err))
+	}
+}
+
+func TestServiceInstallMissingConfigDoesNotCreateData(t *testing.T) {
+	home := isolateHome(t)
+	missing := filepath.Join(home, "nope.yml")
+	dataDir := os.Getenv("HISTER_DATA_DIR")
+	err := executeArgs(t, "--config", missing, "service", "install")
+	if err == nil {
+		t.Fatal("expected missing config error")
+	}
+	if _, statErr := os.Stat(dataDir); !os.IsNotExist(statErr) {
+		t.Fatalf("data dir created: %v", statErr)
+	}
+}
+
+func TestServiceInstallPinsSourcePath(t *testing.T) {
+	home := isolateHome(t)
+	t.Chdir(home)
+	if err := os.WriteFile("mine.yml", []byte("app:\n  title: fromfile\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	fake := &fakeManager{platform: "fake", path: filepath.Join(home, "svc")}
+	withFakeManager(t, fake)
+	if err := executeArgs(t, "--config", "./mine.yml", "service", "install"); err != nil {
+		t.Fatal(err)
+	}
+	want, err := filepath.Abs("mine.yml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fake.lastDef.ConfigPath != want {
+		t.Fatalf("config path = %q, want %q", fake.lastDef.ConfigPath, want)
+	}
+	if fake.lastDef.DataDir == "" || !filepath.IsAbs(fake.lastDef.DataDir) {
+		t.Fatalf("data dir %q", fake.lastDef.DataDir)
+	}
+}
+
+func TestServiceInstallNoStart(t *testing.T) {
+	home := isolateHome(t)
+	fake := &fakeManager{platform: "fake", path: filepath.Join(home, "svc")}
+	withFakeManager(t, fake)
+	if err := executeArgs(t, "service", "install", "--no-start"); err != nil {
+		t.Fatal(err)
+	}
+	if !fake.lastOpts.NoStart || fake.running {
+		t.Fatalf("opts=%+v running=%v", fake.lastOpts, fake.running)
+	}
+}
+
+func TestServiceStatusCodes(t *testing.T) {
+	home := isolateHome(t)
+	fake := &fakeManager{platform: "fake", path: filepath.Join(home, "svc")}
+	withFakeManager(t, fake)
+
+	err := executeArgs(t, "service", "status")
+	if ProcessExitCode(err) != svc.ExitNotInstalled {
+		t.Fatalf("not installed code=%d err=%v", ProcessExitCode(err), err)
+	}
+
+	fake.installed = true
+	err = executeArgs(t, "service", "status")
+	if ProcessExitCode(err) != svc.ExitStopped {
+		t.Fatalf("stopped code=%d err=%v", ProcessExitCode(err), err)
+	}
+
+	fake.running = true
+	if err := executeArgs(t, "service", "status"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestServiceStatusQueryFailure(t *testing.T) {
+	isolateHome(t)
+	fake := &fakeManager{statusErr: errors.New("bus down")}
+	withFakeManager(t, fake)
+	err := executeArgs(t, "service", "status")
+	if ProcessExitCode(err) != 1 {
+		t.Fatalf("query failure code=%d err=%v", ProcessExitCode(err), err)
+	}
+}
+
+func TestServiceStopStartRestart(t *testing.T) {
+	home := isolateHome(t)
+	fake := &fakeManager{platform: "fake", path: filepath.Join(home, "svc"), installed: true, running: true}
+	withFakeManager(t, fake)
+	if err := executeArgs(t, "service", "stop"); err != nil {
+		t.Fatal(err)
+	}
+	if fake.running {
+		t.Fatal("still running")
+	}
+	if err := executeArgs(t, "service", "start"); err != nil {
+		t.Fatal(err)
+	}
+	if err := executeArgs(t, "service", "restart"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestServiceUninstallKeepsDataDir(t *testing.T) {
+	home := isolateHome(t)
+	data := os.Getenv("HISTER_DATA_DIR")
+	if err := os.MkdirAll(data, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	marker := filepath.Join(data, "keep-me")
+	if err := os.WriteFile(marker, []byte("idx"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	fake := &fakeManager{platform: "fake", path: filepath.Join(home, "svc"), installed: true, running: true}
+	withFakeManager(t, fake)
+	if err := executeArgs(t, "service", "uninstall"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(marker); err != nil {
+		t.Fatal("data was deleted")
+	}
+}
+
+func TestServiceInstallRefusesUnpersistedAccessToken(t *testing.T) {
+	home := isolateHome(t)
+	t.Setenv("HISTER__APP__ACCESS_TOKEN", "super-secret-token-value")
+	fake := &fakeManager{platform: "fake", path: filepath.Join(home, "svc")}
+	withFakeManager(t, fake)
+	err := executeArgs(t, "service", "install")
+	if err == nil {
+		t.Fatal("expected refuse")
+	}
+	if !strings.Contains(err.Error(), "HISTER__APP__ACCESS_TOKEN") {
+		t.Fatalf("error = %v", err)
+	}
+	if fake.installed {
+		t.Fatal("must not write a service definition")
+	}
+}
+
+func TestServiceInstallAllowsPinnedDataDir(t *testing.T) {
+	home := isolateHome(t)
+	fake := &fakeManager{platform: "fake", path: filepath.Join(home, "svc")}
+	withFakeManager(t, fake)
+	if err := executeArgs(t, "service", "install"); err != nil {
+		t.Fatal(err)
+	}
+	if !fake.installed {
+		t.Fatal("expected install")
+	}
+}
+
+func TestServiceInstallRefusesHisterPort(t *testing.T) {
+	home := isolateHome(t)
+	t.Setenv("HISTER_PORT", "9999")
+	fake := &fakeManager{platform: "fake", path: filepath.Join(home, "svc")}
+	withFakeManager(t, fake)
+	err := executeArgs(t, "service", "install")
+	if err == nil || !strings.Contains(err.Error(), "HISTER_PORT") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestServiceUninstallQueryFailureDoesNotClaimRemoval(t *testing.T) {
+	home := isolateHome(t)
+	fake := &fakeManager{platform: "fake", path: filepath.Join(home, "svc"), installed: true, statusErr: errors.New("bus down")}
+	withFakeManager(t, fake)
+	out := captureStdout(t, func() {
+		err := executeArgs(t, "service", "uninstall")
+		if ProcessExitCode(err) != 1 {
+			t.Fatalf("err=%v code=%d", err, ProcessExitCode(err))
+		}
+	})
+	if strings.Contains(out, "Removed the Hister service definition.") {
+		t.Fatalf("claimed removal: %s", out)
+	}
+	if !fake.installed {
+		t.Fatal("query failure must not uninstall")
+	}
+}
+
+func TestServiceInstallFailsWhenProcessNotRunning(t *testing.T) {
+	home := isolateHome(t)
+	fake := &fakeManager{platform: "fake", path: filepath.Join(home, "svc"), stayStoppedAfterInstall: true}
+	withFakeManager(t, fake)
+	err := executeArgs(t, "service", "install")
+	if err == nil {
+		t.Fatal("expected install error when process did not start")
+	}
+	if !strings.Contains(err.Error(), "process is not running") {
+		t.Fatalf("error = %v", err)
+	}
+	if ProcessExitCode(err) != 1 {
+		t.Fatalf("code=%d", ProcessExitCode(err))
+	}
+}
+
+func TestServiceInstallHISTERConfigMissingDoesNotFallback(t *testing.T) {
+	home := isolateHome(t)
+	discovered := filepath.Join(home, ".config", "hister", "config.yml")
+	if err := os.MkdirAll(filepath.Dir(discovered), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(discovered, []byte("app:\n  title: discovered\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HISTER_CONFIG", filepath.Join(home, "missing.yml"))
+	fake := &fakeManager{platform: "fake", path: filepath.Join(home, "svc")}
+	withFakeManager(t, fake)
+	err := executeArgs(t, "service", "install")
+	if err == nil {
+		t.Fatal("expected missing HISTER_CONFIG to fail install")
+	}
+	if fake.installed {
+		t.Fatal("must not install using a fallback config")
+	}
+}
+
+func TestServiceInstallPinsHISTERConfig(t *testing.T) {
+	home := isolateHome(t)
+	path := filepath.Join(home, "env.yml")
+	if err := os.WriteFile(path, []byte("app:\n  title: fromenv\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HISTER_CONFIG", path)
+	fake := &fakeManager{platform: "fake", path: filepath.Join(home, "svc")}
+	withFakeManager(t, fake)
+	if err := executeArgs(t, "service", "install"); err != nil {
+		t.Fatal(err)
+	}
+	want, err := filepath.Abs(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fake.lastDef.ConfigPath != want {
+		t.Fatalf("config path = %q, want HISTER_CONFIG %q", fake.lastDef.ConfigPath, want)
+	}
+}
+
+func TestServiceUninstallAlreadyAbsent(t *testing.T) {
+	home := isolateHome(t)
+	fake := &fakeManager{platform: "fake", path: filepath.Join(home, "svc")}
+	withFakeManager(t, fake)
+	out := captureStdout(t, func() {
+		if err := executeArgs(t, "service", "uninstall"); err != nil {
+			t.Fatal(err)
+		}
+	})
+	if !strings.Contains(out, "Hister service is not installed.") {
+		t.Fatalf("output: %s", out)
+	}
+	if strings.Contains(out, "Removed the Hister service definition.") {
+		t.Fatalf("absent uninstall should not claim removal: %s", out)
+	}
+}
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	old := os.Stdout
+	os.Stdout = w
+	defer func() { os.Stdout = old }()
+	done := make(chan string)
+	go func() {
+		var buf bytes.Buffer
+		_, _ = io.Copy(&buf, r)
+		done <- buf.String()
+	}()
+	fn()
+	_ = w.Close()
+	return <-done
+}

--- a/config/config.go
+++ b/config/config.go
@@ -33,6 +33,7 @@ import (
 
 type Config struct {
 	fname                    string
+	sourcePath               string
 	App                      App                   `yaml:"app" mapstructure:"app"`
 	Server                   Server                `yaml:"server" mapstructure:"server"`
 	Indexer                  Indexer               `yaml:"indexer" mapstructure:"indexer"`
@@ -530,6 +531,13 @@ func Load(filename string) (*Config, error) {
 	}
 
 	c.fname = fn
+	if fn != "" {
+		sourcePath, absErr := filepath.Abs(fn)
+		if absErr != nil {
+			return nil, fmt.Errorf("resolve config source path: %w", absErr)
+		}
+		c.sourcePath = sourcePath
+	}
 	return c, c.init()
 }
 
@@ -880,6 +888,15 @@ func (c *Config) Filename() string {
 		return "*Default Config*"
 	}
 	return c.FullPath(c.fname)
+}
+
+// SourcePath returns the absolute path of the config file that was actually
+// read. ok is false when Hister is using built-in defaults (no file).
+func (c *Config) SourcePath() (path string, ok bool) {
+	if c.sourcePath == "" {
+		return "", false
+	}
+	return c.sourcePath, true
 }
 
 func (c *Config) SaveTUIConfig() error {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"os"
+	"path/filepath"
 	"regexp"
 	"testing"
 
@@ -672,5 +673,55 @@ func TestSemanticSearchEmbeddingFingerprint(t *testing.T) {
 	disabledConfig.Enable = false
 	if fingerprint := disabledConfig.EmbeddingFingerprint(); fingerprint != "" {
 		t.Fatalf("disabled semantic search fingerprint = %q, want empty", fingerprint)
+	}
+}
+
+func isolateConfigHome(t *testing.T) {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("XDG_STATE_HOME", filepath.Join(home, ".local/state"))
+	t.Setenv("HISTER_DATA_DIR", filepath.Join(home, "data"))
+	t.Setenv("HISTER_CONFIG", "")
+}
+
+func TestSourcePathMissingFile(t *testing.T) {
+	isolateConfigHome(t)
+	cfg, err := Load(filepath.Join(t.TempDir(), "missing.yml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := cfg.SourcePath(); ok {
+		t.Fatal("SourcePath() ok=true, want false when no config file is read")
+	}
+	if cfg.Filename() == "" {
+		t.Fatal("Filename() is empty")
+	}
+}
+
+func TestSourcePathAbsoluteOfReadFile(t *testing.T) {
+	isolateConfigHome(t)
+	dir := t.TempDir()
+	t.Chdir(dir)
+	name := "mine.yml"
+	if err := os.WriteFile(name, []byte("app:\n  title: sourced\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load("./" + name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, ok := cfg.SourcePath()
+	if !ok {
+		t.Fatal("SourcePath() ok=false, want true")
+	}
+	want, err := filepath.Abs(name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Fatalf("SourcePath() = %q, want cwd-absolute %q", got, want)
 	}
 }

--- a/hister.go
+++ b/hister.go
@@ -8,6 +8,6 @@ import (
 
 func main() {
 	if err := cmd.Execute(); err != nil {
-		os.Exit(1)
+		os.Exit(cmd.ProcessExitCode(err))
 	}
 }

--- a/internal/svc/control_launchd.go
+++ b/internal/svc/control_launchd.go
@@ -1,0 +1,11 @@
+// SPDX-FileContributor: sathwick-p
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//go:build darwin
+
+package svc
+
+func newPlatformManager() (Manager, error) {
+	return newLaunchdManager(defaultRunner, "")
+}

--- a/internal/svc/control_systemd.go
+++ b/internal/svc/control_systemd.go
@@ -1,0 +1,31 @@
+// SPDX-FileContributor: sathwick-p
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//go:build linux
+
+package svc
+
+import (
+	"fmt"
+	"os"
+)
+
+func newPlatformManager() (Manager, error) {
+	if !hasSystemd() {
+		return nil, fmt.Errorf("%w: systemd is not available", ErrUnsupported)
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, err
+	}
+	runtimeDir := os.Getenv("XDG_RUNTIME_DIR")
+	return newSystemdUserManager(defaultRunner, home, runtimeDir, systemdUserBusUp(runtimeDir))
+}
+
+func hasSystemd() bool {
+	if _, err := os.Stat("/run/systemd/system"); err == nil {
+		return true
+	}
+	return systemdUserBusUp("")
+}

--- a/internal/svc/control_unsupported.go
+++ b/internal/svc/control_unsupported.go
@@ -1,0 +1,16 @@
+// SPDX-FileContributor: sathwick-p
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//go:build !darwin && !linux
+
+package svc
+
+import (
+	"fmt"
+	"runtime"
+)
+
+func newPlatformManager() (Manager, error) {
+	return nil, fmt.Errorf("%w on %s", ErrUnsupported, runtime.GOOS)
+}

--- a/internal/svc/definition.go
+++ b/internal/svc/definition.go
@@ -1,0 +1,72 @@
+// SPDX-FileContributor: sathwick-p
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package svc
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+	"unicode"
+	"unicode/utf8"
+)
+
+// Definition is the Hister process a user-level service should run.
+type Definition struct {
+	Binary     string
+	ConfigPath string
+	DataDir    string
+	StdoutLog  string
+	StderrLog  string
+}
+
+func (d Definition) Args() []string {
+	args := []string{d.Binary, "listen"}
+	if d.ConfigPath != "" {
+		args = append(args, "--config", d.ConfigPath)
+	}
+	return args
+}
+
+func (d Definition) Validate() error {
+	if d.Binary == "" {
+		return errors.New("binary path is empty")
+	}
+	if d.DataDir == "" {
+		return errors.New("data directory is empty")
+	}
+	if !filepath.IsAbs(d.Binary) {
+		return fmt.Errorf("binary path %q is not absolute", d.Binary)
+	}
+	if !filepath.IsAbs(d.DataDir) {
+		return fmt.Errorf("data directory %q is not absolute", d.DataDir)
+	}
+	if d.ConfigPath != "" && !filepath.IsAbs(d.ConfigPath) {
+		return fmt.Errorf("config path %q is not absolute", d.ConfigPath)
+	}
+	for _, p := range []string{d.Binary, d.ConfigPath, d.DataDir, d.StdoutLog, d.StderrLog} {
+		if p == "" {
+			continue
+		}
+		if err := rejectPersistedControlChars(p); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func rejectPersistedControlChars(s string) error {
+	if !utf8.ValidString(s) {
+		return errors.New("service path is not valid UTF-8")
+	}
+	for _, r := range s {
+		switch {
+		case r == 0:
+			return errors.New("service path contains a NUL byte")
+		case r == '\n' || r == '\r' || (unicode.IsControl(r) && r != '\t'):
+			return errors.New("service path contains a control character")
+		}
+	}
+	return nil
+}

--- a/internal/svc/exec.go
+++ b/internal/svc/exec.go
@@ -1,0 +1,85 @@
+// SPDX-FileContributor: sathwick-p
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package svc
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// CommandRunner runs an external command and returns stdout, stderr, and the run error.
+type CommandRunner func(name string, args ...string) (stdout, stderr string, err error)
+
+var commandTimeout = 30 * time.Second
+
+func defaultRunner(name string, args ...string) (string, string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), commandTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, name, args...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil && ctx.Err() != nil {
+		return stdout.String(), stderr.String(), fmt.Errorf("%s timed out after %s: %w", name, commandTimeout, ctx.Err())
+	}
+	return stdout.String(), stderr.String(), err
+}
+
+func run(runner CommandRunner, name string, args ...string) (string, string, error) {
+	if runner == nil {
+		runner = defaultRunner
+	}
+	stdout, stderr, err := runner(name, args...)
+	if err != nil {
+		detail := stderr
+		if detail == "" {
+			detail = stdout
+		}
+		if detail != "" {
+			return stdout, stderr, fmt.Errorf("%s: %w: %s", name, err, trimOneLine(detail))
+		}
+		return stdout, stderr, fmt.Errorf("%s: %w", name, err)
+	}
+	return stdout, stderr, nil
+}
+
+func trimOneLine(s string) string {
+	s = strings.TrimRight(s, "\r\n")
+	runes := []rune(s)
+	if len(runes) > 240 {
+		return string(runes[:240]) + "…"
+	}
+	return s
+}
+
+func isMissingExecutable(err error) bool {
+	return err != nil && errors.Is(err, exec.ErrNotFound)
+}
+
+// managerReportsAbsent reports whether launchctl/systemctl output says the
+// job or unit is absent. It inspects command output only, never the Go error
+// string, so "executable file not found in $PATH" is not treated as "not installed".
+func managerReportsAbsent(stderr, stdout string) bool {
+	msg := strings.ToLower(stderr + "\n" + stdout)
+	for _, p := range []string{
+		"could not find service",
+		"could not find domain",
+		"could not be found",
+		"no such process",
+		"service not found",
+		"not loaded",
+	} {
+		if strings.Contains(msg, p) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/svc/exec_test.go
+++ b/internal/svc/exec_test.go
@@ -1,0 +1,58 @@
+// SPDX-FileContributor: sathwick-p
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package svc
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestManagerReportsAbsentDoesNotMatchPATHMiss(t *testing.T) {
+	if managerReportsAbsent("executable file not found in $PATH", "") {
+		t.Fatal("PATH miss must not be treated as a missing job")
+	}
+	if !managerReportsAbsent("Could not find service", "") {
+		t.Fatal("launchd missing job should be absent")
+	}
+	if !managerReportsAbsent("Unit hister.service could not be found.", "") {
+		t.Fatal("systemd missing unit should be absent")
+	}
+}
+
+func TestDefaultRunnerTimeout(t *testing.T) {
+	if os.Getenv("HISTER_TEST_HELPER_SLEEP") == "1" {
+		time.Sleep(time.Hour)
+		return
+	}
+	orig := commandTimeout
+	commandTimeout = 80 * time.Millisecond
+	t.Cleanup(func() { commandTimeout = orig })
+	t.Setenv("HISTER_TEST_HELPER_SLEEP", "1")
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _, err = defaultRunner(exe, "-test.run=^TestDefaultRunnerTimeout$")
+	if err == nil {
+		t.Fatal("expected timeout")
+	}
+	if !strings.Contains(err.Error(), "timed out") {
+		t.Fatalf("timeout error = %v", err)
+	}
+}
+
+func TestIsMissingExecutableUnwraps(t *testing.T) {
+	if isMissingExecutable(errors.New("not found")) {
+		t.Fatal("generic not found is not ErrNotFound")
+	}
+	wrapped := errors.Join(exec.ErrNotFound)
+	if !isMissingExecutable(wrapped) {
+		t.Fatal("wrapped ErrNotFound should match")
+	}
+}

--- a/internal/svc/launchd.go
+++ b/internal/svc/launchd.go
@@ -1,0 +1,120 @@
+// SPDX-FileContributor: sathwick-p
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package svc
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+func newLaunchdManager(runner CommandRunner, home string) (*userManager, error) {
+	if home == "" {
+		var err error
+		home, err = os.UserHomeDir()
+		if err != nil {
+			return nil, err
+		}
+	}
+	if runner == nil {
+		runner = defaultRunner
+	}
+	plist := filepath.Join(home, "Library", "LaunchAgents", launchdLabel+".plist")
+	stdoutLog := filepath.Join(home, "Library", "Logs", "hister.log")
+	stderrLog := filepath.Join(home, "Library", "Logs", "hister-error.log")
+	uid := os.Getuid()
+	domain := "gui/" + strconv.Itoa(uid)
+	target := domain + "/" + launchdLabel
+
+	m := &userManager{
+		platform:       "launchd",
+		definitionPath: plist,
+		logs:           []string{stdoutLog, stderrLog},
+		loginNote:      "Hister will start at login.",
+		runner:         runner,
+	}
+	m.render = RenderLaunchd
+	m.withPlatformPaths = func(def Definition) Definition {
+		def.StdoutLog = stdoutLog
+		def.StderrLog = stderrLog
+		return def
+	}
+	m.prepare = func(def Definition) error {
+		if err := os.MkdirAll(filepath.Dir(plist), 0o755); err != nil {
+			return err
+		}
+		if def.StdoutLog != "" {
+			if err := os.MkdirAll(filepath.Dir(def.StdoutLog), 0o755); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	m.canStartNow = func() bool { return true }
+	m.startUnavailableError = func() error {
+		return errors.New("launchd is unavailable")
+	}
+	m.start = func() error {
+		q, err := m.query()
+		if err != nil {
+			return err
+		}
+		if q.loaded {
+			_, _, err := run(m.runner, "launchctl", "kickstart", target)
+			return err
+		}
+		_, _, err = run(m.runner, "launchctl", "bootstrap", domain, plist)
+		return err
+	}
+	m.stop = func() error {
+		stdout, stderr, err := run(m.runner, "launchctl", "bootout", target)
+		if err != nil && !isMissingExecutable(err) && managerReportsAbsent(stderr, stdout) {
+			return nil
+		}
+		return err
+	}
+	m.reload = func() error { return nil }
+	m.query = func() (jobQuery, error) {
+		stdout, stderr, err := run(m.runner, "launchctl", "print", target)
+		if err != nil {
+			if isMissingExecutable(err) {
+				return jobQuery{}, err
+			}
+			if managerReportsAbsent(stderr, stdout) {
+				return jobQuery{}, nil
+			}
+			return jobQuery{}, err
+		}
+		running, pid := parseLaunchdPrint(stdout)
+		return jobQuery{loaded: true, running: running, pid: pid}, nil
+	}
+	return m, nil
+}
+
+func parseLaunchdPrint(out string) (bool, int) {
+	running := false
+	pid := 0
+	for line := range strings.SplitSeq(out, "\n") {
+		line = strings.TrimSpace(line)
+		switch {
+		case strings.HasPrefix(line, "state = "):
+			state := strings.TrimPrefix(line, "state = ")
+			if state == "running" {
+				running = true
+			}
+		case strings.HasPrefix(line, "pid = "):
+			n, convErr := strconv.Atoi(strings.TrimPrefix(line, "pid = "))
+			if convErr == nil {
+				pid = n
+			}
+		}
+	}
+	if pid > 0 {
+		running = true
+	}
+	return running, pid
+}

--- a/internal/svc/launchd_test.go
+++ b/internal/svc/launchd_test.go
@@ -1,0 +1,348 @@
+// SPDX-FileContributor: sathwick-p
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package svc
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLaunchdInstallStartStopUninstall(t *testing.T) {
+	home := t.TempDir()
+	loaded := false
+	runner := func(name string, args []string) (string, string, error) {
+		if name != "launchctl" {
+			return "", "", fmt.Errorf("unexpected %s", name)
+		}
+		switch args[0] {
+		case "bootstrap":
+			loaded = true
+			return "", "", nil
+		case "bootout":
+			if !loaded {
+				return "", "Could not find service", errors.New("exit 1")
+			}
+			loaded = false
+			return "", "", nil
+		case "print":
+			if !loaded {
+				return "", "Could not find service", errors.New("exit 1")
+			}
+			return "state = running\npid = 99\n", "", nil
+		case "kickstart":
+			return "", "", nil
+		default:
+			return "", "", fmt.Errorf("unexpected %v", args)
+		}
+	}
+	m, err := newLaunchdManager(adaptRunner(runner), home)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	st, err := m.Status()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st.State != StateNotInstalled || st.ExitCode() != ExitNotInstalled {
+		t.Fatalf("status = %+v", st)
+	}
+
+	bin := filepath.Join(home, "bin", "hister")
+	if err := os.MkdirAll(filepath.Dir(bin), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(bin, []byte("x"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	def := Definition{Binary: bin, DataDir: filepath.Join(home, "data")}
+	if err := m.Install(def, InstallOptions{}); err != nil {
+		t.Fatal(err)
+	}
+	body, err := os.ReadFile(m.DefinitionPath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(body), MarkerPlist) {
+		t.Fatal("missing marker")
+	}
+	st, err = m.Status()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st.State != StateRunning || st.PID != 99 {
+		t.Fatalf("after install: %+v", st)
+	}
+
+	if err := m.Install(def, InstallOptions{}); err == nil {
+		t.Fatal("second install should fail without --force")
+	}
+
+	if err := m.Stop(); err != nil {
+		t.Fatal(err)
+	}
+	st, err = m.Status()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st.State != StateStopped || st.ExitCode() != ExitStopped {
+		t.Fatalf("after stop: %+v", st)
+	}
+
+	if err := m.Start(); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.Restart(); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.Uninstall(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(m.DefinitionPath()); !os.IsNotExist(err) {
+		t.Fatal("definition still on disk")
+	}
+	if err := m.Uninstall(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestLaunchdForeignRefusesMutations(t *testing.T) {
+	home := t.TempDir()
+	m, err := newLaunchdManager(adaptRunner(func(string, []string) (string, string, error) {
+		return "state = running\npid = 1\n", "", nil
+	}), home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(m.DefinitionPath()), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	nix := filepath.Join(home, "nix-unit")
+	if err := os.WriteFile(nix, []byte("foreign"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(nix, m.DefinitionPath()); err != nil {
+		t.Fatal(err)
+	}
+
+	def := Definition{Binary: filepath.Join(home, "hister"), DataDir: filepath.Join(home, "data")}
+	if err := os.WriteFile(def.Binary, []byte("x"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.Install(def, InstallOptions{Force: true}); !errors.Is(err, ErrForeign) {
+		t.Fatalf("force install foreign: %v", err)
+	}
+	if err := m.Start(); !errors.Is(err, ErrForeign) {
+		t.Fatalf("start foreign: %v", err)
+	}
+	if err := m.Stop(); !errors.Is(err, ErrForeign) {
+		t.Fatalf("stop foreign: %v", err)
+	}
+	if err := m.Uninstall(); !errors.Is(err, ErrForeign) {
+		t.Fatalf("uninstall foreign: %v", err)
+	}
+	st, err := m.Status()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !st.ExternallyManaged || st.State != StateRunning {
+		t.Fatalf("status %+v", st)
+	}
+}
+
+func TestLaunchdNoStart(t *testing.T) {
+	home := t.TempDir()
+	bootstrapped := false
+	m, err := newLaunchdManager(adaptRunner(func(name string, args []string) (string, string, error) {
+		if args[0] == "bootstrap" {
+			bootstrapped = true
+		}
+		if args[0] == "print" {
+			return "", "Could not find service", errors.New("exit 1")
+		}
+		return "", "", nil
+	}), home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	def := Definition{Binary: filepath.Join(home, "hister"), DataDir: filepath.Join(home, "data")}
+	if err := os.WriteFile(def.Binary, []byte("x"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.Install(def, InstallOptions{NoStart: true}); err != nil {
+		t.Fatal(err)
+	}
+	if bootstrapped {
+		t.Fatal("bootstrap should not run with --no-start")
+	}
+	st, err := m.Status()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st.State != StateStopped {
+		t.Fatalf("status %+v", st)
+	}
+}
+
+func TestLaunchdForceStopFailureLeavesFile(t *testing.T) {
+	home := t.TempDir()
+	m, err := newLaunchdManager(adaptRunner(func(name string, args []string) (string, string, error) {
+		switch args[0] {
+		case "print":
+			return "state = running\npid = 8\n", "", nil
+		case "bootout":
+			return "", "busy", errors.New("exit 1")
+		default:
+			return "", "", nil
+		}
+	}), home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(m.DefinitionPath()), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	original := []byte("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + MarkerPlist + "\nold\n")
+	if err := os.WriteFile(m.DefinitionPath(), original, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	def := Definition{Binary: filepath.Join(home, "hister"), DataDir: filepath.Join(home, "data")}
+	if err := os.WriteFile(def.Binary, []byte("x"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.Install(def, InstallOptions{Force: true}); err == nil {
+		t.Fatal("expected stop failure")
+	}
+	got, err := os.ReadFile(m.DefinitionPath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(original) {
+		t.Fatalf("file overwritten: %q", got)
+	}
+}
+
+func TestLaunchdStartKickstartWhenAlreadyLoaded(t *testing.T) {
+	home := t.TempDir()
+	kickstarted := false
+	bootstrapped := false
+	m, err := newLaunchdManager(adaptRunner(func(name string, args []string) (string, string, error) {
+		switch args[0] {
+		case "bootstrap":
+			bootstrapped = true
+			return "", "service already loaded", errors.New("exit 5")
+		case "kickstart":
+			kickstarted = true
+			return "", "", nil
+		case "print":
+			return "state = running\npid = 3\n", "", nil
+		default:
+			return "", "", fmt.Errorf("unexpected %v", args)
+		}
+	}), home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(m.DefinitionPath()), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(m.DefinitionPath(), []byte("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"+MarkerPlist+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.Start(); err != nil {
+		t.Fatal(err)
+	}
+	if !kickstarted {
+		t.Fatal("expected kickstart when print reports loaded")
+	}
+	if bootstrapped {
+		t.Fatal("bootstrap must not run when the job is already loaded")
+	}
+}
+
+func TestLaunchdOrphanLoadedIsForeign(t *testing.T) {
+	home := t.TempDir()
+	bootout := false
+	m, err := newLaunchdManager(adaptRunner(func(name string, args []string) (string, string, error) {
+		switch args[0] {
+		case "print":
+			return "state = waiting\npid = 0\n", "", nil
+		case "bootout":
+			bootout = true
+			return "", "", nil
+		case "bootstrap":
+			return "", "", fmt.Errorf("must not bootstrap")
+		default:
+			return "", "", fmt.Errorf("unexpected %v", args)
+		}
+	}), home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	st, err := m.Status()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !st.ExternallyManaged || st.State != StateStopped {
+		t.Fatalf("status %+v", st)
+	}
+	def := Definition{Binary: filepath.Join(home, "hister"), DataDir: filepath.Join(home, "data")}
+	if err := os.WriteFile(def.Binary, []byte("x"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.Install(def, InstallOptions{Force: true}); !errors.Is(err, ErrForeign) {
+		t.Fatalf("install orphan: %v", err)
+	}
+	if err := m.Start(); !errors.Is(err, ErrForeign) {
+		t.Fatalf("start orphan: %v", err)
+	}
+	if err := m.Uninstall(); !errors.Is(err, ErrForeign) {
+		t.Fatalf("uninstall orphan: %v", err)
+	}
+	if bootout {
+		t.Fatal("must not bootout an orphan loaded job")
+	}
+}
+
+func TestLaunchdUninstallQueryFailure(t *testing.T) {
+	home := t.TempDir()
+	m, err := newLaunchdManager(adaptRunner(func(string, []string) (string, string, error) {
+		return "", "launchd busy", errors.New("exit 1")
+	}), home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := m.Uninstall(); err == nil {
+		t.Fatal("expected query failure")
+	}
+}
+
+func TestLaunchdStatusMissingLaunchctlIsFailure(t *testing.T) {
+	home := t.TempDir()
+	m, err := newLaunchdManager(adaptRunner(func(string, []string) (string, string, error) {
+		return "", "", exec.ErrNotFound
+	}), home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	st, err := m.Status()
+	if err == nil {
+		t.Fatalf("status succeeded: %+v", st)
+	}
+	if !errors.Is(err, exec.ErrNotFound) {
+		t.Fatalf("status err=%v, want ErrNotFound", err)
+	}
+}
+
+func adaptRunner(fn func(name string, args []string) (string, string, error)) CommandRunner {
+	return func(name string, args ...string) (string, string, error) {
+		return fn(name, args)
+	}
+}

--- a/internal/svc/lifecycle.go
+++ b/internal/svc/lifecycle.go
@@ -1,0 +1,282 @@
+// SPDX-FileContributor: sathwick-p
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package svc
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+type userManager struct {
+	platform              string
+	definitionPath        string
+	wantsPath             string
+	wantsTarget           string
+	logs                  []string
+	loginNote             string
+	runner                CommandRunner
+	render                func(Definition) (string, error)
+	prepare               func(Definition) error
+	withPlatformPaths     func(Definition) Definition
+	start                 func() error
+	stop                  func() error
+	query                 func() (jobQuery, error)
+	reload                func() error
+	canStartNow           func() bool
+	startUnavailableError func() error
+}
+
+func (m *userManager) Platform() string { return m.platform }
+func (m *userManager) DefinitionPath() string {
+	return m.definitionPath
+}
+func (m *userManager) Logs() []string    { return m.logs }
+func (m *userManager) LoginNote() string { return m.loginNote }
+
+type jobQuery struct {
+	loaded  bool
+	running bool
+	failed  bool
+	pid     int
+}
+
+func (m *userManager) Install(def Definition, opts InstallOptions) error {
+	def = m.withPlatformPaths(def)
+	if err := def.Validate(); err != nil {
+		return err
+	}
+
+	own, err := Classify(m.definitionPath)
+	if err != nil {
+		return err
+	}
+	switch own {
+	case OwnershipForeign:
+		return ErrForeign
+	case OwnershipOurs:
+		if !opts.Force {
+			return ErrAlreadyInstalled
+		}
+	}
+	if err := m.requireEnableLinkWritable(); err != nil {
+		return err
+	}
+
+	content, err := m.render(def)
+	if err != nil {
+		return err
+	}
+
+	q, qerr := m.query()
+	if qerr != nil && own != OwnershipMissing {
+		return fmt.Errorf("query service manager: %w", qerr)
+	}
+	if isOrphanJob(own, q, qerr) {
+		return ErrForeign
+	}
+	if err := m.prepare(def); err != nil {
+		return err
+	}
+
+	hooks := replaceHooks{
+		stopFirst:   own == OwnershipOurs && (q.loaded || q.running || opts.Force),
+		restoreRun:  own == OwnershipOurs && q.running,
+		stop:        m.stop,
+		reload:      m.reload,
+		start:       m.start,
+		startWanted: !opts.NoStart,
+	}
+	if !m.canStartNow() {
+		hooks.start = func() error {
+			return m.startUnavailableError()
+		}
+		if opts.NoStart {
+			hooks.startWanted = false
+		}
+	}
+
+	return replaceDefinition(m.definitionPath, []byte(content), m.extras(), hooks)
+}
+
+func (m *userManager) Uninstall() error {
+	own, err := Classify(m.definitionPath)
+	if err != nil {
+		return err
+	}
+	if own == OwnershipForeign {
+		return ErrForeign
+	}
+	if err := m.requireEnableLinkWritable(); err != nil {
+		return err
+	}
+
+	q, qerr := m.query()
+	if qerr != nil {
+		return fmt.Errorf("query service manager: %w", qerr)
+	}
+	if own == OwnershipMissing {
+		if q.loaded || q.running {
+			return ErrForeign
+		}
+		removed := false
+		for _, extra := range m.extras() {
+			if err := os.Remove(extra.path); err != nil {
+				if os.IsNotExist(err) {
+					continue
+				}
+				return err
+			}
+			removed = true
+		}
+		if removed && m.reload != nil {
+			if err := m.reload(); err != nil {
+				return fmt.Errorf("removed service definition, but reload failed: %w", err)
+			}
+		}
+		return nil
+	}
+
+	if err := m.stop(); err != nil {
+		return err
+	}
+	for _, extra := range m.extras() {
+		if err := os.Remove(extra.path); err != nil && !os.IsNotExist(err) {
+			return err
+		}
+	}
+	if err := os.Remove(m.definitionPath); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	if m.reload != nil {
+		if err := m.reload(); err != nil {
+			return fmt.Errorf("removed service definition, but reload failed: %w", err)
+		}
+	}
+	return nil
+}
+
+func (m *userManager) Start() error {
+	if err := m.requireOurs(); err != nil {
+		return err
+	}
+	if !m.canStartNow() {
+		return m.startUnavailableError()
+	}
+	return m.start()
+}
+
+func (m *userManager) Stop() error {
+	if err := m.requireOurs(); err != nil {
+		return err
+	}
+	if !m.canStartNow() {
+		return m.startUnavailableError()
+	}
+	return m.stop()
+}
+
+func (m *userManager) Restart() error {
+	if err := m.requireOurs(); err != nil {
+		return err
+	}
+	if !m.canStartNow() {
+		return m.startUnavailableError()
+	}
+	if err := m.stop(); err != nil {
+		return err
+	}
+	return m.start()
+}
+
+func (m *userManager) Status() (Status, error) {
+	st := Status{
+		DefinitionPath: m.definitionPath,
+		Platform:       m.platform,
+	}
+	own, err := Classify(m.definitionPath)
+	if err != nil {
+		return st, err
+	}
+
+	q, qerr := m.query()
+	if qerr != nil {
+		return st, fmt.Errorf("query service manager: %w", qerr)
+	}
+
+	st.ExternallyManaged = own == OwnershipForeign || isOrphanJob(own, q, qerr)
+	if own == OwnershipMissing && !q.loaded && !q.running {
+		st.State = StateNotInstalled
+		return st, nil
+	}
+	if q.running {
+		st.State = StateRunning
+		st.PID = q.pid
+		return st, nil
+	}
+	st.State = StateStopped
+	st.Failed = q.failed
+	return st, nil
+}
+
+func (m *userManager) requireOurs() error {
+	own, err := Classify(m.definitionPath)
+	if err != nil {
+		return err
+	}
+	switch own {
+	case OwnershipForeign:
+		return ErrForeign
+	case OwnershipMissing:
+		q, qerr := m.query()
+		if qerr != nil {
+			return fmt.Errorf("query service manager: %w", qerr)
+		}
+		if q.loaded || q.running {
+			return ErrForeign
+		}
+		return ErrNotInstalled
+	}
+	return nil
+}
+
+func isOrphanJob(own Ownership, q jobQuery, qerr error) bool {
+	return own == OwnershipMissing && qerr == nil && (q.loaded || q.running)
+}
+
+func (m *userManager) requireEnableLinkWritable() error {
+	own, err := classifyEnableLink(m.wantsPath, m.wantsTarget)
+	if err != nil {
+		return err
+	}
+	if own == OwnershipForeign {
+		return ErrForeign
+	}
+	return nil
+}
+
+func (m *userManager) extras() []extraArtifact {
+	if m.wantsPath == "" {
+		return nil
+	}
+	return []extraArtifact{{path: m.wantsPath, symlink: m.wantsTarget}}
+}
+
+func userConfigDir(home string) (string, error) {
+	if xdg := os.Getenv("XDG_CONFIG_HOME"); xdg != "" {
+		if !filepath.IsAbs(xdg) {
+			return "", fmt.Errorf("XDG_CONFIG_HOME %q is not an absolute path", xdg)
+		}
+		return xdg, nil
+	}
+	if home == "" {
+		var err error
+		home, err = os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+	}
+	return filepath.Join(home, ".config"), nil
+}

--- a/internal/svc/manager.go
+++ b/internal/svc/manager.go
@@ -1,0 +1,103 @@
+// SPDX-FileContributor: sathwick-p
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package svc
+
+import (
+	"errors"
+	"fmt"
+)
+
+// Exit codes for `hister service status`. Ownership (ours vs foreign) does not change them.
+const (
+	ExitRunning      = 0
+	ExitFailure      = 1
+	ExitStopped      = 3
+	ExitNotInstalled = 4
+)
+
+var (
+	ErrUnsupported      = errors.New("background service install is not available on this platform")
+	ErrNotInstalled     = errors.New("hister service is not installed")
+	ErrAlreadyInstalled = errors.New("hister service is already installed; use --force to replace it")
+	ErrForeign          = errors.New("service definition is managed externally")
+	ErrUnstableBinary   = errors.New("refusing to install a binary path that will change on the next upgrade")
+)
+
+// Manager is the native user-level service controller.
+type Manager interface {
+	Platform() string
+	DefinitionPath() string
+	Logs() []string
+	LoginNote() string
+	Install(def Definition, opts InstallOptions) error
+	Uninstall() error
+	Start() error
+	Stop() error
+	Restart() error
+	Status() (Status, error)
+}
+
+// InstallOptions controls whether an existing owned definition may be replaced
+// and whether the process should be started after writing.
+type InstallOptions struct {
+	Force   bool
+	NoStart bool
+}
+
+// State is the process state reported by Status.
+type State int
+
+const (
+	StateNotInstalled State = iota
+	StateStopped
+	StateRunning
+)
+
+// Status is the result of querying the native service manager.
+type Status struct {
+	State             State
+	PID               int
+	DefinitionPath    string
+	Platform          string
+	ExternallyManaged bool
+	Failed            bool
+}
+
+func (s Status) ExitCode() int {
+	switch s.State {
+	case StateRunning:
+		return ExitRunning
+	case StateStopped:
+		return ExitStopped
+	case StateNotInstalled:
+		return ExitNotInstalled
+	default:
+		return ExitFailure
+	}
+}
+
+func (s Status) String() string {
+	switch s.State {
+	case StateRunning:
+		if s.PID > 0 {
+			return fmt.Sprintf("running (pid %d)", s.PID)
+		}
+		return "running"
+	case StateStopped:
+		if s.Failed {
+			return "installed, failed"
+		}
+		return "installed, not running"
+	case StateNotInstalled:
+		return "not installed"
+	default:
+		return "unknown"
+	}
+}
+
+// New returns the platform service manager.
+func New() (Manager, error) {
+	return newPlatformManager()
+}

--- a/internal/svc/owner.go
+++ b/internal/svc/owner.go
@@ -1,0 +1,116 @@
+// SPDX-FileContributor: sathwick-p
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package svc
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	MarkerSystemd = "# Managed by hister service"
+	MarkerPlist   = "<!-- Managed by hister service -->"
+)
+
+// Ownership of a service definition file on disk.
+type Ownership int
+
+const (
+	OwnershipMissing Ownership = iota
+	OwnershipOurs
+	OwnershipForeign
+)
+
+func (o Ownership) String() string {
+	switch o {
+	case OwnershipMissing:
+		return "missing"
+	case OwnershipOurs:
+		return "ours"
+	case OwnershipForeign:
+		return "foreign"
+	default:
+		return "unknown"
+	}
+}
+
+// Classify reports whether path is missing, owned by `hister service`, or
+// managed elsewhere. Symlinks are always foreign (Home Manager / Nix).
+func Classify(path string) (Ownership, error) {
+	st, err := os.Lstat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return OwnershipMissing, nil
+		}
+		return 0, err
+	}
+	if st.Mode()&os.ModeSymlink != 0 || !st.Mode().IsRegular() {
+		return OwnershipForeign, nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return 0, fmt.Errorf("read %s: %w", path, err)
+	}
+	if ownedByHister(data) {
+		return OwnershipOurs, nil
+	}
+	return OwnershipForeign, nil
+}
+
+func ownedByHister(data []byte) bool {
+	s := strings.TrimPrefix(string(data), "\ufeff")
+	var lines []string
+	for line := range strings.SplitSeq(s, "\n") {
+		line = strings.TrimSpace(strings.TrimSuffix(line, "\r"))
+		if line != "" {
+			lines = append(lines, line)
+		}
+	}
+	if len(lines) == 0 {
+		return false
+	}
+	if lines[0] == MarkerSystemd {
+		return true
+	}
+	return strings.HasPrefix(lines[0], "<?xml") && len(lines) > 1 && lines[1] == MarkerPlist
+}
+
+func classifyEnableLink(path, wantTarget string) (Ownership, error) {
+	if path == "" {
+		return OwnershipMissing, nil
+	}
+	st, err := os.Lstat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return OwnershipMissing, nil
+		}
+		return 0, err
+	}
+	if st.Mode()&os.ModeSymlink == 0 {
+		return OwnershipForeign, nil
+	}
+	got, err := os.Readlink(path)
+	if err != nil {
+		return 0, err
+	}
+	if enableLinkPointsAt(path, got, wantTarget) {
+		return OwnershipOurs, nil
+	}
+	return OwnershipForeign, nil
+}
+
+func enableLinkPointsAt(linkPath, got, want string) bool {
+	if got == want {
+		return true
+	}
+	if !filepath.IsAbs(got) {
+		got = filepath.Join(filepath.Dir(linkPath), got)
+	}
+	gotAbs, err1 := filepath.Abs(got)
+	wantAbs, err2 := filepath.Abs(want)
+	return err1 == nil && err2 == nil && gotAbs == wantAbs
+}

--- a/internal/svc/owner_test.go
+++ b/internal/svc/owner_test.go
@@ -1,0 +1,152 @@
+// SPDX-FileContributor: sathwick-p
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package svc
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestClassify(t *testing.T) {
+	dir := t.TempDir()
+
+	missing := filepath.Join(dir, "missing.plist")
+	own, err := Classify(missing)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if own != OwnershipMissing {
+		t.Fatalf("missing: %s", own)
+	}
+
+	ours := filepath.Join(dir, "ours.plist")
+	if err := os.WriteFile(ours, []byte("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"+MarkerPlist+"\n<plist/>\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	own, err = Classify(ours)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if own != OwnershipOurs {
+		t.Fatalf("ours: %s", own)
+	}
+
+	unit := filepath.Join(dir, "hister.service")
+	if err := os.WriteFile(unit, []byte(MarkerSystemd+"\n[Service]\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	own, err = Classify(unit)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if own != OwnershipOurs {
+		t.Fatalf("systemd ours: %s", own)
+	}
+
+	foreign := filepath.Join(dir, "foreign.service")
+	if err := os.WriteFile(foreign, []byte("[Service]\nExecStart=/bin/true\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	own, err = Classify(foreign)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if own != OwnershipForeign {
+		t.Fatalf("no marker: %s", own)
+	}
+
+	link := filepath.Join(dir, "link.service")
+	if err := os.Symlink(unit, link); err != nil {
+		t.Fatal(err)
+	}
+	own, err = Classify(link)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if own != OwnershipForeign {
+		t.Fatalf("symlink: %s", own)
+	}
+
+	embedded := filepath.Join(dir, "embedded.service")
+	if err := os.WriteFile(embedded, []byte("[Unit]\n# example: "+MarkerSystemd+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	own, err = Classify(embedded)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if own != OwnershipForeign {
+		t.Fatalf("embedded marker: %s", own)
+	}
+}
+
+func TestClassifyEnableLink(t *testing.T) {
+	dir := t.TempDir()
+	unit := filepath.Join(dir, "hister.service")
+	wants := filepath.Join(dir, "hister.service.wants")
+
+	own, err := classifyEnableLink(wants, unit)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if own != OwnershipMissing {
+		t.Fatalf("missing wants: %s", own)
+	}
+
+	if err := os.Symlink(unit, wants); err != nil {
+		t.Fatal(err)
+	}
+	own, err = classifyEnableLink(wants, unit)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if own != OwnershipOurs {
+		t.Fatalf("ours wants: %s", own)
+	}
+
+	if err := os.Remove(wants); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(wants, []byte("not a symlink"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	own, err = classifyEnableLink(wants, unit)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if own != OwnershipForeign {
+		t.Fatalf("regular file wants: %s", own)
+	}
+
+	if err := os.Remove(wants); err != nil {
+		t.Fatal(err)
+	}
+	other := filepath.Join(dir, "other.service")
+	if err := os.Symlink(other, wants); err != nil {
+		t.Fatal(err)
+	}
+	own, err = classifyEnableLink(wants, unit)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if own != OwnershipForeign {
+		t.Fatalf("wrong target wants: %s", own)
+	}
+
+	if err := os.Remove(wants); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(wants, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	own, err = classifyEnableLink(wants, unit)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if own != OwnershipForeign {
+		t.Fatalf("directory wants: %s", own)
+	}
+}

--- a/internal/svc/render_launchd.go
+++ b/internal/svc/render_launchd.go
@@ -1,0 +1,144 @@
+// SPDX-FileContributor: sathwick-p
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package svc
+
+import (
+	"encoding/xml"
+	"strconv"
+	"strings"
+)
+
+const launchdLabel = "org.hister.server"
+
+func RenderLaunchd(def Definition) (string, error) {
+	if err := def.Validate(); err != nil {
+		return "", err
+	}
+	var b strings.Builder
+	b.WriteString(`<?xml version="1.0" encoding="UTF-8"?>` + "\n")
+	b.WriteString(MarkerPlist + "\n")
+	b.WriteString(`<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">` + "\n")
+	b.WriteString(`<plist version="1.0">` + "\n")
+	b.WriteString("<dict>\n")
+	if err := writePlistKey(&b, "Label"); err != nil {
+		return "", err
+	}
+	if err := writePlistString(&b, launchdLabel); err != nil {
+		return "", err
+	}
+
+	if err := writePlistKey(&b, "ProgramArguments"); err != nil {
+		return "", err
+	}
+	b.WriteString("<array>\n")
+	for _, arg := range def.Args() {
+		if err := writePlistString(&b, arg); err != nil {
+			return "", err
+		}
+	}
+	b.WriteString("</array>\n")
+
+	if err := writePlistKey(&b, "WorkingDirectory"); err != nil {
+		return "", err
+	}
+	if err := writePlistString(&b, def.DataDir); err != nil {
+		return "", err
+	}
+
+	if err := writePlistKey(&b, "EnvironmentVariables"); err != nil {
+		return "", err
+	}
+	b.WriteString("<dict>\n")
+	if err := writePlistKey(&b, "HISTER_DATA_DIR"); err != nil {
+		return "", err
+	}
+	if err := writePlistString(&b, def.DataDir); err != nil {
+		return "", err
+	}
+	b.WriteString("</dict>\n")
+
+	if err := writePlistKey(&b, "RunAtLoad"); err != nil {
+		return "", err
+	}
+	b.WriteString("<true/>\n")
+
+	if err := writePlistKey(&b, "KeepAlive"); err != nil {
+		return "", err
+	}
+	b.WriteString("<dict>\n")
+	if err := writePlistKey(&b, "Crashed"); err != nil {
+		return "", err
+	}
+	b.WriteString("<true/>\n")
+	if err := writePlistKey(&b, "SuccessfulExit"); err != nil {
+		return "", err
+	}
+	b.WriteString("<false/>\n")
+	b.WriteString("</dict>\n")
+
+	if err := writePlistKey(&b, "ProcessType"); err != nil {
+		return "", err
+	}
+	if err := writePlistString(&b, "Background"); err != nil {
+		return "", err
+	}
+
+	if err := writePlistKey(&b, "Umask"); err != nil {
+		return "", err
+	}
+	b.WriteString("<integer>")
+	b.WriteString(strconv.Itoa(0o077))
+	b.WriteString("</integer>\n")
+
+	if def.StdoutLog != "" {
+		if err := writePlistKey(&b, "StandardOutPath"); err != nil {
+			return "", err
+		}
+		if err := writePlistString(&b, def.StdoutLog); err != nil {
+			return "", err
+		}
+	}
+	if def.StderrLog != "" {
+		if err := writePlistKey(&b, "StandardErrorPath"); err != nil {
+			return "", err
+		}
+		if err := writePlistString(&b, def.StderrLog); err != nil {
+			return "", err
+		}
+	}
+
+	b.WriteString("</dict>\n</plist>\n")
+	return b.String(), nil
+}
+
+func writePlistKey(b *strings.Builder, key string) error {
+	escaped, err := xmlEscape(key)
+	if err != nil {
+		return err
+	}
+	b.WriteString("<key>")
+	b.WriteString(escaped)
+	b.WriteString("</key>\n")
+	return nil
+}
+
+func writePlistString(b *strings.Builder, s string) error {
+	escaped, err := xmlEscape(s)
+	if err != nil {
+		return err
+	}
+	b.WriteString("<string>")
+	b.WriteString(escaped)
+	b.WriteString("</string>\n")
+	return nil
+}
+
+func xmlEscape(s string) (string, error) {
+	var b strings.Builder
+	if err := xml.EscapeText(&b, []byte(s)); err != nil {
+		return "", err
+	}
+	return b.String(), nil
+}

--- a/internal/svc/render_systemd_user.go
+++ b/internal/svc/render_systemd_user.go
@@ -1,0 +1,86 @@
+// SPDX-FileContributor: sathwick-p
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package svc
+
+import (
+	"strings"
+)
+
+func RenderSystemdUser(def Definition) (string, error) {
+	if err := def.Validate(); err != nil {
+		return "", err
+	}
+
+	execParts := make([]string, 0, 4)
+	for _, arg := range def.Args() {
+		quoted, err := quoteSystemdExecArg(arg)
+		if err != nil {
+			return "", err
+		}
+		execParts = append(execParts, quoted)
+	}
+	workDir, err := quoteSystemdPath(def.DataDir)
+	if err != nil {
+		return "", err
+	}
+	env, err := quoteSystemdValue("HISTER_DATA_DIR=" + def.DataDir)
+	if err != nil {
+		return "", err
+	}
+
+	var b strings.Builder
+	b.WriteString(MarkerSystemd + "\n")
+	b.WriteString("[Unit]\n")
+	b.WriteString("Description=Hister search engine\n")
+	b.WriteString("\n")
+	b.WriteString("[Service]\n")
+	b.WriteString("Type=exec\n")
+	b.WriteString("ExecStart=" + strings.Join(execParts, " ") + "\n")
+	b.WriteString("WorkingDirectory=" + workDir + "\n")
+	b.WriteString("Environment=" + env + "\n")
+	b.WriteString("Restart=on-failure\n")
+	b.WriteString("UMask=0077\n")
+	b.WriteString("\n")
+	b.WriteString("[Install]\n")
+	b.WriteString("WantedBy=default.target\n")
+	return b.String(), nil
+}
+
+func quoteSystemdExecArg(s string) (string, error) {
+	if err := rejectPersistedControlChars(s); err != nil {
+		return "", err
+	}
+	s = strings.ReplaceAll(s, "%", "%%")
+	s = strings.ReplaceAll(s, "$", "$$")
+	return quoteSystemdToken(s), nil
+}
+
+func quoteSystemdValue(s string) (string, error) {
+	if err := rejectPersistedControlChars(s); err != nil {
+		return "", err
+	}
+	s = strings.ReplaceAll(s, "%", "%%")
+	return quoteSystemdToken(s), nil
+}
+
+func quoteSystemdPath(s string) (string, error) {
+	if err := rejectPersistedControlChars(s); err != nil {
+		return "", err
+	}
+	return strings.ReplaceAll(s, "%", "%%"), nil
+}
+
+func quoteSystemdToken(s string) string {
+	var b strings.Builder
+	b.WriteByte('"')
+	for _, r := range s {
+		if r == '\\' || r == '"' {
+			b.WriteByte('\\')
+		}
+		b.WriteRune(r)
+	}
+	b.WriteByte('"')
+	return b.String()
+}

--- a/internal/svc/render_test.go
+++ b/internal/svc/render_test.go
@@ -1,0 +1,145 @@
+// SPDX-FileContributor: sathwick-p
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package svc
+
+import (
+	"strings"
+	"testing"
+)
+
+func testDef(pathExtra string) Definition {
+	return Definition{
+		Binary:     "/usr/local/bin/hister" + pathExtra,
+		ConfigPath: "/home/user/My Files/config.yml",
+		DataDir:    "/home/user/My Files/data",
+		StdoutLog:  "/home/user/Library/Logs/hister.log",
+		StderrLog:  "/home/user/Library/Logs/hister-error.log",
+	}
+}
+
+func TestRenderLaunchdEscapesAndKeepAlive(t *testing.T) {
+	xml, err := RenderLaunchd(testDef(" & bin"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		MarkerPlist,
+		"<string>org.hister.server</string>",
+		"<string>/usr/local/bin/hister &amp; bin</string>",
+		"<string>listen</string>",
+		"<string>--config</string>",
+		"<string>/home/user/My Files/config.yml</string>",
+		"<key>HISTER_DATA_DIR</key>",
+		"<key>Crashed</key>",
+		"<true/>",
+		"<key>SuccessfulExit</key>",
+		"<false/>",
+		"<key>RunAtLoad</key>",
+		"<integer>63</integer>",
+	} {
+		if !strings.Contains(xml, want) {
+			t.Fatalf("plist missing %q\n%s", want, xml)
+		}
+	}
+	if strings.Contains(xml, "After=") || strings.Contains(strings.ToLower(xml), "--log-level") {
+		t.Fatal("plist contains unexpected keys")
+	}
+}
+
+func TestRenderSystemdUserQuotesAndMarker(t *testing.T) {
+	unit, err := RenderSystemdUser(testDef(""))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		MarkerSystemd,
+		`ExecStart="/usr/local/bin/hister" "listen" "--config" "/home/user/My Files/config.yml"`,
+		`WorkingDirectory=/home/user/My Files/data`,
+		`Environment="HISTER_DATA_DIR=/home/user/My Files/data"`,
+		"Restart=on-failure",
+		"UMask=0077",
+		"WantedBy=default.target",
+		"Type=exec",
+	} {
+		if !strings.Contains(unit, want) {
+			t.Fatalf("unit missing %q\n%s", want, unit)
+		}
+	}
+	if strings.Contains(unit, "After=network.target") {
+		t.Fatal("user unit must not wait on network.target")
+	}
+	if strings.Contains(unit, "--log-level") {
+		t.Fatal("unit must not persist --log-level")
+	}
+}
+
+func TestRenderSystemdUserEscapesSpecials(t *testing.T) {
+	def := Definition{
+		Binary:  `/tmp/his"ter`,
+		DataDir: `/tmp/data$dir`,
+	}
+	unit, err := RenderSystemdUser(def)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(unit, `ExecStart="/tmp/his\"ter" "listen"`) {
+		t.Fatalf("quoted binary:\n%s", unit)
+	}
+	if strings.Contains(unit, `ExecStart=`) && strings.Contains(unit, `\$`) {
+		t.Fatalf("ExecStart must not use backslash-dollar:\n%s", unit)
+	}
+	if !strings.Contains(unit, `Environment="HISTER_DATA_DIR=/tmp/data$dir"`) {
+		t.Fatalf("Environment $:\n%s", unit)
+	}
+	if !strings.Contains(unit, `WorkingDirectory=/tmp/data$dir`) {
+		t.Fatalf("WorkingDirectory $:\n%s", unit)
+	}
+}
+
+func TestRenderSystemdUserExecStartDoublesDollar(t *testing.T) {
+	def := Definition{
+		Binary:  `/tmp/his$ter`,
+		DataDir: `/tmp/data`,
+	}
+	unit, err := RenderSystemdUser(def)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(unit, `ExecStart="/tmp/his$$ter" "listen"`) {
+		t.Fatalf("ExecStart $$:\n%s", unit)
+	}
+}
+
+func TestRenderSystemdUserRejectsControlChars(t *testing.T) {
+	def := Definition{
+		Binary:  "/tmp/his\nter",
+		DataDir: "/tmp/data",
+	}
+	if _, err := RenderSystemdUser(def); err == nil {
+		t.Fatal("expected control character error")
+	}
+}
+
+func TestRenderRejectsRelativePaths(t *testing.T) {
+	if _, err := RenderLaunchd(Definition{Binary: "hister", DataDir: "/tmp/data"}); err == nil {
+		t.Fatal("expected relative binary to fail")
+	}
+	if _, err := RenderSystemdUser(Definition{Binary: "/bin/hister", DataDir: "data"}); err == nil {
+		t.Fatal("expected relative data dir to fail")
+	}
+}
+
+func TestValidateRejectsInvalidUTF8(t *testing.T) {
+	def := Definition{
+		Binary:  "/tmp/" + string([]byte{0xff, 0xfe}) + "hister",
+		DataDir: "/tmp/data",
+	}
+	if err := def.Validate(); err == nil {
+		t.Fatal("expected invalid UTF-8 error")
+	}
+	if _, err := RenderLaunchd(def); err == nil {
+		t.Fatal("expected launchd render to reject invalid UTF-8")
+	}
+}

--- a/internal/svc/replace.go
+++ b/internal/svc/replace.go
@@ -1,0 +1,219 @@
+// SPDX-FileContributor: sathwick-p
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package svc
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+type snapshot struct {
+	path       string
+	existed    bool
+	isSymlink  bool
+	data       []byte
+	mode       os.FileMode
+	linkTarget string
+}
+
+type extraArtifact struct {
+	path    string
+	symlink string // if set, write a symlink to this target
+}
+
+type replaceHooks struct {
+	stopFirst   bool
+	restoreRun  bool
+	stop        func() error
+	reload      func() error
+	start       func() error
+	startWanted bool
+}
+
+func snapshotPath(path string) (snapshot, error) {
+	s := snapshot{path: path}
+	st, err := os.Lstat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return s, nil
+		}
+		return s, err
+	}
+	s.existed = true
+	s.mode = st.Mode()
+	if st.Mode()&os.ModeSymlink != 0 {
+		target, err := os.Readlink(path)
+		if err != nil {
+			return s, err
+		}
+		s.isSymlink = true
+		s.linkTarget = target
+		return s, nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return s, err
+	}
+	s.data = data
+	return s, nil
+}
+
+func restoreSnapshot(s snapshot) error {
+	if !s.existed {
+		if err := os.Remove(s.path); err != nil && !os.IsNotExist(err) {
+			return err
+		}
+		return nil
+	}
+	if s.isSymlink {
+		if err := os.Remove(s.path); err != nil && !os.IsNotExist(err) {
+			return err
+		}
+		if err := os.MkdirAll(filepath.Dir(s.path), 0o755); err != nil {
+			return err
+		}
+		return os.Symlink(s.linkTarget, s.path)
+	}
+	return atomicWrite(s.path, s.data, s.mode.Perm())
+}
+
+func atomicWrite(path string, data []byte, mode os.FileMode) error {
+	if mode == 0 {
+		mode = 0o644
+	}
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(dir, "."+filepath.Base(path)+".tmp.")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	removeTmp := true
+	defer func() {
+		if removeTmp {
+			_ = os.Remove(tmpName)
+		}
+	}()
+	if err := tmp.Chmod(mode); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		return err
+	}
+	removeTmp = false
+	syncDir(dir)
+	return nil
+}
+
+func writeSymlink(path, target string) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return os.Symlink(target, path)
+}
+
+func syncDir(dir string) {
+	f, err := os.Open(dir)
+	if err != nil {
+		return
+	}
+	_ = f.Sync()
+	_ = f.Close()
+}
+
+func replaceDefinition(path string, content []byte, extras []extraArtifact, hooks replaceHooks) error {
+	defSnap, err := snapshotPath(path)
+	if err != nil {
+		return err
+	}
+	extraSnaps := make([]snapshot, 0, len(extras))
+	for _, extra := range extras {
+		s, err := snapshotPath(extra.path)
+		if err != nil {
+			return err
+		}
+		extraSnaps = append(extraSnaps, s)
+	}
+
+	if hooks.stopFirst {
+		if hooks.stop == nil {
+			return errors.New("stop of existing service is required but no stop function was provided")
+		}
+		if err := hooks.stop(); err != nil {
+			return fmt.Errorf("stop existing service: %w", err)
+		}
+	}
+
+	rollback := func(primary error) error {
+		errs := []error{primary}
+		restored := true
+		if err := restoreSnapshot(defSnap); err != nil {
+			restored = false
+			errs = append(errs, fmt.Errorf("restore service definition: %w", err))
+		}
+		for _, s := range extraSnaps {
+			if err := restoreSnapshot(s); err != nil {
+				restored = false
+				errs = append(errs, fmt.Errorf("restore %s: %w", s.path, err))
+			}
+		}
+		if restored && hooks.reload != nil {
+			if err := hooks.reload(); err != nil {
+				restored = false
+				errs = append(errs, fmt.Errorf("reload restored service definition: %w", err))
+			}
+		}
+		if restored && hooks.restoreRun && hooks.start != nil {
+			if err := hooks.start(); err != nil {
+				errs = append(errs, fmt.Errorf("restore running state: %w", err))
+			}
+		}
+		return errors.Join(errs...)
+	}
+
+	if err := atomicWrite(path, content, 0o644); err != nil {
+		return rollback(err)
+	}
+	for _, extra := range extras {
+		if extra.symlink != "" {
+			if err := writeSymlink(extra.path, extra.symlink); err != nil {
+				return rollback(err)
+			}
+		}
+	}
+	if hooks.reload != nil {
+		if err := hooks.reload(); err != nil {
+			return rollback(err)
+		}
+	}
+	if hooks.startWanted {
+		if hooks.start == nil {
+			return fmt.Errorf("installed service definition at %s, but no start function was provided", path)
+		}
+		if err := hooks.start(); err != nil {
+			return fmt.Errorf("installed service definition at %s, but failed to start: %w", path, err)
+		}
+	}
+	return nil
+}

--- a/internal/svc/replace_test.go
+++ b/internal/svc/replace_test.go
@@ -1,0 +1,263 @@
+// SPDX-FileContributor: sathwick-p
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package svc
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestReplaceStopFailureDoesNotWrite(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hister.service")
+	original := []byte("old\n")
+	if err := os.WriteFile(path, original, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	err := replaceDefinition(path, []byte("new\n"), nil, replaceHooks{
+		stopFirst: true,
+		stop:      func() error { return errors.New("stop failed") },
+	})
+	if err == nil {
+		t.Fatal("expected stop error")
+	}
+	got, readErr := os.ReadFile(path)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if string(got) != string(original) {
+		t.Fatalf("file changed to %q", got)
+	}
+}
+
+func TestReplaceReloadFailureRestores(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hister.service")
+	wants := filepath.Join(dir, "default.target.wants", "hister.service")
+	original := []byte("old\n")
+	if err := os.WriteFile(path, original, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(wants), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(path, wants); err != nil {
+		t.Fatal(err)
+	}
+	err := replaceDefinition(path, []byte("new\n"), []extraArtifact{{path: wants, symlink: path}}, replaceHooks{
+		reload: func() error { return errors.New("reload failed") },
+	})
+	if err == nil {
+		t.Fatal("expected reload error")
+	}
+	got, readErr := os.ReadFile(path)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if string(got) != string(original) {
+		t.Fatalf("definition not restored: %q", got)
+	}
+	target, err := os.Readlink(wants)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if target != path {
+		t.Fatalf("wants target = %q", target)
+	}
+}
+
+func TestReplaceStartFailureKeepsNewDefinition(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hister.service")
+	if err := os.WriteFile(path, []byte("old\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	err := replaceDefinition(path, []byte("new\n"), nil, replaceHooks{
+		startWanted: true,
+		start:       func() error { return errors.New("port busy") },
+	})
+	if err == nil {
+		t.Fatal("expected start error")
+	}
+	got, readErr := os.ReadFile(path)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if string(got) != "new\n" {
+		t.Fatalf("definition = %q, want new file kept", got)
+	}
+	if !strings.Contains(err.Error(), "failed to start") {
+		t.Fatalf("error should report start failure: %v", err)
+	}
+}
+
+func TestReplaceRollbackReloadsBeforeStart(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hister.service")
+	wants := filepath.Join(dir, "default.target.wants", "hister.service")
+	original := []byte("old\n")
+	if err := os.WriteFile(path, original, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(wants), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(path, wants); err != nil {
+		t.Fatal(err)
+	}
+
+	var order []string
+	reloadCount := 0
+	err := replaceDefinition(path, []byte("new\n"), []extraArtifact{{path: wants, symlink: path}}, replaceHooks{
+		stopFirst:  true,
+		restoreRun: true,
+		stop: func() error {
+			order = append(order, "stop")
+			return nil
+		},
+		reload: func() error {
+			reloadCount++
+			order = append(order, "reload")
+			if reloadCount == 1 {
+				return errors.New("reload failed")
+			}
+			return nil
+		},
+		start: func() error {
+			order = append(order, "start")
+			return nil
+		},
+	})
+	if err == nil {
+		t.Fatal("expected reload error")
+	}
+	got, readErr := os.ReadFile(path)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if string(got) != string(original) {
+		t.Fatalf("definition not restored: %q", got)
+	}
+	wantOrder := []string{"stop", "reload", "reload", "start"}
+	if strings.Join(order, ",") != strings.Join(wantOrder, ",") {
+		t.Fatalf("order = %v, want %v", order, wantOrder)
+	}
+}
+
+func TestReplaceRollbackDoesNotStartWhenReloadFails(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hister.service")
+	original := []byte("old\n")
+	if err := os.WriteFile(path, original, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	started := false
+	err := replaceDefinition(path, []byte("new\n"), nil, replaceHooks{
+		restoreRun: true,
+		reload:     func() error { return errors.New("reload failed") },
+		start: func() error {
+			started = true
+			return nil
+		},
+	})
+	if err == nil {
+		t.Fatal("expected reload error")
+	}
+	if started {
+		t.Fatal("must not restore-start after rollback reload failure")
+	}
+	if !strings.Contains(err.Error(), "reload failed") {
+		t.Fatalf("joined error missing reload failure: %v", err)
+	}
+	got, readErr := os.ReadFile(path)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if string(got) != string(original) {
+		t.Fatalf("definition not restored: %q", got)
+	}
+}
+
+func TestReplaceRollbackDoesNotStartWhenRestoreFails(t *testing.T) {
+	if runtime.GOOS == "windows" || os.Geteuid() == 0 {
+		t.Skip("relies on unix directory permissions")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hister.service")
+	if err := os.WriteFile(path, []byte("old\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	started := false
+	err := replaceDefinition(path, []byte("new\n"), nil, replaceHooks{
+		restoreRun: true,
+		reload: func() error {
+			if err := os.Chmod(dir, 0o555); err != nil {
+				t.Fatal(err)
+			}
+			return errors.New("reload failed")
+		},
+		start: func() error {
+			started = true
+			return nil
+		},
+	})
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o755) })
+	if err == nil {
+		t.Fatal("expected rollback error")
+	}
+	if started {
+		t.Fatal("must not restore-start after definition restore failure")
+	}
+	if !strings.Contains(err.Error(), "restore service definition") {
+		t.Fatalf("joined error missing restore failure: %v", err)
+	}
+}
+
+func TestReplaceRollbackDoesNotStartWhenEnableLinkRestoreFails(t *testing.T) {
+	if runtime.GOOS == "windows" || os.Geteuid() == 0 {
+		t.Skip("relies on unix directory permissions")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hister.service")
+	wantsDir := filepath.Join(dir, "wants")
+	wants := filepath.Join(wantsDir, "hister.service")
+	if err := os.WriteFile(path, []byte("old\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(wantsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(path, wants); err != nil {
+		t.Fatal(err)
+	}
+	started := false
+	err := replaceDefinition(path, []byte("new\n"), []extraArtifact{{path: wants, symlink: path}}, replaceHooks{
+		restoreRun: true,
+		reload: func() error {
+			if err := os.Chmod(wantsDir, 0o555); err != nil {
+				t.Fatal(err)
+			}
+			return errors.New("reload failed")
+		},
+		start: func() error {
+			started = true
+			return nil
+		},
+	})
+	t.Cleanup(func() { _ = os.Chmod(wantsDir, 0o755) })
+	if err == nil {
+		t.Fatal("expected rollback error")
+	}
+	if started {
+		t.Fatal("must not restore-start after enable-link restore failure")
+	}
+	if !strings.Contains(err.Error(), "restore "+wants) {
+		t.Fatalf("joined error missing enable-link restore failure: %v", err)
+	}
+}

--- a/internal/svc/resolve.go
+++ b/internal/svc/resolve.go
@@ -1,0 +1,159 @@
+// SPDX-FileContributor: sathwick-p
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package svc
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+var (
+	arg0       = func() string { return os.Args[0] }
+	lookPath   = exec.LookPath
+	executable = os.Executable
+)
+
+// ResolveBinary returns a stable, unresolved path to this hister executable
+// for persistence in a service definition. It never EvalSymlinks the result.
+func ResolveBinary() (string, error) {
+	path, err := resolveBinaryPath()
+	if err != nil {
+		return "", err
+	}
+	if reason := unstableBinaryReason(path); reason != "" {
+		if alias := pathAliasFor(path); alias != "" && unstableBinaryReason(alias) == "" {
+			path = alias
+		} else {
+			return "", fmt.Errorf("%w: %s", ErrUnstableBinary, reason)
+		}
+	}
+	if err := validateResolvedBinary(path); err != nil {
+		return "", err
+	}
+	return path, nil
+}
+
+func resolveBinaryPath() (string, error) {
+	invoked := arg0()
+	if invoked == "" {
+		return absExecutable()
+	}
+	if filepath.IsAbs(invoked) {
+		return invoked, nil
+	}
+	if strings.ContainsRune(invoked, os.PathSeparator) {
+		return filepath.Abs(invoked)
+	}
+
+	if found, err := lookPath(invoked); err == nil && found != "" {
+		if filepath.IsAbs(found) {
+			return found, nil
+		}
+		return filepath.Abs(found)
+	}
+
+	exe, err := absExecutable()
+	if err != nil {
+		return "", err
+	}
+	if alias := pathAliasFor(exe); alias != "" {
+		return alias, nil
+	}
+	return exe, nil
+}
+
+func absExecutable() (string, error) {
+	exe, err := executable()
+	if err != nil {
+		return "", fmt.Errorf("locate hister binary: %w", err)
+	}
+	if filepath.IsAbs(exe) {
+		return exe, nil
+	}
+	return filepath.Abs(exe)
+}
+
+func pathAliasFor(exe string) string {
+	exeInfo, err := os.Stat(exe)
+	if err != nil {
+		return ""
+	}
+	for dir := range strings.SplitSeq(os.Getenv("PATH"), string(os.PathListSeparator)) {
+		if dir == "" {
+			continue
+		}
+		candidate := filepath.Join(dir, filepath.Base(exe))
+		st, err := os.Lstat(candidate)
+		if err != nil {
+			continue
+		}
+		cmp := st
+		if st.Mode()&os.ModeSymlink != 0 {
+			resolved, err := os.Stat(candidate)
+			if err != nil {
+				continue
+			}
+			cmp = resolved
+		}
+		if os.SameFile(exeInfo, cmp) {
+			if filepath.IsAbs(candidate) {
+				return candidate
+			}
+			if abs, err := filepath.Abs(candidate); err == nil {
+				return abs
+			}
+			return candidate
+		}
+	}
+	return ""
+}
+
+func validateResolvedBinary(path string) error {
+	st, err := os.Lstat(path)
+	if err != nil {
+		return fmt.Errorf("binary %q: %w", path, err)
+	}
+	if st.IsDir() {
+		return fmt.Errorf("binary %q is a directory", path)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("binary %q: %w", path, err)
+	}
+	if info.IsDir() {
+		return fmt.Errorf("binary %q is a directory", path)
+	}
+	if runtime.GOOS != "windows" && info.Mode()&0o111 == 0 {
+		return fmt.Errorf("binary %q is not executable", path)
+	}
+	exe, err := executable()
+	if err != nil {
+		return fmt.Errorf("locate running hister executable: %w", err)
+	}
+	exeInfo, err := os.Stat(exe)
+	if err != nil {
+		return fmt.Errorf("inspect running hister executable %q: %w", exe, err)
+	}
+	if !os.SameFile(info, exeInfo) {
+		return fmt.Errorf("binary %q is not this hister executable", path)
+	}
+	return nil
+}
+
+func unstableBinaryReason(path string) string {
+	cleaned := filepath.ToSlash(path)
+	switch {
+	case strings.Contains(cleaned, "/Cellar/hister/") || strings.Contains(cleaned, "/Cellar/hister@"):
+		return "path is inside the Homebrew Cellar (" + path + ")"
+	case strings.HasPrefix(cleaned, "/nix/store/") || strings.Contains(cleaned, "/nix/store/"):
+		return "path is inside /nix/store (" + path + ")"
+	default:
+		return ""
+	}
+}

--- a/internal/svc/resolve_test.go
+++ b/internal/svc/resolve_test.go
@@ -1,0 +1,263 @@
+// SPDX-FileContributor: sathwick-p
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package svc
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func withResolveHooks(t *testing.T, arg string, exe func() (string, error)) {
+	t.Helper()
+	oldArg0, oldExecutable := arg0, executable
+	t.Cleanup(func() {
+		arg0 = oldArg0
+		executable = oldExecutable
+	})
+	arg0 = func() string { return arg }
+	executable = exe
+}
+
+func TestUnstableBinaryReason(t *testing.T) {
+	tests := []struct {
+		path    string
+		wantErr bool
+	}{
+		{path: "/opt/homebrew/bin/hister", wantErr: false},
+		{path: "/usr/local/bin/hister", wantErr: false},
+		{path: "/opt/homebrew/Cellar/hister/0.18.0/bin/hister", wantErr: true},
+		{path: "/nix/store/abc-hister-0.18.0/bin/hister", wantErr: true},
+	}
+	for _, tt := range tests {
+		got := unstableBinaryReason(tt.path)
+		if tt.wantErr && got == "" {
+			t.Fatalf("%s: expected unstable", tt.path)
+		}
+		if !tt.wantErr && got != "" {
+			t.Fatalf("%s: unexpected %q", tt.path, got)
+		}
+	}
+}
+
+func TestResolveBinaryBareNameUsesLookPath(t *testing.T) {
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "hister")
+	if err := os.WriteFile(bin, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	origArg0, origLook, origExec := arg0, lookPath, executable
+	t.Cleanup(func() {
+		arg0, lookPath, executable = origArg0, origLook, origExec
+	})
+	arg0 = func() string { return "hister" }
+	lookPath = func(string) (string, error) { return bin, nil }
+	executable = func() (string, error) { return bin, nil }
+
+	got, err := ResolveBinary()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != bin {
+		t.Fatalf("ResolveBinary() = %q, want PATH alias %q", got, bin)
+	}
+}
+
+func TestResolveBinaryRefusesCellar(t *testing.T) {
+	origArg0 := arg0
+	t.Cleanup(func() { arg0 = origArg0 })
+	arg0 = func() string { return "/opt/homebrew/Cellar/hister/0.18.0/bin/hister" }
+	_, err := ResolveBinary()
+	if err == nil {
+		t.Fatal("expected Cellar path to be refused")
+	}
+}
+
+func TestResolveBinaryRefusesNixStore(t *testing.T) {
+	origArg0 := arg0
+	t.Cleanup(func() { arg0 = origArg0 })
+	arg0 = func() string { return "/nix/store/hash-hister-0.18.0/bin/hister" }
+	_, err := ResolveBinary()
+	if err == nil {
+		t.Fatal("expected nix store path to be refused")
+	}
+}
+
+func TestResolveBinaryPrefersPATHAliasOverCellar(t *testing.T) {
+	dir := t.TempDir()
+	cellarDir := filepath.Join(dir, "Cellar", "hister", "1.0", "bin")
+	if err := os.MkdirAll(cellarDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cellar := filepath.Join(cellarDir, "hister")
+	if err := os.WriteFile(cellar, []byte("x"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	pathDir := filepath.Join(dir, "bin")
+	if err := os.MkdirAll(pathDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	alias := filepath.Join(pathDir, "hister")
+	if err := os.Symlink(cellar, alias); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", pathDir)
+
+	origArg0, origExec := arg0, executable
+	t.Cleanup(func() {
+		arg0 = origArg0
+		executable = origExec
+	})
+	arg0 = func() string { return cellar }
+	executable = func() (string, error) { return cellar, nil }
+
+	got, err := ResolveBinary()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != alias {
+		t.Fatalf("ResolveBinary() = %q, want PATH alias %q", got, alias)
+	}
+}
+
+func TestResolveBinaryKeepsAbsoluteSymlinkPath(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "Cellar", "hister", "1.0", "bin")
+	if err := os.MkdirAll(target, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	realBin := filepath.Join(target, "hister")
+	if err := os.WriteFile(realBin, []byte("x"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	alias := filepath.Join(dir, "bin", "hister")
+	if err := os.MkdirAll(filepath.Dir(alias), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(realBin, alias); err != nil {
+		t.Fatal(err)
+	}
+
+	origArg0, origExec := arg0, executable
+	t.Cleanup(func() {
+		arg0 = origArg0
+		executable = origExec
+	})
+	arg0 = func() string { return alias }
+	executable = func() (string, error) { return realBin, nil }
+
+	got, err := ResolveBinary()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != alias {
+		t.Fatalf("stored %q, want unresolved symlink %q", got, alias)
+	}
+}
+
+func TestResolveBinaryRejectsExecutableLookupFailure(t *testing.T) {
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "hister")
+	if err := os.WriteFile(bin, []byte("x"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	withResolveHooks(t, bin, func() (string, error) {
+		return "", errors.New("executable unavailable")
+	})
+
+	_, err := ResolveBinary()
+	if err == nil || !strings.Contains(err.Error(), "locate running hister executable") {
+		t.Fatalf("ResolveBinary() error = %v", err)
+	}
+}
+
+func TestResolveBinaryRejectsUninspectableExecutable(t *testing.T) {
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "hister")
+	if err := os.WriteFile(bin, []byte("x"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	running := filepath.Join(dir, "missing-hister")
+	withResolveHooks(t, bin, func() (string, error) {
+		return running, nil
+	})
+
+	_, err := ResolveBinary()
+	if err == nil || !strings.Contains(err.Error(), "inspect running hister executable") {
+		t.Fatalf("ResolveBinary() error = %v", err)
+	}
+}
+
+func TestResolveBinaryRejectsDifferentExecutable(t *testing.T) {
+	dir := t.TempDir()
+	selected := filepath.Join(dir, "selected")
+	running := filepath.Join(dir, "running")
+	for _, path := range []string{selected, running} {
+		if err := os.WriteFile(path, []byte("x"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	withResolveHooks(t, selected, func() (string, error) { return running, nil })
+
+	_, err := ResolveBinary()
+	if err == nil || !strings.Contains(err.Error(), "not this hister executable") {
+		t.Fatalf("ResolveBinary() error = %v", err)
+	}
+}
+
+func TestResolveBinaryRejectsMissingPath(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "missing")
+	withResolveHooks(t, missing, func() (string, error) { return missing, nil })
+
+	_, err := ResolveBinary()
+	if err == nil || !strings.Contains(err.Error(), "binary") {
+		t.Fatalf("ResolveBinary() error = %v", err)
+	}
+}
+
+func TestResolveBinaryRejectsDirectory(t *testing.T) {
+	dir := t.TempDir()
+	withResolveHooks(t, dir, func() (string, error) { return dir, nil })
+
+	_, err := ResolveBinary()
+	if err == nil || !strings.Contains(err.Error(), "is a directory") {
+		t.Fatalf("ResolveBinary() error = %v", err)
+	}
+}
+
+func TestResolveBinaryRejectsNonExecutableFile(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix executable bits do not apply on Windows")
+	}
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "hister")
+	if err := os.WriteFile(bin, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	withResolveHooks(t, bin, func() (string, error) { return bin, nil })
+
+	_, err := ResolveBinary()
+	if err == nil || !strings.Contains(err.Error(), "is not executable") {
+		t.Fatalf("ResolveBinary() error = %v", err)
+	}
+}
+
+func TestResolveBinaryRejectsBrokenSymlink(t *testing.T) {
+	dir := t.TempDir()
+	link := filepath.Join(dir, "hister")
+	if err := os.Symlink(filepath.Join(dir, "missing"), link); err != nil {
+		t.Fatal(err)
+	}
+	withResolveHooks(t, link, func() (string, error) { return link, nil })
+
+	_, err := ResolveBinary()
+	if err == nil || !strings.Contains(err.Error(), "binary") {
+		t.Fatalf("ResolveBinary() error = %v", err)
+	}
+}

--- a/internal/svc/systemd_user.go
+++ b/internal/svc/systemd_user.go
@@ -1,0 +1,137 @@
+// SPDX-FileContributor: sathwick-p
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package svc
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+const systemdUnitName = "hister.service"
+
+func newSystemdUserManager(runner CommandRunner, home, runtimeDir string, busUp bool) (*userManager, error) {
+	if home == "" {
+		var err error
+		home, err = os.UserHomeDir()
+		if err != nil {
+			return nil, err
+		}
+	}
+	if runner == nil {
+		runner = defaultRunner
+	}
+	unitDirParent, err := userConfigDir(home)
+	if err != nil {
+		return nil, err
+	}
+	unitDir := filepath.Join(unitDirParent, "systemd", "user")
+	unitPath := filepath.Join(unitDir, systemdUnitName)
+	wantsPath := filepath.Join(unitDir, "default.target.wants", systemdUnitName)
+
+	m := &userManager{
+		platform:       "systemd --user",
+		definitionPath: unitPath,
+		wantsPath:      wantsPath,
+		wantsTarget:    unitPath,
+		loginNote:      "This systemd user service runs while you are logged in. To keep it running after logout and at boot:\n  loginctl enable-linger",
+		runner:         runner,
+	}
+	m.render = RenderSystemdUser
+	m.withPlatformPaths = func(def Definition) Definition { return def }
+	m.prepare = func(Definition) error {
+		return os.MkdirAll(filepath.Join(unitDir, "default.target.wants"), 0o755)
+	}
+	m.canStartNow = func() bool { return busUp }
+	m.startUnavailableError = func() error {
+		return errors.New("the systemd user session is not running; log in or run `loginctl enable-linger`, then: hister service start")
+	}
+	m.start = func() error {
+		_, _, err := run(m.runner, "systemctl", "--user", "start", systemdUnitName)
+		return err
+	}
+	m.stop = func() error {
+		stdout, stderr, err := run(m.runner, "systemctl", "--user", "stop", systemdUnitName)
+		if err != nil && !isMissingExecutable(err) && managerReportsAbsent(stderr, stdout) {
+			return nil
+		}
+		return err
+	}
+	m.reload = func() error {
+		if !busUp {
+			return nil
+		}
+		_, _, err := run(m.runner, "systemctl", "--user", "daemon-reload")
+		return err
+	}
+	m.query = func() (jobQuery, error) {
+		if !busUp {
+			if runtimeDir == "" {
+				runtimeDir = os.Getenv("XDG_RUNTIME_DIR")
+			}
+			if !systemdUserBusUp(runtimeDir) {
+				return jobQuery{}, errors.New("systemd user bus is not available")
+			}
+		}
+		stdout, stderr, err := run(m.runner, "systemctl", "--user", "show", systemdUnitName,
+			"--property=LoadState", "--property=ActiveState", "--property=MainPID")
+		if err != nil {
+			if isMissingExecutable(err) {
+				return jobQuery{}, err
+			}
+			if managerReportsAbsent(stderr, stdout) {
+				return jobQuery{}, nil
+			}
+			return jobQuery{}, err
+		}
+		return parseSystemdShow(stdout)
+	}
+	return m, nil
+}
+
+func systemdUserBusUp(runtimeDir string) bool {
+	if runtimeDir == "" {
+		runtimeDir = os.Getenv("XDG_RUNTIME_DIR")
+	}
+	if runtimeDir == "" {
+		return false
+	}
+	_, err := os.Stat(filepath.Join(runtimeDir, "systemd", "private"))
+	return err == nil
+}
+
+func parseSystemdShow(out string) (jobQuery, error) {
+	loadState := ""
+	activeState := ""
+	pid := 0
+	for line := range strings.SplitSeq(out, "\n") {
+		key, val, ok := strings.Cut(strings.TrimSpace(line), "=")
+		if !ok {
+			continue
+		}
+		switch key {
+		case "LoadState":
+			loadState = val
+		case "ActiveState":
+			activeState = val
+		case "MainPID":
+			n, convErr := strconv.Atoi(val)
+			if convErr == nil {
+				pid = n
+			}
+		}
+	}
+	if loadState == "" || loadState == "not-found" {
+		return jobQuery{}, nil
+	}
+	failed := activeState == "failed"
+	running := !failed && (activeState == "active" || activeState == "activating" || activeState == "reloading")
+	if pid > 0 && !failed {
+		running = true
+	}
+	return jobQuery{loaded: true, running: running, failed: failed, pid: pid}, nil
+}

--- a/internal/svc/systemd_user_test.go
+++ b/internal/svc/systemd_user_test.go
@@ -1,0 +1,329 @@
+// SPDX-FileContributor: sathwick-p
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package svc
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSystemdUserInstallWritesWants(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	started := false
+	reloadCount := 0
+	m, err := newSystemdUserManager(adaptRunner(func(name string, args []string) (string, string, error) {
+		if name != "systemctl" {
+			return "", "", fmt.Errorf("unexpected %s", name)
+		}
+		switch args[1] {
+		case "daemon-reload":
+			reloadCount++
+			return "", "", nil
+		case "start":
+			started = true
+			return "", "", nil
+		case "stop":
+			return "", "", nil
+		case "show":
+			if started {
+				return "LoadState=loaded\nActiveState=active\nMainPID=7\n", "", nil
+			}
+			return "LoadState=not-found\nActiveState=inactive\nMainPID=0\n", "", nil
+		default:
+			return "", "", fmt.Errorf("unexpected %v", args)
+		}
+	}), home, filepath.Join(home, "runtime"), true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	def := Definition{Binary: filepath.Join(home, "hister"), DataDir: filepath.Join(home, "data")}
+	if err := os.WriteFile(def.Binary, []byte("x"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.Install(def, InstallOptions{}); err != nil {
+		t.Fatal(err)
+	}
+	if reloadCount != 1 || !started {
+		t.Fatalf("reloadCount=%d started=%v", reloadCount, started)
+	}
+	body, err := os.ReadFile(m.DefinitionPath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(body), MarkerSystemd) {
+		t.Fatal("missing marker")
+	}
+	if strings.Contains(string(body), "After=network.target") {
+		t.Fatal("unexpected After=")
+	}
+	wants := filepath.Join(filepath.Dir(m.DefinitionPath()), "default.target.wants", "hister.service")
+	target, err := os.Readlink(wants)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if target != m.DefinitionPath() {
+		t.Fatalf("wants -> %q", target)
+	}
+
+	if err := m.Uninstall(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(m.DefinitionPath()); !os.IsNotExist(err) {
+		t.Fatal("unit still present")
+	}
+	if _, err := os.Lstat(wants); !os.IsNotExist(err) {
+		t.Fatal("wants symlink still present")
+	}
+	if reloadCount != 2 {
+		t.Fatalf("uninstall should daemon-reload, reloadCount=%d", reloadCount)
+	}
+}
+
+func TestSystemdUserNoStartNoBus(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	started := false
+	m, err := newSystemdUserManager(adaptRunner(func(name string, args []string) (string, string, error) {
+		if args[1] == "start" {
+			started = true
+		}
+		return "LoadState=not-found\nActiveState=inactive\nMainPID=0\n", "", nil
+	}), home, "", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	def := Definition{Binary: filepath.Join(home, "hister"), DataDir: filepath.Join(home, "data")}
+	if err := os.WriteFile(def.Binary, []byte("x"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.Install(def, InstallOptions{NoStart: true}); err != nil {
+		t.Fatal(err)
+	}
+	if started {
+		t.Fatal("start must not run with --no-start")
+	}
+}
+
+func TestSystemdUserStartWithoutBus(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	m, err := newSystemdUserManager(adaptRunner(func(string, []string) (string, string, error) {
+		return "", "bus down", errors.New("exit 1")
+	}), home, "", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(m.DefinitionPath()), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(m.DefinitionPath(), []byte(MarkerSystemd+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	err = m.Start()
+	if err == nil || !strings.Contains(err.Error(), "loginctl enable-linger") {
+		t.Fatalf("start without bus: %v", err)
+	}
+}
+
+func TestSystemdHandWrittenUnitIsForeign(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	m, err := newSystemdUserManager(adaptRunner(func(string, []string) (string, string, error) {
+		return "LoadState=loaded\nActiveState=inactive\nMainPID=0\n", "", nil
+	}), home, filepath.Join(home, "run"), true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(m.DefinitionPath()), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(m.DefinitionPath(), []byte("[Service]\nExecStart=/bin/true\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	def := Definition{Binary: filepath.Join(home, "hister"), DataDir: filepath.Join(home, "data")}
+	if err := os.WriteFile(def.Binary, []byte("x"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.Install(def, InstallOptions{Force: true}); !errors.Is(err, ErrForeign) {
+		t.Fatalf("force on hand-written unit: %v", err)
+	}
+	wants := filepath.Join(filepath.Dir(m.DefinitionPath()), "default.target.wants")
+	if _, err := os.Stat(wants); !os.IsNotExist(err) {
+		t.Fatal("refusing a foreign unit must not create default.target.wants")
+	}
+}
+
+func TestSystemdOrphanLoadedIsForeign(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	stopped := false
+	m, err := newSystemdUserManager(adaptRunner(func(name string, args []string) (string, string, error) {
+		if len(args) > 1 && args[1] == "stop" {
+			stopped = true
+		}
+		return "LoadState=loaded\nActiveState=active\nMainPID=9\n", "", nil
+	}), home, filepath.Join(home, "run"), true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	st, err := m.Status()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !st.ExternallyManaged || st.State != StateRunning {
+		t.Fatalf("status %+v", st)
+	}
+	def := Definition{Binary: filepath.Join(home, "hister"), DataDir: filepath.Join(home, "data")}
+	if err := os.WriteFile(def.Binary, []byte("x"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.Install(def, InstallOptions{Force: true}); !errors.Is(err, ErrForeign) {
+		t.Fatalf("install orphan: %v", err)
+	}
+	if err := m.Uninstall(); !errors.Is(err, ErrForeign) {
+		t.Fatalf("uninstall orphan: %v", err)
+	}
+	if stopped {
+		t.Fatal("must not stop an orphan loaded unit")
+	}
+}
+
+func TestParseSystemdShowLoadedStopped(t *testing.T) {
+	q, err := parseSystemdShow("LoadState=loaded\nActiveState=inactive\nMainPID=0\n")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !q.loaded || q.running {
+		t.Fatalf("query %+v", q)
+	}
+}
+
+func TestParseSystemdShowFailed(t *testing.T) {
+	q, err := parseSystemdShow("LoadState=loaded\nActiveState=failed\nMainPID=0\n")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !q.loaded || q.running || !q.failed {
+		t.Fatalf("query %+v", q)
+	}
+	st := Status{State: StateStopped, Failed: true}
+	if st.String() != "installed, failed" {
+		t.Fatalf("status string %q", st.String())
+	}
+	if st.ExitCode() != ExitStopped {
+		t.Fatalf("failed exit %d", st.ExitCode())
+	}
+}
+
+func TestSystemdRelativeXDGConfigHome(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", "relative-config")
+	_, err := newSystemdUserManager(adaptRunner(func(string, []string) (string, string, error) {
+		return "", "", nil
+	}), home, filepath.Join(home, "run"), true)
+	if err == nil || !strings.Contains(err.Error(), "XDG_CONFIG_HOME") {
+		t.Fatalf("relative XDG_CONFIG_HOME: %v", err)
+	}
+}
+
+func TestParseSystemdShowNotFound(t *testing.T) {
+	q, err := parseSystemdShow("LoadState=not-found\nActiveState=inactive\nMainPID=0\n")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if q.loaded || q.running || q.pid != 0 {
+		t.Fatalf("query %+v", q)
+	}
+}
+
+func TestSystemdStatusMissingSystemctlIsFailure(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	m, err := newSystemdUserManager(adaptRunner(func(string, []string) (string, string, error) {
+		return "", "", exec.ErrNotFound
+	}), home, filepath.Join(home, "run"), true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	st, err := m.Status()
+	if err == nil {
+		t.Fatalf("status succeeded: %+v", st)
+	}
+	if !errors.Is(err, exec.ErrNotFound) {
+		t.Fatalf("status err=%v, want ErrNotFound", err)
+	}
+}
+
+func TestSystemdForeignWantsRefusesInstall(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	m, err := newSystemdUserManager(adaptRunner(func(string, []string) (string, string, error) {
+		return "LoadState=not-found\nActiveState=inactive\nMainPID=0\n", "", nil
+	}), home, filepath.Join(home, "run"), true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wants := filepath.Join(filepath.Dir(m.DefinitionPath()), "default.target.wants", "hister.service")
+	if err := os.MkdirAll(filepath.Dir(wants), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(wants, []byte("not a symlink"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	def := Definition{Binary: filepath.Join(home, "hister"), DataDir: filepath.Join(home, "data")}
+	if err := os.WriteFile(def.Binary, []byte("x"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.Install(def, InstallOptions{Force: true}); !errors.Is(err, ErrForeign) {
+		t.Fatalf("install with foreign wants: %v", err)
+	}
+	if _, err := os.Stat(m.DefinitionPath()); !os.IsNotExist(err) {
+		t.Fatal("unit must not be written when wants is foreign")
+	}
+}
+
+func TestSystemdForeignWantsRefusesUninstall(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	stopped := false
+	m, err := newSystemdUserManager(adaptRunner(func(name string, args []string) (string, string, error) {
+		if len(args) > 1 && args[1] == "stop" {
+			stopped = true
+		}
+		return "LoadState=loaded\nActiveState=inactive\nMainPID=0\n", "", nil
+	}), home, filepath.Join(home, "run"), true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(m.DefinitionPath()), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(m.DefinitionPath(), []byte(MarkerSystemd+"\n[Service]\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	wants := filepath.Join(filepath.Dir(m.DefinitionPath()), "default.target.wants", "hister.service")
+	if err := os.MkdirAll(filepath.Dir(wants), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(wants, []byte("not a symlink"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.Uninstall(); !errors.Is(err, ErrForeign) {
+		t.Fatalf("uninstall with foreign wants: %v", err)
+	}
+	if stopped {
+		t.Fatal("must not stop when wants is foreign")
+	}
+	if _, err := os.Stat(m.DefinitionPath()); err != nil {
+		t.Fatal("ours unit must remain")
+	}
+}

--- a/server/server.go
+++ b/server/server.go
@@ -141,7 +141,7 @@ func recParseStaticFiles(entries []iofs.DirEntry, dir, baseDir string) error {
 	return nil
 }
 
-func Listen(cfg *config.Config, idx *indexer.Indexer) {
+func Listen(cfg *config.Config, idx *indexer.Indexer) error {
 	sessionStore = newSessionStore(cfg.SecretKey(), cfg.BaseURL(""), sessionMaxAge)
 
 	// This is an ugly hack required to set the base path dynamically in svelte files.
@@ -159,10 +159,7 @@ func Listen(cfg *config.Config, idx *indexer.Indexer) {
 	handler = withLogging(handler)
 
 	log.Info().Str("Address", cfg.Server.Address).Str("Version", Version).Str("URL", cfg.BaseURL("/")).Msg("Starting webserver")
-	err := http.ListenAndServe(cfg.Server.Address, handler)
-	if err != nil {
-		log.Error().Err(err).Msg("Webserver failed to listen on " + cfg.Server.Address)
-	}
+	return http.ListenAndServe(cfg.Server.Address, handler)
 }
 
 func createHandler(cfg *config.Config, idx *indexer.Indexer, h func(*webContext)) func(w http.ResponseWriter, r *http.Request) {

--- a/webui/website/src/content/docs/installing.md
+++ b/webui/website/src/content/docs/installing.md
@@ -39,11 +39,46 @@ If someone else already operates the Hister server you use and you only search t
 
    On Windows, run `hister.exe listen` instead.
 
+   On macOS and systemd Linux you can install a user-level background service instead of leaving a terminal open. From the download directory, use `./hister service install`. See [Running in the background](#running-in-the-background).
+
 6. Open <http://127.0.0.1:4433> in your browser, then continue with the [quickstart](quickstart) to install the browser extension and begin indexing.
 
 Release pages also contain a checksums file that can be used to verify the download. Development snapshots are available from the [rolling release](https://github.com/asciimoo/hister/releases/tag/rolling), but stable releases are recommended for new users.
 
-You may optionally move the binary to a directory on your `PATH`, such as `/usr/local/bin` or `~/.local/bin`.
+You may optionally move the binary to a directory on your `PATH`, such as `/usr/local/bin` or `~/.local/bin`. Use a path that stays the same after upgrades (Homebrew’s `$(brew --prefix)/bin/hister`, not a Cellar path).
+
+## Running in the background
+
+`hister listen` runs in the foreground. On macOS and systemd Linux, a downloaded binary can install a user-level service that starts `hister listen` for you. If the binary is still in the current directory and has not been added to `PATH`, include `./`:
+
+```bash
+./hister service install
+```
+
+That writes a native definition (a LaunchAgent on macOS, a systemd user unit on Linux), starts it unless you pass `--no-start`, and does not require `sudo`.
+
+```bash
+./hister service install [--force] [--no-start]
+./hister service uninstall
+./hister service start
+./hister service stop
+./hister service restart
+./hister service status
+```
+
+After moving the binary to a stable directory on `PATH`, you can omit `./` and use `hister` from any directory. The service records the absolute path of the binary you use; it does not move the binary or modify your shell configuration.
+
+- **macOS:** the LaunchAgent starts at login and restarts after a crash. `hister service stop` keeps it down for the rest of the session.
+- **Linux:** the systemd user unit runs with your user session. It survives logout and starts at boot only if you enable lingering yourself (`loginctl enable-linger`). Hister never runs that command.
+- **Windows:** `hister service` is not supported on Windows yet. Keep using `hister.exe listen`.
+- **Nix / Home Manager:** keep using the Hister modules. `hister service` refuses to change a unit or plist that it did not write (including symlinks). `nix run` is not supported because the store path changes.
+- **`--force`:** replaces a definition previously installed by `hister service`. It will not overwrite a foreign or Nix-managed file.
+- **Uninstall:** removes the service definition only. Indexed data stays on disk.
+- **`--config`:** if you pass `--config`, the file must already exist and be readable. The absolute path is stored in the service. `--log-level` is not written into the unit; the running server uses `config.yml`.
+- **Environment:** `hister service install` fails if unpersisted `HISTER__*` or `HISTER_PORT` variables are set. Put those settings in `config.yml` instead.
+- **Status exit codes:** `hister service status` exits 0 when running, 3 when stopped, and 4 when not installed.
+
+A machine-wide systemd example remains in `contrib/systemd/hister.service` for administrators who manage the service themselves.
 
 ## Building from source
 

--- a/webui/website/src/content/docs/quickstart.md
+++ b/webui/website/src/content/docs/quickstart.md
@@ -29,6 +29,14 @@ Just make sure not to close the terminal that the above command was run on, as d
 (The server can also be closed normally by pressing <kbd>Ctrl</kbd>+<kbd>C</kbd>.)
 It is fine to close and/or reopen the server at any time, but it **must** be running for the clients to be able to index any pages; you will get errors otherwise.
 
+On macOS and systemd Linux, install a user-level background service instead of leaving the terminal open:
+
+```bash
+./hister service install
+```
+
+This uses the binary in the current directory. If you have moved Hister to a directory on `PATH`, use `hister service install` instead. See [Running in the background](installing#running-in-the-background). Windows still uses `hister.exe listen` in a terminal.
+
 More advanced setups are described in the "Advanced Server Setup" documentation.
 To change storage, logging, interface, database, or authentication settings, review the [`app`](configuration#app-section) and [`server`](configuration#server-section) configuration sections.
 

--- a/webui/website/src/content/docs/terminal-client.md
+++ b/webui/website/src/content/docs/terminal-client.md
@@ -33,7 +33,7 @@ Root help groups Hister operations by scope, and each operation help page identi
 command operates:
 
 **Local** commands use configured files or local Hister data directly and do not contact the
-configured Hister HTTP server. Examples include `hister crawl list`, `hister list-files`, and most
+configured Hister HTTP server. Examples include `hister crawl list`, `hister list-files`, `hister service`, and most
 user administration commands.
 
 **Remote** commands use the configured Hister HTTP server without opening the local Hister
@@ -67,6 +67,19 @@ available. It also provides a link to the release. When Hister is current, the c
 that it is up to date.
 
 This check requires internet access. It does not download or install the update.
+
+### Background service
+
+On macOS and systemd Linux, keep the server running without an open terminal:
+
+```bash
+./hister service install
+./hister service status
+./hister service stop
+./hister service uninstall
+```
+
+`hister service` is a local command. Use `./hister` when the binary is in the current directory and has not been added to `PATH`; otherwise use `hister`. `install` needs a readable `--config` file when you pass that flag; `start`, `stop`, `restart`, `status`, and `uninstall` still work if `config.yml` is broken. Details are in [Running in the background](installing#running-in-the-background).
 
 ### Index a URL Manually
 

--- a/webui/website/src/content/docs/troubleshooting.md
+++ b/webui/website/src/content/docs/troubleshooting.md
@@ -15,6 +15,13 @@ If all else fails, you can try asking for help&mdash;see the Community links in 
 
 - Check if port 4433 (or whatever was configured instead) is already in use
 - Verify the configuration file syntax
+- If you installed a background service, run `hister service status` and check the logs:
+  - macOS: `~/Library/Logs/hister.log` and `~/Library/Logs/hister-error.log`
+  - Linux: `journalctl --user -u hister`
+- If your shell says `hister: command not found`, run `./hister service status` from the directory containing the binary, or move the binary to a stable directory on `PATH`. The service can still be running because launchd/systemd uses the recorded absolute binary path.
+- `hister service install` refuses Homebrew Cellar and `/nix/store` binaries, Nix-managed units, a missing or unreadable `--config` file, and unpersisted `HISTER__*` or `HISTER_PORT` environment variables. Move the binary to a stable path (for example `$(brew --prefix)/bin/hister`) or use the Nix module instead.
+- systemd user services stop at logout unless lingering is enabled (`loginctl enable-linger`). Hister does not enable lingering for you.
+- `hister service` is not supported on Windows yet; run `hister.exe listen` in a terminal.
 
 ### Web interface loads, but looks broken
 


### PR DESCRIPTION
Implemented a native user-level service management for standalone Hister installs on macos via LaunchAgent and Linux via systemd user service. This adds a small service-management layer so Hister can run in the background using the platform’s native service manager.

New commands introduced: 

- hister service install
- hister service uninstall
- hister service start
- hister service stop
- hister service restart
- hister service status

Codex was used to assist with implementation, platform-specific investigation, and testing.