### PR TITLE
[fix] do not create indexes for languages that Bleve cannot analyze

### DIFF
--- a/server/indexer/indexer.go
+++ b/server/indexer/indexer.go
@@ -1416,7 +1416,7 @@ func (i *Indexer) getOrCreate(lang string) bleve.Index {
 }
 
 func indexNameForLanguage(lang string) string {
-	if lang == document.UnknownLanguage || lang == "" {
+	if lang == document.UnknownLanguage || lang == "" || !registeredLanguageAnalyzer(lang) {
 		return defaultIndexerName
 	}
 	return fmt.Sprintf(langIndexerName, lang)

--- a/server/indexer/language.go
+++ b/server/indexer/language.go
@@ -2,26 +2,17 @@ package indexer
 
 import (
 	_ "github.com/blevesearch/bleve/v2/analysis/lang/ar"
-	_ "github.com/blevesearch/bleve/v2/analysis/lang/bg"
-	_ "github.com/blevesearch/bleve/v2/analysis/lang/ca"
 	"github.com/blevesearch/bleve/v2/analysis/lang/cjk"
-
-	// _ "github.com/blevesearch/bleve/v2/analysis/lang/cs" // This is only a stopword list, Bleve does not have a Czech language analyzer
 	_ "github.com/blevesearch/bleve/v2/analysis/lang/da"
 	_ "github.com/blevesearch/bleve/v2/analysis/lang/de"
-	_ "github.com/blevesearch/bleve/v2/analysis/lang/el"
 	_ "github.com/blevesearch/bleve/v2/analysis/lang/en"
 	_ "github.com/blevesearch/bleve/v2/analysis/lang/es"
-	_ "github.com/blevesearch/bleve/v2/analysis/lang/eu"
 	_ "github.com/blevesearch/bleve/v2/analysis/lang/fa"
 	_ "github.com/blevesearch/bleve/v2/analysis/lang/fi"
 	_ "github.com/blevesearch/bleve/v2/analysis/lang/fr"
-	_ "github.com/blevesearch/bleve/v2/analysis/lang/ga"
 	_ "github.com/blevesearch/bleve/v2/analysis/lang/hi"
 	_ "github.com/blevesearch/bleve/v2/analysis/lang/hr"
 	_ "github.com/blevesearch/bleve/v2/analysis/lang/hu"
-	_ "github.com/blevesearch/bleve/v2/analysis/lang/hy"
-	_ "github.com/blevesearch/bleve/v2/analysis/lang/id"
 	_ "github.com/blevesearch/bleve/v2/analysis/lang/it"
 	_ "github.com/blevesearch/bleve/v2/analysis/lang/nl"
 	_ "github.com/blevesearch/bleve/v2/analysis/lang/no"


### PR DESCRIPTION
Bleve has no analyzers for bg, ca, cs, el, eu, ga, hy and id, only stopword lists.  Creating an index for these languages failed with "no analyzer with name or type 'ca' registered" (see for example #172) and logged a warning for every document.  These languages were already sent to the default indexer before this change, they now go there without emitting warnings.

Remove the bleve imports for these languages because they are unused.