### PR TITLE
[fix] watch symbolically linked directory roots

### DIFF
--- a/files/watcher.go
+++ b/files/watcher.go
@@ -24,8 +24,19 @@ const debounceTime = 200 * time.Millisecond
 type Watcher struct {
 	watcher *fsnotify.Watcher
 	dirs    []*config.Directory
+	links   []symlinkRoot
 	paths   map[string]bool
 	strict  bool
+}
+
+// symlinkRoot records a configured root that lives somewhere else on disk.
+// Watches and directory walks have to use the resolved location - kqueue
+// follows the link and reports events under the target, and WalkDir does not
+// descend a symbolic link at all - while filters and callbacks keep using the
+// path the user configured.
+type symlinkRoot struct {
+	configured string
+	resolved   string
 }
 
 func NewWatcher(dirs []*config.Directory, paths []string) (*Watcher, error) {
@@ -49,6 +60,7 @@ func newWatcher(dirs []*config.Directory, paths []string, strict bool) (*Watcher
 			return nil, err
 		}
 		w.dirs = append(w.dirs, &copy)
+		w.addSymlinkRoot(copy.Path)
 	}
 	for _, path := range paths {
 		path, err = filepath.Abs(ExpandHome(path))
@@ -57,6 +69,7 @@ func newWatcher(dirs []*config.Directory, paths []string, strict bool) (*Watcher
 			return nil, err
 		}
 		w.paths[path] = true
+		w.addSymlinkRoot(filepath.Dir(path))
 	}
 	if err := w.scan(nil); err != nil {
 		_ = w.Close()
@@ -66,6 +79,52 @@ func newWatcher(dirs []*config.Directory, paths []string, strict bool) (*Watcher
 }
 
 func (w *Watcher) Close() error { return w.watcher.Close() }
+
+// addSymlinkRoot records where root really lives when it is reached through a
+// symbolic link. A root that cannot be resolved yet is left alone; scan reports
+// the missing path.
+func (w *Watcher) addSymlinkRoot(root string) {
+	resolved, err := filepath.EvalSymlinks(root)
+	if err != nil || resolved == root {
+		return
+	}
+	for _, link := range w.links {
+		if link.configured == root {
+			return
+		}
+	}
+	w.links = append(w.links, symlinkRoot{configured: root, resolved: resolved})
+}
+
+// watchPath maps a configured path to the location watches and walks must use.
+func (w *Watcher) watchPath(path string) string {
+	return remapPath(path, w.links, func(link symlinkRoot) (string, string) {
+		return link.configured, link.resolved
+	})
+}
+
+// eventPath maps a path reported by the filesystem back into the configured
+// tree, so filters and callbacks see the path the user asked to watch.
+func (w *Watcher) eventPath(path string) string {
+	return remapPath(path, w.links, func(link symlinkRoot) (string, string) {
+		return link.resolved, link.configured
+	})
+}
+
+func remapPath(path string, links []symlinkRoot, ends func(symlinkRoot) (from, to string)) string {
+	for _, link := range links {
+		from, to := ends(link)
+		if !HasPathPrefix(path, from) {
+			continue
+		}
+		rel, err := filepath.Rel(from, path)
+		if err != nil {
+			continue
+		}
+		return filepath.Join(to, rel)
+	}
+	return path
+}
 
 // The server keeps watching accessible directories when another directory
 // fails. CLI setup reports incomplete coverage as an error instead.
@@ -116,26 +175,29 @@ func (w *Watcher) matchesDirectory(path string) bool {
 }
 
 func (w *Watcher) scanDirectory(root string, callback func(string)) error {
-	// WalkDir does not follow symbolic links, so register the root directly.
-	if err := w.report(w.watcher.Add(root)); err != nil {
+	// Walk where the tree actually lives: WalkDir does not follow a symbolic
+	// link, so walking the configured root would visit the link and stop.
+	target := w.watchPath(root)
+	if err := w.report(w.watcher.Add(target)); err != nil {
 		return err
 	}
-	return filepath.WalkDir(root, func(path string, entry fs.DirEntry, err error) error {
+	return filepath.WalkDir(target, func(path string, entry fs.DirEntry, err error) error {
 		if err != nil {
 			return w.report(err)
 		}
+		configured := w.eventPath(path)
 		if entry.IsDir() {
-			if !w.matchesDirectory(path) {
+			if !w.matchesDirectory(configured) {
 				return filepath.SkipDir
 			}
-			if path == root {
+			if path == target {
 				return nil
 			}
 			// Register before visiting children so writes during a scan are queued.
 			return w.report(w.watcher.Add(path))
 		}
-		if callback != nil && w.matches(path) {
-			callback(path)
+		if callback != nil && w.matches(configured) {
+			callback(configured)
 		}
 		return nil
 	})
@@ -192,9 +254,12 @@ func (w *Watcher) Run(ctx context.Context, onChange, onRemove func(string)) erro
 			if !ok {
 				return nil
 			}
+			// Watches live where the files are; filters and callbacks speak in
+			// the paths the user configured.
+			name := w.eventPath(event.Name)
 			if event.Has(fsnotify.Remove) || event.Has(fsnotify.Rename) {
 				for path := range pending {
-					if HasPathPrefix(path, event.Name) {
+					if HasPathPrefix(path, name) {
 						delete(pending, path)
 					}
 				}
@@ -205,22 +270,22 @@ func (w *Watcher) Run(ctx context.Context, onChange, onRemove func(string)) erro
 						_ = w.watcher.Remove(path)
 					}
 				}
-				dir := FindMatchingDir(w.dirs, event.Name)
-				if onRemove != nil && dir != nil && dir.DeleteOnRemove && DirectoryMatchesPath(dir, event.Name) {
-					onRemove(event.Name)
+				dir := FindMatchingDir(w.dirs, name)
+				if onRemove != nil && dir != nil && dir.DeleteOnRemove && DirectoryMatchesPath(dir, name) {
+					onRemove(name)
 				}
 			}
 			if event.Has(fsnotify.Create) {
 				info, err := os.Stat(event.Name)
-				if err == nil && info.IsDir() && w.matchesDirectory(event.Name) {
-					if err := w.scanDirectory(event.Name, schedule); err != nil && !errors.Is(err, fs.ErrNotExist) {
+				if err == nil && info.IsDir() && w.matchesDirectory(name) {
+					if err := w.scanDirectory(name, schedule); err != nil && !errors.Is(err, fs.ErrNotExist) {
 						return err
 					}
 					continue
 				}
 			}
-			if (event.Has(fsnotify.Write) || event.Has(fsnotify.Create)) && w.matches(event.Name) {
-				schedule(event.Name)
+			if (event.Has(fsnotify.Write) || event.Has(fsnotify.Create)) && w.matches(name) {
+				schedule(name)
 			}
 		case err, ok := <-w.watcher.Errors:
 			if !ok {

--- a/files/watcher_test.go
+++ b/files/watcher_test.go
@@ -258,3 +258,29 @@ func TestWatcherSetupFailurePolicy(t *testing.T) {
 		t.Fatal("server watcher did not observe its accessible directory")
 	}
 }
+
+// TestWatcherSymlinkDirectoryRootSubdirectory covers a nested directory under a
+// symbolically linked root. WalkDir does not descend a symbolic link, so the
+// scan that registers watches stopped at the link and nothing below the root
+// was ever observed.
+func TestWatcherSymlinkDirectoryRootSubdirectory(t *testing.T) {
+	target := t.TempDir()
+	root := filepath.Join(t.TempDir(), "notes")
+	if err := os.Symlink(target, root); err != nil {
+		t.Skipf("cannot create symbolic link: %v", err)
+	}
+	nested := filepath.Join(target, "chapters")
+	if err := os.Mkdir(nested, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(nested, "note.txt")
+	if err := os.WriteFile(path, []byte("initial"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	changed, _, _ := startTestWatcher(t, []*config.Directory{{Path: root}}, nil)
+	if err := os.WriteFile(path, []byte("updated"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	waitForFileEvent(t, changed, filepath.Join(root, "chapters", "note.txt"))
+}


### PR DESCRIPTION
A directory root reached through a symbolic link (`~/notes -> /mnt/data/notes`) was watched by its link path, which breaks in two ways.

**Events are reported under the target.** fsnotify's kqueue backend follows the link and watches the target, so macOS and the BSDs report `/mnt/data/notes/file.md` while the configured root — and every filter derived from it — speaks in `~/notes/...` paths. Nothing matched, so no file under such a root was ever reported. inotify reports events under the name the watch was registered with, so Linux (and CI) never saw this.

**Nested directories were never watched.** `filepath.WalkDir` does not descend a symbolic link on any platform, so the scan that registers watches stopped at the root. Only direct children of the root produced events, and only on Linux.

`TestWatcherSymlinkDirectoryRoot` fails on macOS today; the new nested-directory test fails on Linux too.

## Changes

- Resolve each configured root once and keep it alongside the path the user configured.
- Register watches and walk the tree at the resolved location, translating event paths back into configured paths before filtering, scheduling, or reporting — so callbacks still return the path that was configured, not the link target.
- Add `TestWatcherSymlinkDirectoryRootSubdirectory` for the nested case.

Non-symlinked roots resolve to themselves, so nothing changes for them.