### PR TITLE
[fix] store database timestamps in UTC

### DIFF
--- a/server/model/embedding.go
+++ b/server/model/embedding.go
@@ -52,7 +52,7 @@ func EnqueueEmbeddingJob(docID string) error {
 	if err != nil {
 		return err
 	}
-	now := time.Now()
+	now := time.Now().UTC()
 	job := EmbeddingJob{
 		DocID:       docID,
 		Status:      EmbeddingJobPending,
@@ -95,7 +95,7 @@ func ClaimNextEmbeddingJob() (*EmbeddingJob, error) {
 	}
 	for {
 		var job EmbeddingJob
-		now := time.Now()
+		now := time.Now().UTC()
 		err := db.Where("status = ? AND available_at <= ?", EmbeddingJobPending, now).
 			Order("available_at ASC").
 			Order("created_at ASC").
@@ -144,7 +144,7 @@ func CompleteEmbeddingJob(docID string) (retry bool, err error) {
 	if result.RowsAffected == 1 {
 		return false, nil
 	}
-	now := time.Now()
+	now := time.Now().UTC()
 	result = db.Model(&EmbeddingJob{}).
 		Where("doc_id = ? AND status = ? AND dirty = ?", docID, EmbeddingJobInProgress, true).
 		Updates(map[string]any{
@@ -168,7 +168,8 @@ func RetryEmbeddingJob(docID string, retryAt time.Time, lastError string) error 
 	if err != nil {
 		return err
 	}
-	now := time.Now()
+	retryAt = retryAt.UTC()
+	now := time.Now().UTC()
 	return db.Model(&EmbeddingJob{}).
 		Where("doc_id = ? AND status = ?", docID, EmbeddingJobInProgress).
 		Updates(map[string]any{
@@ -195,7 +196,7 @@ func FailEmbeddingJob(docID string, lastError string) (retry bool, err error) {
 	if err != nil {
 		return false, err
 	}
-	now := time.Now()
+	now := time.Now().UTC()
 	result := db.Model(&EmbeddingJob{}).
 		Where("doc_id = ? AND status = ? AND dirty = ?", docID, EmbeddingJobInProgress, false).
 		Updates(map[string]any{
@@ -232,7 +233,7 @@ func ReleaseEmbeddingJob(docID string) error {
 	if err != nil {
 		return err
 	}
-	now := time.Now()
+	now := time.Now().UTC()
 	return db.Model(&EmbeddingJob{}).
 		Where("doc_id = ? AND status = ?", docID, EmbeddingJobInProgress).
 		Updates(map[string]any{
@@ -274,7 +275,7 @@ func ResetInProgressEmbeddingJobs() error {
 	if err != nil {
 		return err
 	}
-	now := time.Now()
+	now := time.Now().UTC()
 	return db.Model(&EmbeddingJob{}).
 		Where("status = ?", EmbeddingJobInProgress).
 		Updates(map[string]any{

--- a/server/model/history.go
+++ b/server/model/history.go
@@ -192,6 +192,7 @@ func GetLatestHistoryItemsFilteredByDate(userID uint, limit int, lastID uint, la
 		q = q.Where("history_links.updated_at < ?", time.Unix(dateTo, 0).UTC())
 	}
 	if !lastUpdatedAt.IsZero() {
+		lastUpdatedAt = lastUpdatedAt.UTC()
 		q = q.Where(
 			"(history_links.updated_at < ? OR (history_links.updated_at = ? AND history_links.id < ?))",
 			lastUpdatedAt,

--- a/server/model/history_timezone_test.go
+++ b/server/model/history_timezone_test.go
@@ -1,0 +1,42 @@
+package model_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/asciimoo/hister/server/model"
+	"github.com/asciimoo/hister/server/testutil"
+)
+
+// TestHistoryDateRangeIgnoresServerTimezone pins that a row written by a server
+// running west of UTC is still found by a range query expressed in UTC. SQLite
+// keeps whatever offset a time value carries and compares those values as text,
+// so a timestamp stored as local wall clock sorts by that wall clock: an entry
+// written at 20:21-07:00 reads as "2026-09-09 ..." and falls outside the UTC day
+// it actually belongs to.
+func TestHistoryDateRangeIgnoresServerTimezone(t *testing.T) {
+	originalLocal := time.Local
+	time.Local = time.FixedZone("UTC-8", -8*60*60)
+	t.Cleanup(func() { time.Local = originalLocal })
+
+	testutil.InitModel(t)
+	if err := model.UpdateHistory(0, "q", "https://example.com", "Example"); err != nil {
+		t.Fatalf("UpdateHistory() error: %v", err)
+	}
+
+	now := time.Now().UTC()
+	dayStart := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
+	dayEnd := dayStart.AddDate(0, 0, 1)
+
+	timestamps, err := model.GetHistoryItemTimestampsFilteredByDate(0, "", dayStart.Unix(), dayEnd.Unix())
+	if err != nil {
+		t.Fatalf("GetHistoryItemTimestampsFilteredByDate() error: %v", err)
+	}
+	if len(timestamps) != 1 {
+		t.Fatalf("timestamps in the current UTC day = %d, want 1", len(timestamps))
+	}
+
+	if got := timestamps[0].UTC(); got.Before(dayStart) || !got.Before(dayEnd) {
+		t.Errorf("stored timestamp %s is outside the queried day %s..%s", got, dayStart, dayEnd)
+	}
+}

--- a/server/model/model.go
+++ b/server/model/model.go
@@ -46,7 +46,13 @@ func InitReadOnly(c *config.Config) error {
 }
 
 func initDatabase(c *config.Config, accessMode AccessMode) error {
-	dbCfg := &gorm.Config{}
+	dbCfg := &gorm.Config{
+		// SQLite keeps whatever offset a time value carries and compares those
+		// values as text, so a timestamp written at a local offset does not
+		// order against one bound in UTC. Generate every timestamp in UTC to
+		// keep text order and chronological order the same thing.
+		NowFunc: func() time.Time { return time.Now().UTC() },
+	}
 	if c.App.DebugSQL {
 		dbCfg.Logger = logger.Default.LogMode(logger.Info)
 	} else {

--- a/server/model/session.go
+++ b/server/model/session.go
@@ -25,6 +25,7 @@ type WebSession struct {
 }
 
 func CreateWebSession(session *WebSession) error {
+	session.ExpiresAt = session.ExpiresAt.UTC()
 	return DB.Create(session).Error
 }
 
@@ -42,7 +43,7 @@ func GetWebSession(tokenHash string) (*WebSession, error) {
 func UpdateWebSession(tokenHash string, data []byte, expiresAt time.Time) error {
 	result := DB.Model(&WebSession{}).Where("token_hash = ?", tokenHash).Updates(map[string]any{
 		"data":       data,
-		"expires_at": expiresAt,
+		"expires_at": expiresAt.UTC(),
 	})
 	if result.Error != nil {
 		return result.Error
@@ -58,5 +59,5 @@ func DeleteWebSession(tokenHash string) error {
 }
 
 func DeleteExpiredWebSessions(now time.Time) error {
-	return DB.Where("expires_at <= ?", now).Delete(&WebSession{}).Error
+	return DB.Where("expires_at <= ?", now.UTC()).Delete(&WebSession{}).Error
 }


### PR DESCRIPTION
SQLite has no date type: it stores a time as text and compares it as text, and the driver stores "whatever timezone they come with". `gorm` generated `CreatedAt`/`UpdatedAt` from `time.Now()`, so a server west of UTC wrote `2026-09-09 20:21:05.855826-07:00` while queries bind their ranges in UTC (`2026-09-10 00:00:00+00:00`). Compared as text, `2026-09-09 ...` sorts before `2026-09-10 ...`, so the row falls outside the UTC day it belongs to.

Visible effect: the history timeline reports an item for today, and drilling into that same day returns nothing. It affects any server whose local date differs from the UTC date, and it is invisible on a UTC machine, so CI never caught it. `TestPublicModeEnablesHistoryForAuthenticatedCallers` fails today under `TZ=America/Los_Angeles` and passes under `TZ=UTC`.

## Changes

- Generate gorm timestamps in UTC through `gorm.Config.NowFunc`.
- Convert caller-supplied times to UTC at the model boundary rather than trusting each call site: embedding retry deadlines, web session expiry, and the history pagination cursor.
- Add `TestHistoryDateRangeIgnoresServerTimezone`, which pins its own local zone eight hours behind UTC so it fails regardless of the machine running it.

## Notes

Rows written before this change keep their original offsets, so their text order stays wrong until they are rewritten. Fixing those needs a migration that rewrites every timestamp column, which is not included here.

Verified with the full suite under `TZ=UTC`, `America/Los_Angeles`, `Asia/Tokyo` and `Australia/Sydney`.